### PR TITLE
Fix billing cache issue by reloading jobs data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -481,8 +481,8 @@ const App = () => {
 
     // For any billing-related updates, just reload fresh data
     if (type.includes('billing') || type.includes('event')) {
-      console.log('🔄 Billing data updated, reloading fresh data...');
-      await loadLiveData(['billing']);
+      console.log('🔄 Billing data updated, reloading fresh jobs + billing...');
+      await loadLiveData(['jobs', 'billing']);
       return;
     }
 


### PR DESCRIPTION
## Purpose

User reported a billing component cache issue where invoice status changes from "Open" to "Paid" would temporarily appear correct but then revert back to "Open". The balance would update correctly and the correct status would show after leaving and returning to the component, indicating a data synchronization problem between billing and jobs data.

## Code changes

- Modified the billing data update handler in `App.js` to reload both `jobs` and `billing` data instead of just `billing` data
- Updated the console log message to reflect that both jobs and billing data are being reloaded
- This ensures proper synchronization between related data when billing updates occurTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/mystic-haven)

👀 [Preview Link](https://ddd291a471d24dc4a8c6060599d1fd79-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>mystic-haven</branchName>-->