### PR TITLE
Add CSV and PowerCama appeal import to AppealLogTab

### DIFF
--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -2706,6 +2706,62 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           </div>
         </div>
       )}
+
+      {/* POWERCAMA IMPORT MODAL */}
+      {showPwrCamaModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-bold text-gray-900">Import Appeals from PowerCama</h2>
+              <button onClick={() => setShowPwrCamaModal(false)} className="text-gray-500 hover:text-gray-700">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                Supports the PowerCama appeals export (.xlsx). All imported appeals will be set to status <strong>D (Defend)</strong>. Duplicates are skipped automatically.
+              </p>
+              <div className="border-2 border-dashed border-purple-300 rounded-lg p-6 text-center">
+                <input
+                  type="file"
+                  accept=".xlsx,.xls"
+                  id="pwrcama-import-input"
+                  className="hidden"
+                  onChange={(e) => setPwrCamaFile(e.target.files[0] || null)}
+                />
+                <label htmlFor="pwrcama-import-input" className="cursor-pointer">
+                  <Upload className="w-8 h-8 text-purple-400 mx-auto mb-2" />
+                  <p className="text-sm text-gray-600">
+                    {pwrCamaFile ? pwrCamaFile.name : 'Click to select .xlsx file'}
+                  </p>
+                </label>
+              </div>
+              {pwrCamaResult && (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-1 text-sm">
+                  <p className="font-semibold text-gray-800">Import Complete</p>
+                  <p className="text-green-700">✓ {pwrCamaResult.imported} records imported</p>
+                  {pwrCamaResult.skipped > 0 && <p className="text-amber-700">⚠ {pwrCamaResult.skipped} skipped (duplicates)</p>}
+                  {pwrCamaResult.unmatched > 0 && <p className="text-blue-700">ℹ {pwrCamaResult.unmatched} unmatched to property records</p>}
+                </div>
+              )}
+              <div className="flex gap-3 justify-end pt-2">
+                <button onClick={() => setShowPwrCamaModal(false)} className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50">
+                  {pwrCamaResult ? 'Close' : 'Cancel'}
+                </button>
+                {!pwrCamaResult && (
+                  <button
+                    onClick={handleImportPwrCama}
+                    disabled={!pwrCamaFile || pwrCamaProcessing}
+                    className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {pwrCamaProcessing ? 'Importing...' : 'Import'}
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1331,6 +1331,150 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     }
   };
 
+  // ==================== PWR CAMA IMPORT HANDLER ====================
+
+  const handleImportPwrCama = async () => {
+    if (!pwrCamaFile) return;
+    setPwrCamaProcessing(true);
+    setPwrCamaResult(null);
+    try {
+      const XLSX = await import('https://cdn.sheetjs.com/xlsx-0.20.3/package/xlsx.mjs');
+      const arrayBuffer = await pwrCamaFile.arrayBuffer();
+      const workbook = XLSX.read(arrayBuffer, { type: 'array', cellDates: true });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows = XLSX.utils.sheet_to_json(sheet, { defval: null });
+
+      const { data: existingAppeals } = await supabase
+        .from('appeal_log')
+        .select('appeal_number')
+        .eq('job_id', jobData.id);
+      const existingNumbers = new Set((existingAppeals || []).map(a => a.appeal_number));
+
+      let imported = 0;
+      let skipped = 0;
+      let unmatched = 0;
+      const records = [];
+
+      for (const row of rows) {
+        const appealNumber = row['APPEALS'] ? String(row['APPEALS']).trim() : null;
+        if (!appealNumber) continue;
+        if (existingNumbers.has(appealNumber)) { skipped++; continue; }
+
+        const block = row['PROP_BLOCK'] != null ? String(row['PROP_BLOCK']).trim() : '';
+        const lotRaw = row['PROP_LOT'];
+        const lot = lotRaw != null ? String(Math.floor(Number(lotRaw))) : '';
+        const qualifier = row['PROP_QUALIFIER'] != null ? String(row['PROP_QUALIFIER']).trim() : '';
+
+        const matchedProperty = properties.find(p =>
+          (p.property_block || '').toString().trim() === block &&
+          (p.property_lot || '').toString().trim() === lot &&
+          (p.property_qualifier || '').toString().trim() === qualifier
+        );
+        if (!matchedProperty) unmatched++;
+
+        const attorney = row['ATTORNEY_NAME'] ? String(row['ATTORNEY_NAME']).trim() : '';
+        const appealType = attorney ? 'represented' : 'petitioner';
+
+        let hearingDate = null;
+        if (row['HEARING_DATE'] && !isNaN(new Date(row['HEARING_DATE']).getTime())) {
+          hearingDate = new Date(row['HEARING_DATE']).toISOString().split('T')[0];
+        }
+        let evidenceDueDate = null;
+        if (hearingDate) {
+          const d = new Date(hearingDate);
+          d.setDate(d.getDate() - 7);
+          evidenceDueDate = d.toISOString().split('T')[0];
+        }
+
+        const taxCourtPending = String(row['ATTRIB_TAXCOURTPENDING'] || '').trim().toUpperCase() === 'Y';
+        const jdgNet = row['ASSESSMENT_JDG.NET'];
+        const judgmentValue = jdgNet != null && !isNaN(Number(jdgNet)) ? Number(jdgNet) : null;
+        const curNet = row['ASSESSMENT_CUR.NET'];
+        const currentAssessment = matchedProperty?.values_mod_total || (curNet != null && !isNaN(Number(curNet)) ? Number(curNet) : 0);
+        let loss = null;
+        let lossPct = null;
+        if (judgmentValue !== null && currentAssessment) {
+          loss = currentAssessment - judgmentValue;
+          lossPct = (loss / currentAssessment) * 100;
+        }
+
+        const ownerName = row['OWNER_NAME'] ? String(row['OWNER_NAME']).trim() : '';
+        records.push({
+          job_id: jobData.id,
+          appeal_number: appealNumber,
+          appeal_year: new Date().getFullYear(),
+          appeal_type: appealType,
+          status: 'D',
+          stip_status: 'not_started',
+          petitioner_name: ownerName,
+          taxpayer_name: ownerName,
+          attorney,
+          attorney_address: row['ATTORNEY_ADDR1'] ? String(row['ATTORNEY_ADDR1']).trim() : '',
+          attorney_city_state: row['ATTORNEY_CITYST'] ? String(row['ATTORNEY_CITYST']).trim() : '',
+          current_assessment: currentAssessment,
+          requested_value: 0,
+          judgment_value: judgmentValue,
+          loss,
+          loss_pct: lossPct,
+          property_block: block,
+          property_lot: lot,
+          property_qualifier: qualifier,
+          property_location: row['PROP_LOCATION'] ? String(row['PROP_LOCATION']).trim() : '',
+          property_composite_key: matchedProperty?.property_composite_key || '',
+          hearing_date: hearingDate,
+          evidence_due_date: evidenceDueDate,
+          tax_court_pending: taxCourtPending,
+          submission_type: null,
+          evidence_status: '',
+          inspected: false,
+          comments: row['NOTES'] ? String(row['NOTES']).trim() : ''
+        });
+      }
+
+      if (records.length > 0) {
+        const { error } = await supabase.from('appeal_log').insert(records);
+        if (error) throw error;
+        imported = records.length;
+      }
+
+      const { data: fetchData, error: fetchError } = await supabase
+        .from('appeal_log')
+        .select('*')
+        .eq('job_id', jobData.id)
+        .order('appeal_number', { ascending: true });
+      if (fetchError) throw fetchError;
+
+      const enrichedAppeals = (fetchData || []).map(appeal => {
+        const property = properties.find(p => p.property_composite_key === appeal.property_composite_key);
+        let appealType = appeal.appeal_type;
+        if (!appealType && appeal.appeal_number) {
+          const parsed = parseAppealNumber(appeal.appeal_number);
+          appealType = parsed.appealType;
+        }
+        return {
+          ...appeal,
+          appeal_type: appealType,
+          property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
+          new_vcs: property?.new_vcs || null,
+          owner_name: property?.owner_name || null,
+          property_block: appeal.property_block || property?.property_block || null,
+          property_lot: appeal.property_lot || property?.property_lot || null,
+          property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
+          property_location: appeal.property_location || property?.property_location || null
+        };
+      });
+
+      setAppeals(enrichedAppeals);
+      setPwrCamaResult({ imported, skipped, unmatched });
+      setPwrCamaFile(null);
+    } catch (error) {
+      console.error('PowerCama import error:', error);
+      alert(`Import failed: ${error.message}`);
+    } finally {
+      setPwrCamaProcessing(false);
+    }
+  };
+
   // ==================== RENDER ====================
 
   return (

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { AlertCircle, ChevronDown, ChevronUp, Trash2, X, Upload } from 'lucide-react';
 import { supabase } from '../../../lib/supabaseClient';
+import * as XLSX from 'xlsx';
 
 const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigateToCME = () => {} }) => {
   // State
@@ -1338,7 +1339,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     setPwrCamaProcessing(true);
     setPwrCamaResult(null);
     try {
-      const XLSX = await import('https://cdn.sheetjs.com/xlsx-0.20.3/package/xlsx.mjs');
       const arrayBuffer = await pwrCamaFile.arrayBuffer();
       const workbook = XLSX.read(arrayBuffer, { type: 'array', cellDates: true });
       const sheet = workbook.Sheets[workbook.SheetNames[0]];

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -639,7 +639,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
     return {
       suffix: suffix || '',
-      appealType: appealTypeMap[suffix] || null
+      appealType: appealTypeMap[suffix] || 'petitioner'
     };
   };
 

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { AlertCircle, ChevronDown, ChevronUp, Trash2, X } from 'lucide-react';
+import { AlertCircle, ChevronDown, ChevronUp, Trash2, X, Upload } from 'lucide-react';
 import { supabase } from '../../../lib/supabaseClient';
 
 const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigateToCME = () => {} }) => {
@@ -86,6 +86,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
   const [showMixedBracketModal, setShowMixedBracketModal] = useState(false);
   const [mixedBracketInfo, setMixedBracketInfo] = useState({});
   const [isSendingToCME, setIsSendingToCME] = useState(false);
+
+  // Import state
+  const [showImportModal, setShowImportModal] = useState(false);
+  const [importFile, setImportFile] = useState(null);
+  const [importProcessing, setImportProcessing] = useState(false);
+  const [importResult, setImportResult] = useState(null); // { imported, skipped, unmatched }
 
   // CME Brackets constant
   const CME_BRACKETS = [
@@ -1077,6 +1083,240 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     );
   }
 
+  // ==================== CSV IMPORT HANDLER ====================
+
+  const handleImportCSV = async () => {
+    if (!importFile) return;
+    setImportProcessing(true);
+    setImportResult(null);
+
+    try {
+      const text = await importFile.text();
+      const lines = text.split('\n');
+
+      // Parse header row — strip BOM if present
+      const rawHeader = lines[0].replace(/^\uFEFF/, '');
+      const headers = rawHeader.split(',').map(h => h.trim().replace(/^"|"$/g, ''));
+
+      // Column index helpers
+      const col = (name) => headers.findIndex(h => h === name);
+
+      const idxBLQ       = col('BLQ');
+      const idxAppealNum = col('Appeal #');
+      const idxName      = col('Name');
+      const idxLocation  = col('Location');
+      const idxClass     = col('Class.');
+      const idxAssess    = col('Assessment');
+      const idxTaxCrt    = col('Tax Crt?');
+      const idxEntry     = col('Entry');
+      const idxContact   = col('Adtl. Contact');
+      const idxAddr      = col('Addl Contact Address');
+      const idxCityState = col('Addl Contact City, State');
+      const idxStatus    = col('Appeal Status');
+
+      // Parse a CSV line respecting quoted fields
+      const parseCSVLine = (line) => {
+        const result = [];
+        let current = '';
+        let inQuotes = false;
+        for (let i = 0; i < line.length; i++) {
+          const ch = line[i];
+          if (ch === '"') {
+            inQuotes = !inQuotes;
+          } else if (ch === ',' && !inQuotes) {
+            result.push(current.trim());
+            current = '';
+          } else {
+            current += ch;
+          }
+        }
+        result.push(current.trim());
+        return result;
+      };
+
+      // Parse BLQ — format: "188-26", "155-7.01", "96-4-C0102"
+      const parseBLQ = (blq) => {
+        if (!blq) return { block: '', lot: '', qualifier: '' };
+
+        // Handle Excel date corruption: "8-Dec" should be "12-8"
+        // Excel converts "12-8" to Dec-8 and displays as "8-Dec"
+        const excelDateMatch = blq.match(/^(\d+)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/i);
+        if (excelDateMatch) {
+          const monthMap = {
+            jan:'1', feb:'2', mar:'3', apr:'4', may:'5', jun:'6',
+            jul:'7', aug:'8', sep:'9', oct:'10', nov:'11', dec:'12'
+          };
+          const day = excelDateMatch[1];
+          const month = monthMap[excelDateMatch[2].toLowerCase()];
+          return { block: month, lot: day, qualifier: '' };
+        }
+
+        const parts = blq.split('-');
+        if (parts.length === 3) {
+          // Three segments: block-lot-qualifier (e.g. 96-4-C0102)
+          return { block: parts[0], lot: parts[1], qualifier: parts[2] };
+        } else if (parts.length === 2) {
+          // Two segments: block-lot (qualifier is empty, lot may have decimal)
+          return { block: parts[0], lot: parts[1], qualifier: '' };
+        }
+        return { block: blq, lot: '', qualifier: '' };
+      };
+
+      // Fetch existing appeal numbers for this job to detect duplicates
+      const { data: existingAppeals } = await supabase
+        .from('appeal_log')
+        .select('appeal_number')
+        .eq('job_id', jobData.id);
+
+      const existingNumbers = new Set(
+        (existingAppeals || []).map(a => a.appeal_number)
+      );
+
+      let imported = 0;
+      let skipped = 0;
+      let unmatched = 0;
+      const records = [];
+
+      // Process data rows (skip header row 0)
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        const cols = parseCSVLine(line);
+        const getValue = (idx) => (idx >= 0 && cols[idx] ? cols[idx].replace(/^"|"$/g, '').trim() : '');
+
+        const appealNumber = getValue(idxAppealNum);
+        if (!appealNumber) continue;
+
+        // Skip duplicates
+        if (existingNumbers.has(appealNumber)) {
+          skipped++;
+          continue;
+        }
+
+        const blqRaw = getValue(idxBLQ);
+        const { block, lot, qualifier } = parseBLQ(blqRaw);
+
+        // Attempt property match against in-memory properties array
+        const matchedProperty = properties.find(p => {
+          const pBlock = (p.property_block || '').toString().trim();
+          const pLot = (p.property_lot || '').toString().trim();
+          const pQual = (p.property_qualifier || '').toString().trim();
+          return pBlock === block && pLot === lot && pQual === qualifier;
+        });
+
+        if (!matchedProperty) unmatched++;
+
+        // Parse appeal_type from appeal number suffix
+        const { appealType } = parseAppealNumber(appealNumber);
+
+        // Map submission type
+        const entryRaw = getValue(idxEntry);
+        let submissionType = '';
+        if (entryRaw === 'ONLINE') submissionType = 'ONLINE';
+        else if (entryRaw === 'PAPER') submissionType = 'PAPER';
+
+        // Map tax_court_pending
+        const taxCrtRaw = getValue(idxTaxCrt).toUpperCase();
+        const taxCourtPending = taxCrtRaw === 'TRUE';
+
+        // Attorney fields — only populate when Adtl. Contact column has a value
+        const attorney = getValue(idxContact);
+        const attorneyAddress = attorney ? getValue(idxAddr) : '';
+        const attorneyCityState = attorney ? getValue(idxCityState) : '';
+
+        // Assessment — strip commas just in case
+        const assessmentRaw = getValue(idxAssess).replace(/,/g, '');
+        const currentAssessment = parseFloat(assessmentRaw) || 0;
+
+        // Property class — stored as-is (2, 1, 6A, 15D etc.)
+        const propertyClass = getValue(idxClass);
+
+        const record = {
+          job_id: jobData.id,
+          appeal_number: appealNumber,
+          appeal_year: new Date().getFullYear(),
+          appeal_type: appealType,
+          status: 'D',
+          stip_status: 'not_started',
+          petitioner_name: getValue(idxName),
+          taxpayer_name: getValue(idxName),
+          attorney: attorney || '',
+          attorney_address: attorneyAddress,
+          attorney_city_state: attorneyCityState,
+          current_assessment: currentAssessment,
+          requested_value: 0,
+          property_block: block,
+          property_lot: lot,
+          property_qualifier: qualifier,
+          property_location: getValue(idxLocation),
+          property_composite_key: matchedProperty?.property_composite_key || '',
+          property_m4_class: propertyClass || matchedProperty?.property_m4_class || null,
+          submission_type: submissionType,
+          tax_court_pending: taxCourtPending,
+          inspected: false,
+          comments: '',
+          hearing_date: null,
+          evidence_due_date: null,
+          evidence_status: ''
+        };
+
+        records.push(record);
+      }
+
+      // Batch insert
+      if (records.length > 0) {
+        const { error } = await supabase
+          .from('appeal_log')
+          .insert(records);
+
+        if (error) throw error;
+        imported = records.length;
+      }
+
+      // Reload appeals
+      const { data: fetchData, error: fetchError } = await supabase
+        .from('appeal_log')
+        .select('*')
+        .eq('job_id', jobData.id)
+        .order('appeal_number', { ascending: true });
+
+      if (fetchError) throw fetchError;
+
+      const enrichedAppeals = (fetchData || []).map(appeal => {
+        const property = properties.find(
+          p => p.property_composite_key === appeal.property_composite_key
+        );
+        let appealType = appeal.appeal_type;
+        if (!appealType && appeal.appeal_number) {
+          const parsed = parseAppealNumber(appeal.appeal_number);
+          appealType = parsed.appealType;
+        }
+        return {
+          ...appeal,
+          appeal_type: appealType,
+          property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
+          new_vcs: property?.new_vcs || null,
+          owner_name: property?.owner_name || null,
+          property_block: appeal.property_block || property?.property_block || null,
+          property_lot: appeal.property_lot || property?.property_lot || null,
+          property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
+          property_location: appeal.property_location || property?.property_location || null
+        };
+      });
+
+      setAppeals(enrichedAppeals);
+      setImportResult({ imported, skipped, unmatched });
+      setImportFile(null);
+
+    } catch (error) {
+      console.error('Import error:', error);
+      alert(`Import failed: ${error.message}`);
+    } finally {
+      setImportProcessing(false);
+    }
+  };
+
   // ==================== RENDER ====================
 
   return (
@@ -1102,6 +1342,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
               ))}
             </select>
           </div>
+          <button
+            onClick={() => { setShowImportModal(true); setImportResult(null); setImportFile(null); }}
+            className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
+          >
+            <Upload className="w-4 h-4" />
+            Import CSV
+          </button>
           <button
             className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-300"
           >
@@ -2222,6 +2469,74 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                   {isSaving ? 'Saving...' : 'Save Appeal'}
                 </button>
               )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* IMPORT MODAL */}
+      {showImportModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-bold text-gray-900">Import Appeals from CSV</h2>
+              <button onClick={() => setShowImportModal(false)} className="text-gray-500 hover:text-gray-700">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                Supports the BRT online appeal system CSV export format.
+                Duplicate appeal numbers will be skipped automatically.
+              </p>
+
+              <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
+                <input
+                  type="file"
+                  accept=".csv"
+                  id="import-csv-input"
+                  className="hidden"
+                  onChange={(e) => setImportFile(e.target.files[0] || null)}
+                />
+                <label htmlFor="import-csv-input" className="cursor-pointer">
+                  <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
+                  <p className="text-sm text-gray-600">
+                    {importFile ? importFile.name : 'Click to select CSV file'}
+                  </p>
+                </label>
+              </div>
+
+              {importResult && (
+                <div className="bg-gray-50 rounded-lg p-4 space-y-1 text-sm">
+                  <p className="font-semibold text-gray-800">Import Complete</p>
+                  <p className="text-green-700">✓ {importResult.imported} records imported</p>
+                  {importResult.skipped > 0 && (
+                    <p className="text-amber-700">⚠ {importResult.skipped} skipped (duplicates)</p>
+                  )}
+                  {importResult.unmatched > 0 && (
+                    <p className="text-blue-700">ℹ {importResult.unmatched} unmatched to property records</p>
+                  )}
+                </div>
+              )}
+
+              <div className="flex gap-3 justify-end pt-2">
+                <button
+                  onClick={() => setShowImportModal(false)}
+                  className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+                >
+                  {importResult ? 'Close' : 'Cancel'}
+                </button>
+                {!importResult && (
+                  <button
+                    onClick={handleImportCSV}
+                    disabled={!importFile || importProcessing}
+                    className="px-4 py-2 bg-green-600 text-white rounded-lg text-sm hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {importProcessing ? 'Importing...' : 'Import'}
+                  </button>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1364,6 +1364,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
             Import MyNJAppeal
           </button>
           <button
+            onClick={() => { setShowPwrCamaModal(true); setPwrCamaResult(null); setPwrCamaFile(null); }}
+            className="px-4 py-2 bg-purple-600 text-white rounded-lg font-medium text-sm hover:bg-purple-700 flex items-center gap-2"
+          >
+            <Upload className="w-4 h-4" />
+            Import PwrCama Appeals
+          </button>
+          <button
             className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-300"
           >
             📊 Export to Excel

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1251,7 +1251,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           property_qualifier: qualifier,
           property_location: getValue(idxLocation),
           property_composite_key: matchedProperty?.property_composite_key || '',
-          property_m4_class: propertyClass || matchedProperty?.property_m4_class || null,
           submission_type: submissionType,
           tax_court_pending: taxCourtPending,
           inspected: false,

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1189,8 +1189,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         const cols = parseCSVLine(line);
         const getValue = (idx) => (idx >= 0 && cols[idx] ? cols[idx].replace(/^"|"$/g, '').trim() : '');
 
-        const appealNumber = getValue(idxAppealNum);
-        if (!appealNumber) continue;
+        const rawAppealNumber = getValue(idxAppealNum);
+        if (!rawAppealNumber) continue;
+        const appealNumber = rawAppealNumber.startsWith('20@')
+          ? rawAppealNumber.slice(3)
+          : rawAppealNumber;
 
         // Skip duplicates
         if (existingNumbers.has(appealNumber)) {
@@ -1220,7 +1223,10 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         const submissionType = validSubmissionTypes.includes(entryRaw) ? entryRaw : null;
 
         // Map tax_court_pending
-        const taxCrtRaw = getValue(idxTaxCrt).toUpperCase();
+        const taxCrtRaw = cols.find(c =>
+          c.trim().toUpperCase() === 'TRUE' ||
+          c.trim().toUpperCase() === 'FALSE'
+        )?.trim().toUpperCase();
         const taxCourtPending = taxCrtRaw === 'TRUE';
 
         // Attorney fields — only populate when Adtl. Contact column has a value
@@ -1247,7 +1253,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           attorney: attorney || '',
           attorney_address: attorneyAddress,
           attorney_city_state: attorneyCityState,
-          current_assessment: currentAssessment,
+          current_assessment: matchedProperty?.values_mod_total || currentAssessment || 0,
           requested_value: 0,
           property_block: block,
           property_lot: lot,

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -93,6 +93,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
   const [importProcessing, setImportProcessing] = useState(false);
   const [importResult, setImportResult] = useState(null); // { imported, skipped, unmatched }
 
+  // PWR CAMA state
+  const [showPwrCamaModal, setShowPwrCamaModal] = useState(false);
+  const [pwrCamaFile, setPwrCamaFile] = useState(null);
+  const [pwrCamaProcessing, setPwrCamaProcessing] = useState(false);
+  const [pwrCamaResult, setPwrCamaResult] = useState(null);
+
   // CME Brackets constant
   const CME_BRACKETS = [
     { min: 0, max: 99999, label: 'Under $100K', color: '#FF9999', textColor: 'black' },

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1361,8 +1361,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         if (existingNumbers.has(appealNumber)) { skipped++; continue; }
 
         const block = row['PROP_BLOCK'] != null ? String(row['PROP_BLOCK']).trim() : '';
-        const lotRaw = row['PROP_LOT'];
-        const lot = lotRaw != null ? String(Math.floor(Number(lotRaw))) : '';
+        const lot = row['PROP_LOT'] != null ? String(row['PROP_LOT']).trim() : '';
         const qualifier = row['PROP_QUALIFIER'] != null ? String(row['PROP_QUALIFIER']).trim() : '';
 
         const matchedProperty = properties.find(p =>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1216,9 +1216,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
         // Map submission type
         const entryRaw = getValue(idxEntry);
-        let submissionType = '';
-        if (entryRaw === 'ONLINE') submissionType = 'ONLINE';
-        else if (entryRaw === 'PAPER') submissionType = 'PAPER';
+        const validSubmissionTypes = ['ONLINE', 'PAPER', 'ELECTRONIC'];
+        const submissionType = validSubmissionTypes.includes(entryRaw) ? entryRaw : null;
 
         // Map tax_court_pending
         const taxCrtRaw = getValue(idxTaxCrt).toUpperCase();

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1355,7 +1355,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
             className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
           >
             <Upload className="w-4 h-4" />
-            Import CSV
+            Import MyNJAppeal
           </button>
           <button
             className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-300"

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1101,6 +1101,10 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       // Column index helpers
       const col = (name) => headers.findIndex(h => h === name);
 
+      console.log('CSV Headers:', headers);
+      console.log('Entry col index:', col('Entry'));
+      console.log('Hearing Type col index:', col('Hearing Type'));
+
       const idxBLQ       = col('BLQ');
       const idxAppealNum = col('Appeal #');
       const idxName      = col('Name');

--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -589,7 +589,10 @@ useEffect(() => {
 
     Object.keys(vcsSection).forEach(vcsKey => {
       const entry = vcsSection[vcsKey];
-      const urcMap = entry?.MAP?.['8']?.MAP;
+      const urcEntry = entry?.MAP
+        ? Object.values(entry.MAP).find(v => v?.KEY === 'URC')
+        : null;
+      const urcMap = urcEntry?.MAP;
       if (!urcMap) return;
       Object.keys(urcMap).forEach(k => {
         const e = urcMap[k];

--- a/src/lib/data-pipeline/brt-updater.js
+++ b/src/lib/data-pipeline/brt-updater.js
@@ -432,19 +432,23 @@ export class BRTUpdater {
             const vcsCode = vcsItem.DATA.VALUE;
             this.vcsLookups.set(vcsCode, vcsItem);
             
-            if (vcsItem.MAP && vcsItem.MAP['8'] && vcsItem.MAP['8'].DATA && vcsItem.MAP['8'].DATA.VALUE === 'URC') {
-              const urcSection = vcsItem.MAP['8'].MAP;
-              if (urcSection) {
-                Object.keys(urcSection).forEach(urcKey => {
-                  const urcItem = urcSection[urcKey];
-                  if (urcItem.MAP && urcItem.MAP['1'] && urcItem.MAP['1'].DATA) {
-                    const description = urcItem.MAP['1'].DATA.VALUE;
-                    const lookupKey = `${sectionName}_URC_${vcsCode}_${urcKey}`;
-                    this.codeLookups.set(lookupKey, description);
-                    this.codeLookups.set(urcKey, description);
-                  }
-                });
-              }
+            if (vcsItem.MAP) {
+              // Search any field for URC section (not just field 8)
+              Object.keys(vcsItem.MAP).forEach(fieldKey => {
+                const field = vcsItem.MAP[fieldKey];
+                if (field.DATA && field.DATA.VALUE === 'URC' && field.MAP) {
+                  const urcSection = field.MAP;
+                  Object.keys(urcSection).forEach(urcKey => {
+                    const urcItem = urcSection[urcKey];
+                    if (urcItem.MAP && urcItem.MAP['1'] && urcItem.MAP['1'].DATA) {
+                      const description = urcItem.MAP['1'].DATA.VALUE;
+                      const lookupKey = `${sectionName}_URC_${vcsCode}_${urcKey}`;
+                      this.codeLookups.set(lookupKey, description);
+                      this.codeLookups.set(urcKey, description);
+                    }
+                  });
+                }
+              });
             }
           }
         });


### PR DESCRIPTION
### Summary
Adds two new appeal import workflows to the Appeal Log tab: a MyNJAppeal CSV import (BRT online appeal system format) and a PowerCama XLSX import. Also fixes a position-dependent URC lookup bug in the BRT data pipeline and pre-valuation tab that caused unit rates to not appear for certain archived jobs.

### Problem
The Appeal Log had no bulk import capability, requiring appeals to be entered manually one at a time. Additionally, unit rate codes (URC) were not appearing in the unit rate configuration dropdown for some archived/legacy jobs because the BRT parser and pre-valuation tab assumed URC was always at a fixed field position (`MAP['8']`), which is not always the case across different municipalities.

### Solution
- Added a full CSV import handler (`handleImportCSV`) supporting the MyNJAppeal/BRT online system export format, with BLQ parsing, Excel date corruption handling, duplicate detection, and property matching.
- Added a separate PowerCama XLSX import handler (`handleImportPwrCama`) using SheetJS, mapping PowerCama-specific fields (block/lot/qualifier, attorney, hearing date, judgment value, tax court status, etc.).
- Fixed the URC lookup in both `brt-updater.js` and `PreValuationTab.jsx` to search all VCS MAP fields for the URC section rather than assuming it is always at index `8`.

### Key Changes
- **`AppealLogTab.jsx`**
  - Added `Upload` icon import from `lucide-react`
  - Added import state variables for both MyNJAppeal CSV and PowerCama XLSX flows
  - Added `handleImportCSV`: parses BRT CSV format, handles BLQ block/lot/qualifier splitting, Excel date corruption in BLQ fields, duplicate skipping, property matching, and batch insert to `appeal_log`
  - Added `handleImportPwrCama`: parses PowerCama XLSX via SheetJS (dynamic CDN import), maps all PowerCama columns, computes evidence due date (7 days before hearing), calculates loss/loss_pct, and batch inserts
  - Added "Import MyNJAppeal" (green) and "Import PwrCama Appeals" (purple) toolbar buttons
  - Added two import modals with file pickers, result summaries (imported / skipped / unmatched counts), and processing states
  - Fixed `parseAppealNumber` to default to `'petitioner'` instead of `null` when no suffix is found
  - Submission type validation now uses an allowlist (`ONLINE`, `PAPER`, `ELECTRONIC`) and falls back to `null`
  - `current_assessment` prefers matched property's `values_mod_total` over the CSV value

- **`PreValuationTab.jsx`**
  - Replaced hardcoded `entry?.MAP?.['8']` URC lookup with a position-independent search using `Object.values(entry.MAP).find(v => v?.KEY === 'URC')`, fixing missing unit rates in the dropdown for municipalities where URC is not at field index 8

- **`brt-updater.js`**
  - Updated VCS URC section parsing to iterate all MAP fields and find the URC entry by `DATA.VALUE === 'URC'` rather than assuming it is always at `MAP['8']`, ensuring unit rate codes are correctly indexed for all municipalities


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/druid-nest-wggh4xew"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-druid-nest-wggh4xew_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 154`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>druid-nest-wggh4xew</branchName>-->