### PR TITLE
Add job exit confirmation dialog and fix broken emojis

### DIFF
--- a/copilot-os.md
+++ b/copilot-os.md
@@ -566,3 +566,5 @@ This codebase has been built iteratively over the course of a year. Every patter
 7. **Don't add loading states or spinners** to working flows — If a component doesn't show a loading spinner, it's probably because the data loads fast enough that a spinner causes more visual disruption than a brief blank frame.
 
 8. **`comparison_reports` are generated, not user-created** — They're produced automatically when a new source file is uploaded over an existing one. Don't expose CRUD for them.
+
+😊

--- a/src/App.js
+++ b/src/App.js
@@ -70,6 +70,71 @@ const App = () => {
   });
 
 
+  // Listen for browser back/forward buttons (moved after selectedJob declaration below)
+
+  // ==========================================
+  // PERFORMANCE MONITORING
+  // ==========================================
+  const performanceRef = useRef({
+    appStartTime: Date.now(),
+    dbQueries: 0,
+    avgLoadTime: 0
+  });
+
+  // ==========================================
+  // LIVE DATA STATE - NO CACHING
+  // ==========================================
+  const [appData, setAppData] = useState({
+    // Core Data
+    jobs: [],
+    employees: [],
+    managers: [],
+    planningJobs: [],
+    archivedJobs: [],
+
+    // Billing Data
+    activeJobs: [],
+    legacyJobs: [],
+    expenses: [],
+    receivables: [],
+    distributions: [],
+    billingMetrics: null,
+
+    // Computed Data
+    jobFreshness: {},
+    assignedPropertyCounts: {},
+    workflowStats: {},
+    globalInspectionAnalytics: null,
+
+    // Payroll Data
+    archivedPayrollPeriods: [],
+    dataRecency: [],
+
+    // Additional Data for Components
+    countyHpiData: [],
+    jobResponsibilities: [],
+
+    // Live State
+    isLoading: false,
+    isInitialized: false
+  });
+
+  // UI State - loading status tracking
+  const [loadingStatus, setLoadingStatus] = useState({
+    isStale: false,
+    isRefreshing: false,
+    lastError: null,
+    message: ''
+  });
+
+  // Job selection state
+  const [selectedJob, setSelectedJob] = useState(null);
+  const [fileRefreshTrigger, setFileRefreshTrigger] = useState(0);
+
+  // Job exit confirmation
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
+  const pendingExitAction = useRef(null);
+
   // Listen for browser back/forward buttons
   useEffect(() => {
     const handlePopState = (e) => {
@@ -137,69 +202,6 @@ const App = () => {
     setShowExitConfirm(false);
     pendingExitAction.current = null;
   }, []);
-
-  // ==========================================
-  // PERFORMANCE MONITORING
-  // ==========================================
-  const performanceRef = useRef({
-    appStartTime: Date.now(),
-    dbQueries: 0,
-    avgLoadTime: 0
-  });
-
-  // ==========================================
-  // LIVE DATA STATE - NO CACHING
-  // ==========================================
-  const [appData, setAppData] = useState({
-    // Core Data
-    jobs: [],
-    employees: [],
-    managers: [],
-    planningJobs: [],
-    archivedJobs: [],
-
-    // Billing Data
-    activeJobs: [],
-    legacyJobs: [],
-    expenses: [],
-    receivables: [],
-    distributions: [],
-    billingMetrics: null,
-
-    // Computed Data
-    jobFreshness: {},
-    assignedPropertyCounts: {},
-    workflowStats: {},
-    globalInspectionAnalytics: null,
-
-    // Payroll Data
-    archivedPayrollPeriods: [],
-    dataRecency: [],
-
-    // Additional Data for Components
-    countyHpiData: [],
-    jobResponsibilities: [],
-
-    // Live State
-    isLoading: false,
-    isInitialized: false
-  });
-
-  // UI State - loading status tracking
-  const [loadingStatus, setLoadingStatus] = useState({
-    isStale: false,
-    isRefreshing: false,
-    lastError: null,
-    message: ''
-  });
-
-  // Job selection state
-  const [selectedJob, setSelectedJob] = useState(null);
-  const [fileRefreshTrigger, setFileRefreshTrigger] = useState(0);
-
-  // Job exit confirmation
-  const [showExitConfirm, setShowExitConfirm] = useState(false);
-  const pendingExitAction = useRef(null);
 
   // Dev mode: "View As" impersonation state
   const [viewingAs, setViewingAs] = useState(null);

--- a/src/App.js
+++ b/src/App.js
@@ -72,16 +72,33 @@ const App = () => {
 
   // Listen for browser back/forward buttons
   useEffect(() => {
-    const handlePopState = () => {
+    const handlePopState = (e) => {
       const path = window.location.pathname;
       const parts = path.split('/');
-      
+
       // Handle job-specific URLs
       if (parts[1] === 'job' && parts[2]) {
         // Don't do anything here - the other useEffect handles job selection
         return;
       }
-      
+
+      // If currently in a job, intercept and confirm
+      if (selectedJob && activeView === 'job-modules') {
+        // Push the job URL back so the user stays on the page
+        window.history.pushState({}, '', `/job/${selectedJob.id}`);
+        const viewPath = path.slice(1) || 'admin-jobs';
+        pendingExitAction.current = () => {
+          const validViews = ['dashboard', 'admin-jobs', 'appeals', 'billing', 'employees', 'payroll', 'users', 'organizations', 'revenue', 'assessor-dashboard'];
+          if (validViews.includes(viewPath)) {
+            setActiveView(viewPath);
+            setSelectedJob(null);
+            window.history.pushState({}, '', `/${viewPath}`);
+          }
+        };
+        setShowExitConfirm(true);
+        return;
+      }
+
       // Handle main navigation
       const viewPath = path.slice(1) || 'admin-jobs';
       const validViews = ['dashboard', 'admin-jobs', 'appeals', 'billing', 'employees', 'payroll', 'users', 'organizations', 'revenue', 'assessor-dashboard'];
@@ -90,9 +107,35 @@ const App = () => {
         setSelectedJob(null); // Clear job selection when navigating to main views
       }
     };
-    
+
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
+  }, [selectedJob, activeView]);
+
+  // Warn on browser refresh/close when in a job
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      if (selectedJob && activeView === 'job-modules') {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [selectedJob, activeView]);
+
+  // Exit confirmation handlers
+  const confirmExitJob = useCallback(() => {
+    setShowExitConfirm(false);
+    if (pendingExitAction.current) {
+      pendingExitAction.current();
+      pendingExitAction.current = null;
+    }
+  }, []);
+
+  const cancelExitJob = useCallback(() => {
+    setShowExitConfirm(false);
+    pendingExitAction.current = null;
   }, []);
 
   // ==========================================
@@ -153,6 +196,10 @@ const App = () => {
   // Job selection state
   const [selectedJob, setSelectedJob] = useState(null);
   const [fileRefreshTrigger, setFileRefreshTrigger] = useState(0);
+
+  // Job exit confirmation
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
+  const pendingExitAction = useRef(null);
 
   // Dev mode: "View As" impersonation state
   const [viewingAs, setViewingAs] = useState(null);
@@ -272,7 +319,7 @@ const App = () => {
   };
 
   // Update URL when view changes
-  const handleViewChange = useCallback((view) => {
+  const executeViewChange = useCallback((view) => {
     // Prevent non-admins from navigating to billing/payroll
     const role = user?.role?.toString?.().toLowerCase?.() || '';
     const isAdminLocal = role === 'admin' || role === 'owner';
@@ -295,10 +342,21 @@ const App = () => {
       return;
     }
 
+    setSelectedJob(null);
     setActiveView(view);
     // Update URL without page reload
     window.history.pushState({}, '', `/${view}`);
   }, [user, tenantConfig]);
+
+  const handleViewChange = useCallback((view) => {
+    // If currently in a job, confirm before leaving
+    if (selectedJob && activeView === 'job-modules') {
+      pendingExitAction.current = () => executeViewChange(view);
+      setShowExitConfirm(true);
+      return;
+    }
+    executeViewChange(view);
+  }, [selectedJob, activeView, executeViewChange]);
 
   // ==========================================
   // JOB FRESHNESS CALCULATOR
@@ -815,7 +873,7 @@ const App = () => {
     console.log(`🔄 Selected job ${job.id} - will load fresh data`);
   }, []);
 
-  const handleBackToJobs = useCallback(() => {
+  const executeBackToJobs = useCallback(() => {
     setSelectedJob(null);
     const backView = isAssessorUser ? 'assessor-dashboard' : 'admin-jobs';
     setActiveView(backView);
@@ -825,6 +883,15 @@ const App = () => {
     console.log('🔄 Refreshing jobs data after returning from modules');
     loadLiveData(['jobs']);
   }, [loadLiveData, isAssessorUser]);
+
+  const handleBackToJobs = useCallback(() => {
+    if (selectedJob && activeView === 'job-modules') {
+      pendingExitAction.current = () => executeBackToJobs();
+      setShowExitConfirm(true);
+      return;
+    }
+    executeBackToJobs();
+  }, [selectedJob, activeView, executeBackToJobs]);
 
   const handleFileProcessed = useCallback(() => {
     console.log('📁 File processed acknowledged - jobs list will refresh when user returns to jobs');
@@ -1762,6 +1829,43 @@ const App = () => {
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Exit Job Confirmation Modal */}
+      {showExitConfirm && (
+        <div style={{
+          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+          background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center',
+          justifyContent: 'center', zIndex: 9999
+        }}>
+          <div style={{
+            background: 'white', borderRadius: '12px', padding: '2rem',
+            width: '90%', maxWidth: '400px', boxShadow: '0 20px 25px rgba(0,0,0,0.15)',
+            textAlign: 'center'
+          }}>
+            <div style={{ fontSize: '2.5rem', marginBottom: '0.75rem' }}>⚠️</div>
+            <h3 style={{ margin: '0 0 0.5rem', fontSize: '1.25rem', color: '#1a202c' }}>
+              Exit Job?
+            </h3>
+            <p style={{ fontSize: '0.9rem', color: '#6b7280', marginBottom: '1.5rem', lineHeight: '1.5' }}>
+              Are you sure you want to leave <strong>{selectedJob?.job_name || selectedJob?.name}</strong>? Large jobs may take several minutes to reload.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'center', gap: '0.75rem' }}>
+              <button
+                onClick={cancelExitJob}
+                style={{ padding: '0.6rem 1.5rem', borderRadius: '8px', border: '1px solid #d1d5db', background: '#f9fafb', color: '#374151', fontWeight: '600', cursor: 'pointer', fontSize: '0.9rem' }}
+              >
+                Stay in Job
+              </button>
+              <button
+                onClick={confirmExitJob}
+                style={{ padding: '0.6rem 1.5rem', borderRadius: '8px', border: 'none', background: 'linear-gradient(135deg, #2a5298, #1e3c72)', color: 'white', fontWeight: '600', cursor: 'pointer', fontSize: '0.9rem' }}
+              >
+                Yes, Exit
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/job-modules/FileUploadButton.jsx
+++ b/src/components/job-modules/FileUploadButton.jsx
@@ -3687,7 +3687,7 @@ const handleCodeFileUpdate = async () => {
       <div className="flex items-center gap-3 text-gray-300">
         <FileText className="w-4 h-4 text-blue-400" />
         <span className="text-sm min-w-0 flex-1">
-          📄 Source: {getFileStatusWithRealVersion(job.updated_at || job.created_at, 'source')}
+          Source: {getFileStatusWithRealVersion(job.updated_at || job.created_at, 'source')}
         </span>
 
         <input
@@ -3744,7 +3744,7 @@ const handleCodeFileUpdate = async () => {
       <div className="flex items-center gap-3 text-gray-300">
         <Settings className="w-4 h-4 text-green-400" />
         <span className="text-sm min-w-0 flex-1">
-          ⚙�� Code: {getFileStatusWithRealVersion(localCodeUploadedAt || latestCodeUploadedAt || job.code_file_uploaded_at || job.created_at, 'code')}
+          Code: {getFileStatusWithRealVersion(localCodeUploadedAt || latestCodeUploadedAt || job.code_file_uploaded_at || job.created_at, 'code')}
         </span>
         
         <input
@@ -3798,7 +3798,7 @@ const handleCodeFileUpdate = async () => {
       <div className="flex items-center gap-3 text-gray-300">
         <Database className="w-4 h-4 text-purple-400" />
         <span className="text-sm min-w-0 flex-1">
-          �� Reports: {reportCount} saved comparison{reportCount !== 1 ? 's' : ''}
+          Reports: {reportCount} saved comparison{reportCount !== 1 ? 's' : ''}
         </span>
         <button
           onClick={() => {


### PR DESCRIPTION
### Summary
Adds a confirmation modal when users attempt to navigate away from an active job, preventing accidental exits that would require lengthy reloads. Also removes broken emoji characters from the file upload banner.

### Problem
Users working in large jobs (e.g., Franklin, Berkshire, Jackson) that take 5+ minutes to reload were accidentally navigating away — especially during busy workflows like meeting taxpayers or taking phone calls — losing their place and forcing a full reload. Additionally, broken emoji characters (rendering as diamonds with question marks) were appearing in the file upload banner.

### Solution
Intercepts all navigation paths out of an active job (sidebar view changes, back-to-jobs button, and browser back/forward buttons) and presents a confirmation modal asking the user to confirm before exiting. A `beforeunload` handler also warns on browser refresh or tab close. Broken emojis were removed from the file upload component labels.

### Key Changes
- **Exit confirmation modal** — A centered overlay modal with a warning icon, job name, and "Stay in Job" / "Yes, Exit" buttons is shown whenever a user attempts to leave an active job view
- **`handleViewChange` interceptor** — Wraps the existing `executeViewChange` logic to check for an active job before proceeding
- **`handleBackToJobs` interceptor** — Wraps `executeBackToJobs` with the same confirmation gate
- **`popstate` handler updated** — Browser back/forward navigation now triggers the confirmation modal when inside a job, pushing the job URL back to keep the user on the page until confirmed
- **`beforeunload` handler added** — Warns users on browser refresh or tab close when a job is active
- **`pendingExitAction` ref** — Stores the deferred navigation callback to execute only after the user confirms
- **Broken emojis removed** — Stripped `📄`, `⚙️`, and `🗂️` emoji prefixes from the Source, Code, and Reports labels in `FileUploadButton.jsx`
- **`copilot-os.md` updated** — Minor doc touch to trigger PR (😊)


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/hidden-coin-pwrq1nuk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-hidden-coin-pwrq1nuk_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 163`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>hidden-coin-pwrq1nuk</branchName>-->