### PR TITLE
Fix autosave table reference in LandValuationTab

### DIFF
--- a/src/components/job-modules/market-tabs/LandValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/LandValuationTab.jsx
@@ -1006,7 +1006,7 @@ const getPricePerUnit = useCallback((price, size) => {
   // Auto-save every 30 seconds - but only after initial load is complete
   useEffect(() => {
     if (!isInitialLoadComplete) {
-      debug('�����️ Auto-save waiting for initial load to complete');
+      debug('�������� Auto-save waiting for initial load to complete');
       return;
     }
 
@@ -3480,10 +3480,10 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
         totalSales: analysisData.vacant_sales_analysis.sales.length
       });
 
-      // Use the same table that's used for loading: property_market_analysis
-      debug('💾 Saving to property_market_analysis table...');
+      // Use the same table that's used for loading: market_land_valuation
+      debug('💾 Saving to market_land_valuation table...');
       const { error } = await supabase
-        .from('property_market_analysis')
+        .from('market_land_valuation')
         .upsert(analysisData, {
           onConflict: 'job_id',
           ignoreDuplicates: false


### PR DESCRIPTION
## Purpose
Fix autosave functionality in LandValuationTab that was throwing a schema cache error due to incorrect table reference. The user reported that the autosave was trying to access the 'allocation_study' column in 'property_market_analysis' table, but the data should be saved to the 'market_land_valuation' table instead.

## Code changes
- Updated table reference in autosave functionality from `property_market_analysis` to `market_land_valuation`
- Updated debug log message to reflect the correct table name
- Minor formatting adjustment to debug emoji in auto-save waiting messageTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 57`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/flare-sanctuary)

👀 [Preview Link](https://ddd291a471d24dc4a8c6060599d1fd79-flare-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>flare-sanctuary</branchName>-->