### PR TITLE
Make Appeal Log table fully editable with bulk date tools

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1545,8 +1545,10 @@ const App = () => {
         {activeView === 'appeals' && (
           <AppealsSummary
             jobs={[
-              // Include archived PPA jobs
-              ...filterJobsForUser(appData.archivedJobs || []).filter(job => isPpaJob(job))
+              // Include archived PPA jobs plus Maplewood and Jackson
+              ...filterJobsForUser(appData.archivedJobs || []).filter(job =>
+                isPpaJob(job) || job.job_name === 'Maplewood' || job.job_name === 'Jackson'
+              )
             ]}
             onJobSelect={handleJobSelect}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -1545,10 +1545,15 @@ const App = () => {
         {activeView === 'appeals' && (
           <AppealsSummary
             jobs={[
-              // Include archived PPA jobs plus Maplewood and Jackson
-              ...filterJobsForUser(appData.archivedJobs || []).filter(job =>
-                isPpaJob(job) || job.job_name === 'Maplewood' || job.job_name === 'Jackson'
-              )
+              // Include archived PPA jobs plus Maplewood and Jackson from any job list
+              ...filterJobsForUser([
+                ...(appData.archivedJobs || []),
+                ...(appData.activeJobs || []),
+                ...(appData.planningJobs || [])
+              ]).filter(job => {
+                const jobName = (job.job_name || '').toLowerCase().trim();
+                return isPpaJob(job) || jobName === 'maplewood' || jobName === 'jackson';
+              })
             ]}
             onJobSelect={handleJobSelect}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -1545,8 +1545,8 @@ const App = () => {
         {activeView === 'appeals' && (
           <AppealsSummary
             jobs={[
-              ...filterJobsForUser(appData.jobs).filter(job => isPpaJob(job) || job.job_name === 'Jackson' || job.job_name === 'Maplewood'),
-              ...filterJobsForUser(appData.archivedJobs || []).filter(job => isPpaJob(job) || job.job_name === 'Jackson' || job.job_name === 'Maplewood')
+              // Include archived PPA jobs
+              ...filterJobsForUser(appData.archivedJobs || []).filter(job => isPpaJob(job))
             ]}
             onJobSelect={handleJobSelect}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -487,6 +487,7 @@ const App = () => {
             source_file_uploaded_at,
             unit_rate_config,
             staged_unit_rate_config,
+            appeal_summary_snapshot,
             job_responsibilities(count),
             job_contracts(
               id,

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -20,14 +20,15 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       return { residential: 0, commercial: 0, other: 0 };
     }
 
+    // Match AppealLogTab logic: Residential = '2' or '3A', Commercial = '4A', '4B', '4C'
     const residential = snapshot.filter(a => {
-      const cls = String(a.property_m4_class || '');
-      return cls.startsWith('2') || cls === '3A';
+      const cls = String(a.property_m4_class || '').trim();
+      return cls === '2' || cls === '3A';
     }).length;
 
     const commercial = snapshot.filter(a => {
-      const cls = String(a.property_m4_class || '');
-      return cls.startsWith('4A') || cls.startsWith('4B') || cls.startsWith('4C') || cls.startsWith('4');
+      const cls = String(a.property_m4_class || '').trim();
+      return cls === '4A' || cls === '4B' || cls === '4C';
     }).length;
 
     const other = snapshot.length - residential - commercial;

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -15,22 +15,73 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
     }
   }, [jobs]);
 
+  const computeClassBreakdown = (snapshot) => {
+    if (!snapshot || !Array.isArray(snapshot)) {
+      return { residential: 0, commercial: 0, other: 0 };
+    }
+
+    const residential = snapshot.filter(a => {
+      const cls = String(a.property_m4_class || '');
+      return cls.startsWith('2') || cls === '3A';
+    }).length;
+
+    const commercial = snapshot.filter(a => {
+      const cls = String(a.property_m4_class || '');
+      return cls.startsWith('4A') || cls.startsWith('4B') || cls.startsWith('4C') || cls.startsWith('4');
+    }).length;
+
+    const other = snapshot.length - residential - commercial;
+
+    return { residential, commercial, other };
+  };
+
+  const getHearingDates = (snapshot) => {
+    if (!snapshot || !Array.isArray(snapshot)) {
+      return { earliest: null, hasMultiple: false };
+    }
+
+    const hearingDates = [...new Set(
+      snapshot
+        .map(a => a.hearing_date)
+        .filter(Boolean)
+        .sort()
+    )];
+
+    if (hearingDates.length === 0) {
+      return { earliest: null, hasMultiple: false };
+    }
+
+    const earliest = new Date(hearingDates[0]).toLocaleDateString('en-US', {
+      month: 'numeric',
+      day: 'numeric',
+      year: '2-digit'
+    });
+
+    return { earliest, hasMultiple: hearingDates.length > 1 };
+  };
+
   const loadAppealsByJob = async () => {
     try {
       setLoading(true);
       const summaryData = [];
 
-      // For each active job, load appeal_log data
+      // For each active job, use appeal_summary_snapshot if available, otherwise load from DB
       for (const job of jobs) {
         try {
-          const { data: appeals, error } = await supabase
-            .from('appeal_log')
-            .select('*')
-            .eq('job_id', job.id);
+          let appeals = job.appeal_summary_snapshot;
 
-          if (error) {
-            console.error(`Error loading appeals for job ${job.id}:`, error);
-            continue;
+          // Fall back to database query if snapshot is not available
+          if (!appeals) {
+            const { data: fetchedAppeals, error } = await supabase
+              .from('appeal_log')
+              .select('*')
+              .eq('job_id', job.id);
+
+            if (error) {
+              console.error(`Error loading appeals for job ${job.id}:`, error);
+              continue;
+            }
+            appeals = fetchedAppeals || [];
           }
 
           if (appeals && appeals.length > 0) {
@@ -71,13 +122,41 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
               }
             });
 
+            // Compute class breakdown and hearing dates from snapshot
+            const classBreakdown = computeClassBreakdown(appeals);
+            const hearingInfo = getHearingDates(appeals);
+
             summaryData.push({
               jobId: job.id,
               jobName: job.job_name || 'Unnamed Job',
               totalAppeals: appeals.length,
               statusBreakdown,
               proSeCount,
-              attorneyCount
+              attorneyCount,
+              residential: classBreakdown.residential,
+              commercial: classBreakdown.commercial,
+              other: classBreakdown.other,
+              hearingDate: hearingInfo.earliest,
+              hasMultipleHearings: hearingInfo.hasMultiple,
+              snapshotAvailable: !!job.appeal_summary_snapshot
+            });
+          } else {
+            // Job exists but has no appeals - add row with all zeros/blanks
+            summaryData.push({
+              jobId: job.id,
+              jobName: job.job_name || 'Unnamed Job',
+              totalAppeals: 0,
+              statusBreakdown: {
+                defend: 0, stipulated: 0, heard: 0, withdrawn: 0, assessor: 0, affirmed: 0, hasCME: 0
+              },
+              proSeCount: 0,
+              attorneyCount: 0,
+              residential: job.appeal_summary_snapshot ? 0 : null,
+              commercial: job.appeal_summary_snapshot ? 0 : null,
+              other: job.appeal_summary_snapshot ? 0 : null,
+              hearingDate: job.appeal_summary_snapshot ? null : null,
+              hasMultipleHearings: false,
+              snapshotAvailable: !!job.appeal_summary_snapshot
             });
           }
         } catch (err) {
@@ -105,9 +184,12 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       affirmed: acc.affirmed + row.statusBreakdown.affirmed,
       hasCME: acc.hasCME + row.statusBreakdown.hasCME,
       proSe: acc.proSe + row.proSeCount,
-      attorney: acc.attorney + row.attorneyCount
+      attorney: acc.attorney + row.attorneyCount,
+      residential: acc.residential + (row.residential !== null ? row.residential : 0),
+      commercial: acc.commercial + (row.commercial !== null ? row.commercial : 0),
+      other: acc.other + (row.other !== null ? row.other : 0)
     }),
-    { totalAppeals: 0, defend: 0, stipulated: 0, heard: 0, withdrawn: 0, assessor: 0, affirmed: 0, hasCME: 0, proSe: 0, attorney: 0 }
+    { totalAppeals: 0, defend: 0, stipulated: 0, heard: 0, withdrawn: 0, assessor: 0, affirmed: 0, hasCME: 0, proSe: 0, attorney: 0, residential: 0, commercial: 0, other: 0 }
   );
 
 
@@ -148,7 +230,8 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
             </p>
           </div>
         ) : (
-          <table className="w-full">
+          <>
+            <table className="w-full">
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">
                 <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700">Job Name</th>
@@ -162,6 +245,10 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                 <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Has CME</th>
                 <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Pro Se</th>
                 <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Attorney</th>
+                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Residential</th>
+                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Commercial</th>
+                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Other</th>
+                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Hearing</th>
               </tr>
             </thead>
             <tbody>
@@ -182,6 +269,10 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                   <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.hasCME}</td>
                   <td className="px-6 py-3 text-sm text-center text-gray-700">{row.proSeCount}</td>
                   <td className="px-6 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
+                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
+                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
+                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.other !== null ? row.other : '—'}</td>
+                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.hearingDate ? `${row.hearingDate}${row.hasMultipleHearings ? '*' : ''}` : '—'}</td>
                 </tr>
               ))}
               {/* Totals Row */}
@@ -197,9 +288,19 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                 <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.hasCME}</td>
                 <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.proSe}</td>
                 <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.attorney}</td>
+                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
+                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>
+                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.other}</td>
+                <td className="px-6 py-3 text-sm text-center text-gray-900">—</td>
               </tr>
             </tbody>
           </table>
+
+            {/* Legend */}
+            <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 text-xs text-gray-600">
+              <p>* Multiple hearing dates on file</p>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -165,9 +165,9 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
         }
       }
 
-      // Only show jobs that have appeals, sorted by CCDD code
+      // Show jobs that have appeals, plus Maplewood and Jackson as special cases, sorted by CCDD code
       const jobsWithAppeals = summaryData
-        .filter(row => row.totalAppeals > 0)
+        .filter(row => row.totalAppeals > 0 || row.jobName === 'Maplewood' || row.jobName === 'Jackson')
         .sort((a, b) => {
           // Sort by CCDD code (from job object if available)
           const ccddA = jobs.find(j => j.id === a.jobId)?.ccdd_code || '';

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -52,7 +52,10 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       return { earliest: null, hasMultiple: false };
     }
 
-    const earliest = new Date(hearingDates[0]).toLocaleDateString('en-US', {
+    // Parse date locally to avoid timezone drift (same as AppealLogTab)
+    const [year, month, day] = hearingDates[0].split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    const earliest = date.toLocaleDateString('en-US', {
       month: 'numeric',
       day: 'numeric',
       year: '2-digit'

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -165,7 +165,9 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
         }
       }
 
-      setJobAppealsSummary(summaryData);
+      // Only show jobs that have appeals
+      const jobsWithAppeals = summaryData.filter(row => row.totalAppeals > 0);
+      setJobAppealsSummary(jobsWithAppeals);
     } catch (error) {
       console.error('Error loading appeals:', error);
     } finally {
@@ -206,7 +208,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 h-full flex flex-col">
       {/* Header */}
       <div className="px-6 py-4 border-b border-gray-200">
         <h2 className="text-2xl font-bold text-gray-900 flex items-center gap-3">
@@ -219,7 +221,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       </div>
 
       {/* Content */}
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto flex-1">
         {jobAppealsSummary.length === 0 ? (
           <div className="px-6 py-12 text-center">
             <FileText className="w-12 h-12 text-gray-300 mx-auto mb-4" />
@@ -236,20 +238,20 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">
                 <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700">Job Name</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Total</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Defend</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Stipulated</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Heard</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Withdrawn</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Assessor</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Affirmed</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Has CME</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Pro Se</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Attorney</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Residential</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Commercial</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Other</th>
-                <th className="px-6 py-3 text-center text-xs font-semibold text-gray-700">Hearing</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Total</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Residential</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Commercial</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Other</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Defend</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Stipulated</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Heard</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Withdrawn</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Assessor</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Affirmed</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Has CME</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Pro Se</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Attorney</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Hearing</th>
               </tr>
             </thead>
             <tbody>
@@ -259,40 +261,40 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                   className="border-b border-gray-200 hover:bg-gray-50 cursor-pointer"
                   onClick={() => onJobSelect && onJobSelect(row.jobId)}
                 >
-                  <td className="px-6 py-3 text-sm font-medium text-gray-900">{row.jobName}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700 font-semibold">{row.totalAppeals}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.defend}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.stipulated}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.heard}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.withdrawn}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.assessor}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.affirmed}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.hasCME}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.proSeCount}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.other !== null ? row.other : '—'}</td>
-                  <td className="px-6 py-3 text-sm text-center text-gray-700">{row.hearingDate ? `${row.hearingDate}${row.hasMultipleHearings ? '*' : ''}` : '—'}</td>
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900">{row.jobName}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700 font-semibold">{row.totalAppeals}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.other !== null ? row.other : '—'}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.defend}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.stipulated}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.heard}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.withdrawn}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.assessor}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.affirmed}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.hasCME}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.proSeCount}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.hearingDate ? `${row.hearingDate}${row.hasMultipleHearings ? '*' : ''}` : '—'}</td>
                 </tr>
               ))}
               {/* Totals Row */}
               <tr className="bg-blue-50 border-t-2 border-blue-200 font-bold">
-                <td className="px-6 py-3 text-sm text-gray-900">TOTALS</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.totalAppeals}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.defend}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.stipulated}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.heard}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.withdrawn}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.assessor}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.affirmed}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.hasCME}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.proSe}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.attorney}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">{totals.other}</td>
-                <td className="px-6 py-3 text-sm text-center text-gray-900">—</td>
+                <td className="px-4 py-3 text-sm text-gray-900">TOTALS</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.totalAppeals}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.other}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.defend}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.stipulated}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.heard}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.withdrawn}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.assessor}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.affirmed}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.hasCME}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.proSe}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.attorney}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">—</td>
               </tr>
             </tbody>
           </table>

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -17,10 +17,10 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
 
   const computeClassBreakdown = (snapshot) => {
     if (!snapshot || !Array.isArray(snapshot)) {
-      return { residential: 0, commercial: 0, other: 0 };
+      return { residential: 0, commercial: 0, vacant: 0 };
     }
 
-    // Match AppealLogTab logic: Residential = '2' or '3A', Commercial = '4A', '4B', '4C'
+    // Match AppealLogTab logic: Residential = '2' or '3A', Commercial = '4A', '4B', '4C', Vacant Land = everything else
     const residential = snapshot.filter(a => {
       const cls = String(a.property_m4_class || '').trim();
       return cls === '2' || cls === '3A';
@@ -31,9 +31,9 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       return cls === '4A' || cls === '4B' || cls === '4C';
     }).length;
 
-    const other = snapshot.length - residential - commercial;
+    const vacant = snapshot.length - residential - commercial;
 
-    return { residential, commercial, other };
+    return { residential, commercial, vacant };
   };
 
   const getHearingDates = (snapshot) => {
@@ -136,7 +136,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
               attorneyCount,
               residential: classBreakdown.residential,
               commercial: classBreakdown.commercial,
-              other: classBreakdown.other,
+              vacant: classBreakdown.vacant,
               hearingDate: hearingInfo.earliest,
               hasMultipleHearings: hearingInfo.hasMultiple,
               snapshotAvailable: !!job.appeal_summary_snapshot
@@ -154,7 +154,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
               attorneyCount: 0,
               residential: job.appeal_summary_snapshot ? 0 : null,
               commercial: job.appeal_summary_snapshot ? 0 : null,
-              other: job.appeal_summary_snapshot ? 0 : null,
+              vacant: job.appeal_summary_snapshot ? 0 : null,
               hearingDate: job.appeal_summary_snapshot ? null : null,
               hasMultipleHearings: false,
               snapshotAvailable: !!job.appeal_summary_snapshot
@@ -197,9 +197,9 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       attorney: acc.attorney + row.attorneyCount,
       residential: acc.residential + (row.residential !== null ? row.residential : 0),
       commercial: acc.commercial + (row.commercial !== null ? row.commercial : 0),
-      other: acc.other + (row.other !== null ? row.other : 0)
+      vacant: acc.vacant + (row.vacant !== null ? row.vacant : 0)
     }),
-    { totalAppeals: 0, defend: 0, stipulated: 0, heard: 0, withdrawn: 0, assessor: 0, affirmed: 0, hasCME: 0, proSe: 0, attorney: 0, residential: 0, commercial: 0, other: 0 }
+    { totalAppeals: 0, defend: 0, stipulated: 0, heard: 0, withdrawn: 0, assessor: 0, affirmed: 0, hasCME: 0, proSe: 0, attorney: 0, residential: 0, commercial: 0, vacant: 0 }
   );
 
 
@@ -248,7 +248,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Total</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Residential</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Commercial</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Other</th>
+                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Vacant Land</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Defend</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Stipulated</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Heard</th>
@@ -272,7 +272,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                   <td className="px-4 py-3 text-sm text-center text-gray-700 font-semibold">{row.totalAppeals}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.other !== null ? row.other : '—'}</td>
+                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.vacant !== null ? row.vacant : '—'}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.defend}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.stipulated}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.heard}</td>
@@ -291,7 +291,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.totalAppeals}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.other}</td>
+                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.vacant}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.defend}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.stipulated}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.heard}</td>

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -165,8 +165,15 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
         }
       }
 
-      // Only show jobs that have appeals
-      const jobsWithAppeals = summaryData.filter(row => row.totalAppeals > 0);
+      // Only show jobs that have appeals, sorted by CCDD code
+      const jobsWithAppeals = summaryData
+        .filter(row => row.totalAppeals > 0)
+        .sort((a, b) => {
+          // Sort by CCDD code (from job object if available)
+          const ccddA = jobs.find(j => j.id === a.jobId)?.ccdd_code || '';
+          const ccddB = jobs.find(j => j.id === b.jobId)?.ccdd_code || '';
+          return ccddA.localeCompare(ccddB);
+        });
       setJobAppealsSummary(jobsWithAppeals);
     } catch (error) {
       console.error('Error loading appeals:', error);

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -1006,6 +1006,7 @@ const JobContainer = ({
       checklistStatus,  // NEW: Pass checklist status
       employees,  // NEW: Pass employees data
       appealStats,  // NEW: Pass appeal log statistics
+      appealSummarySnapshot: jobData?.appeal_summary_snapshot || null,  // NEW: Pass appeal snapshot for AppealSummary
       tenantConfig: jobTenantConfig,  // Tenant configuration for module behavior
       onBackToJobs,
       activeSubModule: activeModule,

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -99,7 +99,8 @@ const JobContainer = ({
   const [hpiData, setHpiData] = useState([]);
   const [checklistItems, setChecklistItems] = useState([]);
   const [checklistStatus, setChecklistStatus] = useState([]);
-  const [employees, setEmployees] = useState([]); 
+  const [employees, setEmployees] = useState([]);
+  const [appealStats, setAppealStats] = useState(null);
 
   // NEW: Data update notification for child components
   const [dataUpdateNotification, setDataUpdateNotification] = useState({
@@ -1004,6 +1005,7 @@ const JobContainer = ({
       checklistItems,  // NEW: Pass checklist items
       checklistStatus,  // NEW: Pass checklist status
       employees,  // NEW: Pass employees data
+      appealStats,  // NEW: Pass appeal log statistics
       tenantConfig: jobTenantConfig,  // Tenant configuration for module behavior
       onBackToJobs,
       activeSubModule: activeModule,
@@ -1117,7 +1119,7 @@ const JobContainer = ({
       };
     }
 
-    // Appeal Log: provide CME navigation callback
+    // Appeal Log: provide CME navigation callback and stats update callback
     if (activeModule === 'appeal-log') {
       return {
         ...baseProps,
@@ -1130,7 +1132,8 @@ const JobContainer = ({
           } : prev);
           // Switch to Final Valuation module
           setActiveModule('final-valuation');
-        }
+        },
+        onAppealsStatUpdate: (stats) => setAppealStats(stats)
       };
     }
 

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -298,7 +298,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     };
 
     loadAppeals();
-  }, [jobData?.id, properties, computeAndEmitStats]);
+  }, [jobData?.id, properties]);
 
   // Get unique attorney and VCS values from appeals
   const uniqueAttorneys = useMemo(() => {

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -149,6 +149,20 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     onAppealsStatUpdate(stats);
   }, [onAppealsStatUpdate]);
 
+  // ==================== SNAPSHOT SAVE ====================
+
+  const saveSnapshot = useCallback(async (currentAppeals) => {
+    if (!jobData?.id) return;
+    try {
+      await supabase
+        .from('jobs')
+        .update({ appeal_summary_snapshot: currentAppeals })
+        .eq('id', jobData.id);
+    } catch (e) {
+      console.warn('Appeal snapshot save failed:', e);
+    }
+  }, [jobData?.id]);
+
   // Compute VCS to bracket mapping on mount
   useEffect(() => {
     if (!jobData?.end_date || properties.length === 0) return;
@@ -285,6 +299,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         // Emit stats on initial load
         computeAndEmitStats(enrichedAppeals);
 
+        // Save snapshot on initial load
+        saveSnapshot(enrichedAppeals);
+
         // Build unique years from data + current year
         const yearsFromData = [...new Set(enrichedAppeals.map(a => a.appeal_year).filter(Boolean))];
         const currentYear = new Date().getFullYear();
@@ -298,6 +315,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     };
 
     loadAppeals();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [jobData?.id, properties]);
 
   // Get unique attorney and VCS values from appeals
@@ -1036,6 +1054,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       setAppeals(enrichedAppeals);
       console.log('DEBUG: Appeals state updated with', enrichedAppeals.length, 'records');
       computeAndEmitStats(enrichedAppeals);
+      saveSnapshot(enrichedAppeals);
       handleCloseModal();
     } catch (error) {
       console.error('Error saving appeal:', error);
@@ -1107,6 +1126,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       );
       setAppeals(updatedAppeals);
       computeAndEmitStats(updatedAppeals);
+      saveSnapshot(updatedAppeals);
       setEditingCell(null);
     } catch (error) {
       console.error('Error saving field:', error);
@@ -1130,6 +1150,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       const updatedAppeals = appeals.filter(a => a.id !== appealId);
       setAppeals(updatedAppeals);
       computeAndEmitStats(updatedAppeals);
+      saveSnapshot(updatedAppeals);
     } catch (error) {
       console.error('Error deleting appeal:', error);
       alert(`Failed to delete: ${error.message}`);
@@ -1151,6 +1172,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       );
       setAppeals(updatedAppeals);
       computeAndEmitStats(updatedAppeals);
+      saveSnapshot(updatedAppeals);
     } catch (error) {
       console.error('Error updating field:', error);
     }
@@ -1203,6 +1225,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       );
       setAppeals(updatedAppeals);
       computeAndEmitStats(updatedAppeals);
+      saveSnapshot(updatedAppeals);
 
       setShowBulkDateModal(false);
       setBulkHearingDate('');
@@ -1455,6 +1478,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       });
 
       setAppeals(enrichedAppeals);
+      computeAndEmitStats(enrichedAppeals);
+      saveSnapshot(enrichedAppeals);
       setImportResult({ imported, skipped, unmatched });
       setImportFile(null);
 
@@ -1598,6 +1623,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       });
 
       setAppeals(enrichedAppeals);
+      computeAndEmitStats(enrichedAppeals);
+      saveSnapshot(enrichedAppeals);
       setPwrCamaResult({ imported, skipped, unmatched });
       setPwrCamaFile(null);
     } catch (error) {

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -100,6 +100,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
   const [pwrCamaProcessing, setPwrCamaProcessing] = useState(false);
   const [pwrCamaResult, setPwrCamaResult] = useState(null);
 
+  // Bulk apply hearing date state
+  const [showBulkDateModal, setShowBulkDateModal] = useState(false);
+  const [bulkHearingDate, setBulkHearingDate] = useState('');
+  const [isApplyingBulkDate, setIsApplyingBulkDate] = useState(false);
+
   // CME Brackets constant
   const CME_BRACKETS = [
     { min: 0, max: 99999, label: 'Under $100K', color: '#FF9999', textColor: 'black' },
@@ -575,13 +580,21 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
   const renderEditableCell = (appealId, field, value, type = 'text') => {
     const isEditing = editingCell?.appealId === appealId && editingCell?.field === field;
     const isCurrencyField = ['current_assessment', 'requested_value', 'judgment_value', 'possible_loss', 'loss', 'cme_projected_value'].includes(field);
+    const isDateField = type === 'date';
+
+    // Convert date to YYYY-MM-DD format for input
+    const getDateInputValue = (dateVal) => {
+      if (!dateVal) return '';
+      const date = new Date(dateVal);
+      return date.toISOString().split('T')[0];
+    };
 
     if (isEditing) {
       return (
         <input
           autoFocus
           type={type}
-          value={editValue}
+          value={isDateField ? getDateInputValue(editValue) : editValue}
           onChange={(e) => setEditValue(e.target.value)}
           onBlur={() => handleSaveEdit(appealId, field, editValue)}
           onKeyDown={(e) => {
@@ -593,13 +606,19 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       );
     }
 
-    const displayValue = isCurrencyField ? formatCurrency(value) : (value || '-');
-    const isCurrency = isCurrencyField;
+    let displayValue = '-';
+    if (isDateField && value) {
+      displayValue = new Date(value).toLocaleDateString();
+    } else if (isCurrencyField && value) {
+      displayValue = formatCurrency(value);
+    } else if (value) {
+      displayValue = value;
+    }
 
     return (
       <div
         onClick={() => handleStartEdit(appealId, field, value)}
-        className={`cursor-pointer hover:bg-blue-50 px-1 py-0.5 rounded whitespace-nowrap ${isCurrency ? 'text-right' : ''}`}
+        className={`cursor-pointer hover:bg-blue-50 px-1 py-0.5 rounded whitespace-nowrap ${isCurrencyField ? 'text-right' : ''}`}
         title="Click to edit"
       >
         {displayValue}
@@ -1079,6 +1098,60 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       ));
     } catch (error) {
       console.error('Error updating field:', error);
+    }
+  };
+
+  const handleApplyBulkHearingDate = async () => {
+    if (!bulkHearingDate || selectedAppeals.size === 0) {
+      alert('Please select appeals and enter a hearing date');
+      return;
+    }
+
+    try {
+      setIsApplyingBulkDate(true);
+      const selectedAppealIds = Array.from(selectedAppeals);
+
+      // Calculate evidence due date (7 days before hearing)
+      const hearingDate = new Date(bulkHearingDate);
+      const evidenceDueDate = new Date(hearingDate);
+      evidenceDueDate.setDate(evidenceDueDate.getDate() - 7);
+      const evidenceDueDateStr = evidenceDueDate.toISOString().split('T')[0];
+
+      // Update all selected appeals in parallel
+      const updates = selectedAppealIds.map(appealId =>
+        supabase
+          .from('appeal_log')
+          .update({
+            hearing_date: bulkHearingDate,
+            evidence_due_date: evidenceDueDateStr
+          })
+          .eq('id', appealId)
+      );
+
+      const results = await Promise.all(updates);
+
+      // Check for errors
+      const hasError = results.some(result => result.error);
+      if (hasError) {
+        throw new Error('Failed to update some appeals');
+      }
+
+      // Update local state
+      setAppeals(prev => prev.map(a =>
+        selectedAppeals.has(a.id)
+          ? { ...a, hearing_date: bulkHearingDate, evidence_due_date: evidenceDueDateStr }
+          : a
+      ));
+
+      setShowBulkDateModal(false);
+      setBulkHearingDate('');
+      setSelectedAppeals(new Set());
+      alert(`Successfully updated ${selectedAppealIds.length} appeals with hearing date ${new Date(bulkHearingDate).toLocaleDateString()}`);
+    } catch (error) {
+      console.error('Error applying bulk hearing date:', error);
+      alert(`Failed to apply bulk hearing date: ${error.message}`);
+    } finally {
+      setIsApplyingBulkDate(false);
     }
   };
 
@@ -2182,6 +2255,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
               {selectedAppeals.size} selected
             </span>
             <button
+              onClick={() => setShowBulkDateModal(true)}
+              disabled={isSendingToCME}
+              className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Bulk Apply Hearing Date
+            </button>
+            <button
               onClick={handleSendToCME}
               disabled={isSendingToCME}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium text-sm hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
@@ -2229,6 +2309,45 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                 className="flex-1 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-300"
               >
                 Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* BULK APPLY HEARING DATE MODAL */}
+      {showBulkDateModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+            <h2 className="text-lg font-bold text-gray-900 mb-4">Apply Hearing Date to Selected Appeals</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              This will apply the hearing date to all {selectedAppeals.size} selected appeal{selectedAppeals.size !== 1 ? 's' : ''} and automatically set the evidence due date 7 days prior.
+            </p>
+            <div className="mb-6">
+              <label className="block text-sm font-medium text-gray-700 mb-2">Hearing Date</label>
+              <input
+                type="date"
+                value={bulkHearingDate}
+                onChange={(e) => setBulkHearingDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+              />
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => {
+                  setShowBulkDateModal(false);
+                  setBulkHearingDate('');
+                }}
+                className="flex-1 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-300"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleApplyBulkHearingDate}
+                disabled={isApplyingBulkDate || !bulkHearingDate}
+                className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isApplyingBulkDate ? 'Applying...' : 'Apply to All'}
               </button>
             </div>
           </div>
@@ -2338,7 +2457,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                     {renderEditableCell(appeal.id, 'attorney', appeal.attorney, 'text')}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap text-gray-600" style={{ minWidth: '120px' }}>
-                    {appeal.hearing_date ? new Date(appeal.hearing_date).toLocaleDateString() : '-'}
+                    {renderEditableCell(appeal.id, 'hearing_date', appeal.hearing_date, 'date')}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap text-gray-600" style={{ minWidth: '100px' }}>
                     <label className="flex items-center gap-2 cursor-pointer">

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -2517,11 +2517,45 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
             {/* TOTALS ROW */}
             <tr className="bg-gray-50 border-t-2 border-gray-300 font-bold text-gray-900">
-              <td colSpan="15" className="px-3 py-3 text-right">TOTALS:</td>
-              <td className="px-3 py-3 whitespace-nowrap">{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.current_assessment || 0), 0))}</td>
-              <td className="px-3 py-3 whitespace-nowrap text-blue-600">{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.cme_projected_value || 0), 0))}</td>
-              <td className="px-3 py-3 whitespace-nowrap">{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.judgment_value || 0), 0))}</td>
-              <td className="px-3 py-3 whitespace-nowrap text-red-600">{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.loss || 0), 0))}</td>
+              {/* Checkbox column */}
+              <td style={{ minWidth: '50px', maxWidth: '50px' }}></td>
+              {/* Status */}
+              <td style={{ minWidth: '85px', maxWidth: '85px' }}></td>
+              {/* Appeal # */}
+              <td style={{ minWidth: '120px', maxWidth: '120px' }}></td>
+              {/* Block */}
+              <td style={{ minWidth: '60px', maxWidth: '60px' }}></td>
+              {/* Lot */}
+              <td style={{ minWidth: '60px', maxWidth: '60px' }}></td>
+              {/* Qualifier */}
+              <td style={{ minWidth: '50px', maxWidth: '50px' }}></td>
+              {/* Location */}
+              <td style={{ minWidth: '120px' }}></td>
+              {/* Class */}
+              <td style={{ minWidth: '50px', maxWidth: '50px' }}></td>
+              {/* VCS */}
+              <td style={{ minWidth: '60px', maxWidth: '60px' }}></td>
+              {/* Bracket */}
+              <td style={{ minWidth: '110px', maxWidth: '110px' }}></td>
+              {/* Inspected */}
+              <td style={{ minWidth: '90px', maxWidth: '90px' }}></td>
+              {/* Petitioner */}
+              <td style={{ minWidth: '120px' }}></td>
+              {/* Attorney */}
+              <td style={{ minWidth: '100px' }}></td>
+              {/* Hearing - TOTALS label goes here */}
+              <td className="px-3 py-3 text-right" style={{ minWidth: '120px' }}>TOTALS:</td>
+              {/* Tax Court */}
+              <td style={{ minWidth: '100px' }}></td>
+              {/* Current Assessment */}
+              <td className="px-3 py-3 whitespace-nowrap text-right" style={{ minWidth: '120px', maxWidth: '120px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.current_assessment || 0), 0))}</td>
+              {/* CME Value */}
+              <td className="px-3 py-3 whitespace-nowrap text-blue-600 text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.cme_projected_value || 0), 0))}</td>
+              {/* Judgment */}
+              <td className="px-3 py-3 whitespace-nowrap text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.judgment_value || 0), 0))}</td>
+              {/* Loss */}
+              <td className="px-3 py-3 whitespace-nowrap text-red-600 text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.loss || 0), 0))}</td>
+              {/* Action */}
               <td></td>
             </tr>
           </tbody>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1020,9 +1020,14 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
       // Recalculate dependent fields
       if (field === 'hearing_date' && value) {
-        const date = new Date(value);
+        // Parse date string (YYYY-MM-DD) without timezone conversion
+        const [year, month, day] = value.split('-').map(Number);
+        const date = new Date(year, month - 1, day);
         date.setDate(date.getDate() - 7);
-        updateData.evidence_due_date = date.toISOString().split('T')[0];
+        const evidenceDueYear = date.getFullYear();
+        const evidenceDueMonth = String(date.getMonth() + 1).padStart(2, '0');
+        const evidenceDueDay = String(date.getDate()).padStart(2, '0');
+        updateData.evidence_due_date = `${evidenceDueYear}-${evidenceDueMonth}-${evidenceDueDay}`;
       }
 
       if (field === 'appeal_number') {
@@ -1111,11 +1116,15 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       setIsApplyingBulkDate(true);
       const selectedAppealIds = Array.from(selectedAppeals);
 
-      // Calculate evidence due date (7 days before hearing)
-      const hearingDate = new Date(bulkHearingDate);
+      // Calculate evidence due date (7 days before hearing) without timezone conversion
+      const [year, month, day] = bulkHearingDate.split('-').map(Number);
+      const hearingDate = new Date(year, month - 1, day);
       const evidenceDueDate = new Date(hearingDate);
       evidenceDueDate.setDate(evidenceDueDate.getDate() - 7);
-      const evidenceDueDateStr = evidenceDueDate.toISOString().split('T')[0];
+      const evidenceDueYear = evidenceDueDate.getFullYear();
+      const evidenceDueMonth = String(evidenceDueDate.getMonth() + 1).padStart(2, '0');
+      const evidenceDueDay = String(evidenceDueDate.getDate()).padStart(2, '0');
+      const evidenceDueDateStr = `${evidenceDueYear}-${evidenceDueMonth}-${evidenceDueDay}`;
 
       // Update all selected appeals in parallel
       const updates = selectedAppealIds.map(appealId =>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { AlertCircle, ChevronDown, ChevronUp, Trash2, X, Upload } from 'lucide-react';
 import { supabase } from '../../../lib/supabaseClient';
 import * as XLSX from 'xlsx';
 
-const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigateToCME = () => {} }) => {
+const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigateToCME = () => {}, onAppealsStatUpdate = () => {} }) => {
   // State
   const [appeals, setAppeals] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -118,6 +118,36 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     { min: 1500000, max: 1999999, label: '$1.5M-$1.99M', color: '#CC99FF', textColor: 'black' },
     { min: 2000000, max: 99999999, label: '$2M+', color: '#FF99FF', textColor: 'black' }
   ];
+
+  // ==================== STATS COMPUTATION ====================
+
+  const computeAndEmitStats = useCallback((currentAppeals) => {
+    if (typeof onAppealsStatUpdate !== 'function') return;
+
+    const stats = {
+      total_appeals: currentAppeals.length,
+      open: currentAppeals.filter(a => a.status !== 'C').length,
+      closed: currentAppeals.filter(a => a.status === 'C').length,
+      total_current_assessment_at_risk: currentAppeals.reduce((sum, a) => sum + (a.current_assessment || 0), 0),
+      total_projected_loss: currentAppeals.reduce((sum, a) => sum + (a.loss || 0), 0),
+      hearing_date: currentAppeals.find(a => a.hearing_date)?.hearing_date || null,
+      evidence_due_date: currentAppeals.find(a => a.evidence_due_date)?.evidence_due_date || null,
+      stip_status_breakdown: currentAppeals.reduce((acc, a) => {
+        const s = a.stip_status || 'not_started';
+        acc[s] = (acc[s] || 0) + 1;
+        return acc;
+      }, {}),
+      by_class: currentAppeals.reduce((acc, a) => {
+        const cls = a.property_m4_class || 'Unknown';
+        if (!acc[cls]) acc[cls] = { count: 0, loss: 0 };
+        acc[cls].count++;
+        acc[cls].loss += (a.loss || 0);
+        return acc;
+      }, {})
+    };
+
+    onAppealsStatUpdate(stats);
+  }, [onAppealsStatUpdate]);
 
   // Compute VCS to bracket mapping on mount
   useEffect(() => {
@@ -252,6 +282,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         setAppeals(enrichedAppeals);
         console.log('DEBUG: Appeals state set with:', enrichedAppeals.length, 'records');
 
+        // Emit stats on initial load
+        computeAndEmitStats(enrichedAppeals);
+
         // Build unique years from data + current year
         const yearsFromData = [...new Set(enrichedAppeals.map(a => a.appeal_year).filter(Boolean))];
         const currentYear = new Date().getFullYear();
@@ -265,7 +298,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     };
 
     loadAppeals();
-  }, [jobData?.id, properties]);
+  }, [jobData?.id, properties, computeAndEmitStats]);
 
   // Get unique attorney and VCS values from appeals
   const uniqueAttorneys = useMemo(() => {
@@ -1002,6 +1035,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
       setAppeals(enrichedAppeals);
       console.log('DEBUG: Appeals state updated with', enrichedAppeals.length, 'records');
+      computeAndEmitStats(enrichedAppeals);
       handleCloseModal();
     } catch (error) {
       console.error('Error saving appeal:', error);
@@ -1068,9 +1102,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       if (error) throw error;
 
       // Update local state
-      setAppeals(prev => prev.map(a =>
+      const updatedAppeals = appeals.map(a =>
         a.id === appealId ? { ...a, ...updateData } : a
-      ));
+      );
+      setAppeals(updatedAppeals);
+      computeAndEmitStats(updatedAppeals);
       setEditingCell(null);
     } catch (error) {
       console.error('Error saving field:', error);
@@ -1091,7 +1127,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
       if (error) throw error;
 
-      setAppeals(prev => prev.filter(a => a.id !== appealId));
+      const updatedAppeals = appeals.filter(a => a.id !== appealId);
+      setAppeals(updatedAppeals);
+      computeAndEmitStats(updatedAppeals);
     } catch (error) {
       console.error('Error deleting appeal:', error);
       alert(`Failed to delete: ${error.message}`);
@@ -1108,9 +1146,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
       if (error) throw error;
 
-      setAppeals(prev => prev.map(a =>
+      const updatedAppeals = appeals.map(a =>
         a.id === appealId ? { ...a, [field]: value } : a
-      ));
+      );
+      setAppeals(updatedAppeals);
+      computeAndEmitStats(updatedAppeals);
     } catch (error) {
       console.error('Error updating field:', error);
     }
@@ -1156,11 +1196,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       }
 
       // Update local state
-      setAppeals(prev => prev.map(a =>
+      const updatedAppeals = appeals.map(a =>
         selectedAppeals.has(a.id)
           ? { ...a, hearing_date: bulkHearingDate, evidence_due_date: evidenceDueDateStr }
           : a
-      ));
+      );
+      setAppeals(updatedAppeals);
+      computeAndEmitStats(updatedAppeals);
 
       setShowBulkDateModal(false);
       setBulkHearingDate('');

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -582,9 +582,14 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     const isCurrencyField = ['current_assessment', 'requested_value', 'judgment_value', 'possible_loss', 'loss', 'cme_projected_value'].includes(field);
     const isDateField = type === 'date';
 
-    // Convert date to YYYY-MM-DD format for input
+    // Convert date to YYYY-MM-DD format for input (without timezone conversion)
     const getDateInputValue = (dateVal) => {
       if (!dateVal) return '';
+      // If it's already in YYYY-MM-DD format, use it directly
+      if (typeof dateVal === 'string' && dateVal.match(/^\d{4}-\d{2}-\d{2}/)) {
+        return dateVal.split('T')[0];
+      }
+      // Otherwise parse and format
       const date = new Date(dateVal);
       return date.toISOString().split('T')[0];
     };
@@ -608,7 +613,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
     let displayValue = '-';
     if (isDateField && value) {
-      displayValue = new Date(value).toLocaleDateString();
+      // Parse YYYY-MM-DD format directly without timezone conversion
+      const parts = value.split('-');
+      if (parts.length === 3) {
+        const date = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
+        displayValue = date.toLocaleDateString();
+      }
     } else if (isCurrencyField && value) {
       displayValue = formatCurrency(value);
     } else if (value) {
@@ -2507,7 +2517,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
             {/* TOTALS ROW */}
             <tr className="bg-gray-50 border-t-2 border-gray-300 font-bold text-gray-900">
-              <td colSpan="10" className="px-3 py-3 text-right">TOTALS:</td>
+              <td colSpan="15" className="px-3 py-3 text-right">TOTALS:</td>
               <td className="px-3 py-3 whitespace-nowrap">{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.current_assessment || 0), 0))}</td>
               <td className="px-3 py-3 whitespace-nowrap text-blue-600">{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.cme_projected_value || 0), 0))}</td>
               <td className="px-3 py-3 whitespace-nowrap">{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.judgment_value || 0), 0))}</td>


### PR DESCRIPTION
### Summary
Makes the Appeal Log table fully editable inline (including hearing dates), adds a bulk hearing date apply tool for mass updates, and introduces an `appeal_summary_snapshot` system so the Appeals Summary component displays accurate class breakdowns and hearing dates across all PPA jobs.

### Problem
The Appeal Log table was read-only for many fields, making it impossible to correct data that came in via import — for example, hearing dates for all Carneys Point appeals could not be entered directly in the table. Additionally, jobs with large appeal counts (e.g., Atlantic City with 1,200+ appeals) needed a way to apply a single hearing date to many records at once. The Appeals Summary component also lacked class breakdown (Residential / Commercial / Vacant Land) and hearing date columns, and was not correctly showing all relevant jobs including Maplewood and Jackson.

### Solution
- Made the `hearing_date` column in the Appeal Log table an inline-editable cell using the existing `renderEditableCell` pattern.
- Added a **Bulk Apply Hearing Date** modal that applies a selected hearing date (and auto-calculates evidence due date 7 days prior) to all currently selected appeals in one action.
- Introduced an `appeal_summary_snapshot` JSONB column on the `jobs` table. After every mutation in `AppealLogTab`, a full snapshot of the appeals array is written to this column, giving `AppealsSummary` a reliable, pre-enriched data source.
- Updated `AppealsSummary` to read from the snapshot for class breakdown and hearing date display, with a fallback to a live DB query if no snapshot exists.
- Fixed the totals row alignment so summary values (Current Assessment, CME Value, Judgment, Loss) are correctly positioned under their respective columns.
- Fixed timezone drift in hearing date display by parsing dates locally instead of via `new Date()`.
- Ensured Maplewood and Jackson appear in the Appeals Summary as special cases, and that all jobs are sorted by CCDD code.

### Key Changes
- **`AppealLogTab.jsx`**: `hearing_date` cell is now rendered via `renderEditableCell` for inline editing; added `showBulkDateModal`, `bulkHearingDate`, and `isApplyingBulkDate` state; added `handleApplyBulkHearingDate` function that batch-updates selected appeals in Supabase and updates local state; added `saveSnapshot` callback that writes the current appeals array to `jobs.appeal_summary_snapshot` after every mutation; added `computeAndEmitStats` for upstream stat reporting; fixed totals row to use per-column `<td>` cells with correct alignment.
- **`AppealsSummary.jsx`**: Added `computeClassBreakdown` (matching AppealLogTab's Residential/Commercial/Vacant Land logic) and `getHearingDates` helpers; updated `loadAppealsByJob` to prefer `appeal_summary_snapshot` over live DB queries; added Residential, Commercial, Vacant Land, and Hearing Date columns to the summary table; filters out jobs with zero appeals (except Maplewood and Jackson); sorts rows by CCDD code; totals row now sums class breakdown columns.
- **`App.js`**: Added `appeal_summary_snapshot` to the jobs Supabase select query; updated the Appeals view job filter to correctly include Maplewood and Jackson from any job list (active, archived, planning) using case-insensitive matching.

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/matte-element-u6kqcq2g"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-matte-element-u6kqcq2g_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 157`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>matte-element-u6kqcq2g</branchName>-->