### PR TITLE
Update CME sales date range end from 12/31 to 10/31

### DIFF
--- a/copilot-os.md
+++ b/copilot-os.md
@@ -11,7 +11,7 @@
 | Layer | Tech |
 |-------|------|
 | Frontend | React 18 (CRA), Tailwind CSS, Lucide icons |
-| Backend / DB | Supabase (Postgres), Row-Level Security |
+| Backend / DB | Supabase (Postgres), Row-Level Security — **Project ID: `zxvavttfvpsagzluqqwn`** |
 | Auth | Supabase Auth (email/password) |
 | Exports | jsPDF (PDF), xlsx-js-style (Excel) |
 | Multi-tenant | `organizations` table, `organization_id` FK on jobs/employees/profiles |

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1708,7 +1708,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         'Current Assessment': appeal.current_assessment || 0,
         'Requested Value': appeal.requested_value || 0,
         'CME Value': appeal.cme_projected_value || 0,
-        'CME Assessment': appeal.cme_new_assessment || 0,
+        'CME Assessment': appeal.cme_projected_value && jobData?.director_ratio
+          ? Math.round(appeal.cme_projected_value * jobData.director_ratio)
+          : 0,
         Judgment: appeal.judgment_value || 0,
         Loss: '',  // Will be populated with formula
         'Loss %': '',  // Will be populated with formula

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { AlertCircle, ChevronDown, ChevronUp, Trash2, X, Upload } from 'lucide-react';
 import { supabase } from '../../../lib/supabaseClient';
-import * as XLSX from 'xlsx';
+import * as XLSX from 'xlsx-js-style';
 
 const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigateToCME = () => {}, onAppealsStatUpdate = () => {} }) => {
   // State
@@ -286,6 +286,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
             property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
             new_vcs: property?.new_vcs || null,
             owner_name: property?.owner_name || null,
+            owner_street: property?.owner_street || null,
+            owner_csz: property?.owner_csz || null,
             property_block: appeal.property_block || property?.property_block || null,
             property_lot: appeal.property_lot || property?.property_lot || null,
             property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
@@ -1044,6 +1046,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
           new_vcs: property?.new_vcs || null,
           owner_name: property?.owner_name || null,
+          owner_street: property?.owner_street || null,
+          owner_csz: property?.owner_csz || null,
           property_block: appeal.property_block || property?.property_block || null,
           property_lot: appeal.property_lot || property?.property_lot || null,
           property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
@@ -1470,6 +1474,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
           new_vcs: property?.new_vcs || null,
           owner_name: property?.owner_name || null,
+          owner_street: property?.owner_street || null,
+          owner_csz: property?.owner_csz || null,
           property_block: appeal.property_block || property?.property_block || null,
           property_lot: appeal.property_lot || property?.property_lot || null,
           property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
@@ -1615,6 +1621,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
           new_vcs: property?.new_vcs || null,
           owner_name: property?.owner_name || null,
+          owner_street: property?.owner_street || null,
+          owner_csz: property?.owner_csz || null,
           property_block: appeal.property_block || property?.property_block || null,
           property_lot: appeal.property_lot || property?.property_lot || null,
           property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
@@ -1683,6 +1691,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         Inspected: inspectionDate ? 'Yes' : 'No',
         'Last Inspection': inspectionDate || '-',
         Petitioner: appeal.petitioner_name || '-',
+        'Petitioner Address': appeal.owner_street || '-',
+        'Petitioner City/State': appeal.owner_csz || '-',
         Taxpayer: appeal.taxpayer_name || '-',
         Attorney: appeal.attorney || '-',
         'Atty Address': appeal.attorney_address || '-',

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1699,8 +1699,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         'Atty City/State': appeal.attorney_city_state || '-',
         'Atty Phone': appeal.attorney_phone || '-',
         'Atty Email': appeal.attorney_email || '-',
-        'Hearing Date': appeal.hearing_date ? new Date(appeal.hearing_date).toLocaleDateString() : '-',
         'Evidence Due': appeal.evidence_due_date ? new Date(appeal.evidence_due_date).toLocaleDateString() : '-',
+        'Hearing Date': appeal.hearing_date ? new Date(appeal.hearing_date).toLocaleDateString() : '-',
         'Evidence Status': appeal.evidence_status || '-',
         'Submission Type': appeal.submission_type || '-',
         'Stip Status': appeal.stip_status || '-',
@@ -1747,7 +1747,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     // Set column widths - expand for readability
     ws['!cols'] = headers.map(key => {
       if (key.includes('Address') || key.includes('Comments')) return { wch: 30 };
-      if (key.includes('Location') || key.includes('Petitioner') || key.includes('Attorney')) return { wch: 28 };
+      if (key.includes('Location') || key.includes('Petitioner') || key.includes('Attorney') || key === 'Taxpayer') return { wch: 28 };
       if (key.includes('Phone') || key.includes('Email') || key.includes('Inspection')) return { wch: 22 };
       if (key.includes('Assessment') || key.includes('Judgment') || key.includes('Loss') || key.includes('Value') || key.includes('CME')) return { wch: 20 };
       if (key.includes('Bracket')) return { wch: 18 };

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -100,6 +100,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
   const [pwrCamaProcessing, setPwrCamaProcessing] = useState(false);
   const [pwrCamaResult, setPwrCamaResult] = useState(null);
 
+  // Import from export state
+  const [showImportExportModal, setShowImportExportModal] = useState(false);
+  const [importExportFile, setImportExportFile] = useState(null);
+  const [importExportResult, setImportExportResult] = useState(null);
+  const [importExportProcessing, setImportExportProcessing] = useState(false);
+
   // Bulk apply hearing date state
   const [showBulkDateModal, setShowBulkDateModal] = useState(false);
   const [bulkHearingDate, setBulkHearingDate] = useState('');
@@ -1879,8 +1885,134 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     const timestamp = new Date().toISOString().split('T')[0];
     const filename = `${jobName}_AppealLog_${timestamp}.xlsx`;
 
+    // Add data validation dropdowns for Status Code and Stip Status
+    const statusCodeColIndex = headers.indexOf('Status Code');
+    const stipStatusColIndex = headers.indexOf('Stip Status');
+    if (!ws['!dataValidation']) ws['!dataValidation'] = [];
+    if (statusCodeColIndex >= 0) {
+      ws['!dataValidation'].push({
+        ref: `${XLSX.utils.encode_col(statusCodeColIndex)}2:${XLSX.utils.encode_col(statusCodeColIndex)}${range.e.r + 1}`,
+        type: 'list',
+        operator: 'equal',
+        formula1: '"D,S,H,W,A,AP,AWP,NA"',
+        showDropDown: true
+      });
+    }
+    if (stipStatusColIndex >= 0) {
+      ws['!dataValidation'].push({
+        ref: `${XLSX.utils.encode_col(stipStatusColIndex)}2:${XLSX.utils.encode_col(stipStatusColIndex)}${range.e.r + 1}`,
+        type: 'list',
+        operator: 'equal',
+        formula1: '"not_started,drafted,sent,signed,filed"',
+        showDropDown: true
+      });
+    }
+
     // Save file
     XLSX.writeFile(wb, filename);
+  };
+
+  // ==================== IMPORT HANDLER (Status Code + Stip Status from exported Excel) ====================
+  const handleImportFromExport = async () => {
+    if (!importExportFile) return;
+    try {
+      setImportExportProcessing(true);
+      const arrayBuffer = await importExportFile.arrayBuffer();
+      const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+
+      let updated = 0;
+      let skipped = 0;
+      let notFound = 0;
+
+      for (const row of rows) {
+        const appealNumber = String(row['Appeal #'] || '').trim();
+        const appealYear = row['Appeal Year'];
+        if (!appealNumber || appealNumber === '-' || !appealYear) {
+          skipped++;
+          continue;
+        }
+
+        // Find matching appeal
+        const match = appeals.find(a =>
+          String(a.appeal_number || '').trim() === appealNumber &&
+          String(a.appeal_year) === String(appealYear)
+        );
+        if (!match) {
+          notFound++;
+          continue;
+        }
+
+        // Build update with only allowed fields
+        const updateData = {};
+        const newStatus = String(row['Status Code'] || '').trim();
+        const newStip = String(row['Stip Status'] || '').trim();
+        const validStatuses = ['D', 'S', 'H', 'W', 'A', 'AP', 'AWP', 'NA'];
+        const validStips = ['not_started', 'drafted', 'sent', 'signed', 'filed'];
+
+        if (newStatus && validStatuses.includes(newStatus) && newStatus !== (match.status_code || '')) {
+          updateData.status_code = newStatus;
+        }
+        if (newStip && validStips.includes(newStip) && newStip !== (match.stip_status || '')) {
+          updateData.stip_status = newStip;
+        }
+
+        if (Object.keys(updateData).length === 0) {
+          skipped++;
+          continue;
+        }
+
+        const { error } = await supabase
+          .from('appeal_log')
+          .update(updateData)
+          .eq('id', match.id);
+
+        if (!error) updated++;
+        else skipped++;
+      }
+
+      // Refresh appeals
+      const { data: fetchData } = await supabase
+        .from('appeal_log')
+        .select('*')
+        .eq('job_id', jobData.id)
+        .eq('appeal_year', selectedYear);
+
+      if (fetchData) {
+        const enrichedAppeals = (fetchData || []).map(appeal => {
+          const property = properties.find(p =>
+            p.property_block === appeal.property_block &&
+            p.property_lot === appeal.property_lot &&
+            (p.property_qualifier || '') === (appeal.property_qualifier || '')
+          );
+          const { appealType } = parseAppealNumber(appeal.appeal_number);
+          return {
+            ...appeal,
+            appeal_type: appealType,
+            property_m4_class: property?.property_m4_class || appeal.property_m4_class || null,
+            new_vcs: property?.new_vcs || null,
+            owner_name: property?.owner_name || null,
+            owner_street: property?.owner_street || null,
+            owner_csz: property?.owner_csz || null,
+            property_block: appeal.property_block || property?.property_block || null,
+            property_lot: appeal.property_lot || property?.property_lot || null,
+            property_qualifier: appeal.property_qualifier || property?.property_qualifier || null,
+            property_location: appeal.property_location || property?.property_location || null
+          };
+        });
+        setAppeals(enrichedAppeals);
+        computeAndEmitStats(enrichedAppeals);
+        saveSnapshot(enrichedAppeals);
+      }
+
+      setImportExportResult({ updated, skipped, notFound, total: rows.length });
+    } catch (error) {
+      console.error('Import from export error:', error);
+      alert(`Import failed: ${error.message}`);
+    } finally {
+      setImportExportProcessing(false);
+    }
   };
 
   // ==================== RENDER ====================
@@ -1927,6 +2059,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
             className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium text-sm hover:bg-gray-300"
           >
             📊 Export to Excel
+          </button>
+          <button
+            onClick={() => { setShowImportExportModal(true); setImportExportResult(null); setImportExportFile(null); }}
+            className="px-4 py-2 bg-orange-600 text-white rounded-lg font-medium text-sm hover:bg-orange-700 flex items-center gap-2"
+          >
+            <Upload className="w-4 h-4" />
+            Import from Export
           </button>
         </div>
       </div>
@@ -2578,7 +2717,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                   <td className={`px-3 py-2 whitespace-nowrap ${textStrong} font-medium`} style={{ minWidth: '120px', maxWidth: '120px' }}>
                     {renderEditableCell(appeal.id, 'current_assessment', appeal.current_assessment, 'number')}
                   </td>
-                  <td className={`px-3 py-2 whitespace-nowrap ${isResolved ? 'text-blue-400' : 'text-blue-600'} font-semibold`} style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(appeal.cme_projected_value)}</td>
+                  <td className={`px-3 py-2 whitespace-nowrap ${isResolved ? 'text-blue-400' : 'text-blue-600'} font-semibold`} style={{ minWidth: '100px', maxWidth: '100px' }}>
+                    {renderEditableCell(appeal.id, 'cme_projected_value', appeal.cme_projected_value, 'number')}
+                  </td>
                   <td className={`px-3 py-2 whitespace-nowrap ${textStrong} font-medium`} style={{ minWidth: '100px', maxWidth: '100px' }}>
                     {renderEditableCell(appeal.id, 'judgment_value', appeal.judgment_value, 'number')}
                   </td>
@@ -2635,7 +2776,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
               {/* Current Assessment */}
               <td className="px-3 py-3 whitespace-nowrap text-right" style={{ minWidth: '120px', maxWidth: '120px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.current_assessment || 0), 0))}</td>
               {/* CME Value */}
-              <td className="px-3 py-3 whitespace-nowrap text-blue-600 text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.cme_projected_value || 0), 0))}</td>
+              <td className="px-3 py-3 whitespace-nowrap text-blue-600 text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (Number(a.cme_projected_value) || 0), 0))}</td>
               {/* Judgment */}
               <td className="px-3 py-3 whitespace-nowrap text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.judgment_value || 0), 0))}</td>
               {/* Loss */}
@@ -3116,6 +3257,58 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                   </button>
                 )}
               </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* IMPORT FROM EXPORT MODAL */}
+      {showImportExportModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-lg font-semibold">Import from Exported Excel</h3>
+              <button onClick={() => setShowImportExportModal(false)} className="text-gray-400 hover:text-gray-600">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <p className="text-sm text-gray-600 mb-2">
+              Upload a previously exported Appeal Log Excel file to update <strong>Status Code</strong> and <strong>Stip Status</strong> values.
+            </p>
+            <p className="text-xs text-gray-500 mb-4">
+              Appeals are matched by Appeal # and Appeal Year. Only Status Code and Stip Status columns are imported — all other columns are ignored.
+            </p>
+            <input
+              type="file"
+              accept=".xlsx,.xls"
+              onChange={(e) => setImportExportFile(e.target.files[0])}
+              className="w-full mb-4 text-sm"
+            />
+            {importExportResult && (
+              <div className="mb-4 p-3 bg-gray-50 rounded-lg text-sm">
+                <p className="font-medium mb-1">Import Complete</p>
+                <p>Updated: <strong>{importExportResult.updated}</strong></p>
+                <p>Skipped (no changes): <strong>{importExportResult.skipped}</strong></p>
+                <p>Not found: <strong>{importExportResult.notFound}</strong></p>
+                <p className="text-gray-500 mt-1">Total rows: {importExportResult.total}</p>
+              </div>
+            )}
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setShowImportExportModal(false)}
+                className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg text-sm hover:bg-gray-200"
+              >
+                {importExportResult ? 'Close' : 'Cancel'}
+              </button>
+              {!importExportResult && (
+                <button
+                  onClick={handleImportFromExport}
+                  disabled={!importExportFile || importExportProcessing}
+                  className="px-4 py-2 bg-orange-600 text-white rounded-lg text-sm hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {importExportProcessing ? 'Importing...' : 'Import'}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1788,10 +1788,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
     // Define a function to create proper cell style
     const getCellStyle = (columnName, bgFill, isFormula = false) => {
+      const thinBorder = { style: 'thin', color: { rgb: 'D0D0D0' } };
       const baseStyle = {
         font: { name: 'Leelawadee', sz: 10, color: { rgb: '000000' } },
         alignment: { horizontal: 'center', vertical: 'center', wrapText: false },
-        fill: bgFill
+        fill: bgFill,
+        border: { left: thinBorder, right: thinBorder, top: thinBorder, bottom: thinBorder }
       };
 
       if (currencyColumns.includes(columnName)) {
@@ -1828,18 +1830,15 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
     };
 
     // Format data rows
+    const defaultBgFill = { fgColor: { rgb: 'FFFFFF' }, patternType: 'solid' };
     for (let R = 1; R <= range.e.r; R++) {
-      // Use Judgment value for default row color
-      const judgmentValue = exportData[R - 1]?.Judgment || 0;
-      const defaultBgFill = { fgColor: { rgb: getBracketColor(judgmentValue) }, patternType: 'solid' };
-
       for (let C = 0; C < headers.length; C++) {
         const cellRef = XLSX.utils.encode_cell({ r: R, c: C });
         const columnName = headers[C];
 
         if (!ws[cellRef]) ws[cellRef] = {};
 
-        // For Bracket column, use bracket-specific color
+        // For Bracket column, use bracket-specific color; all other columns use white
         let cellBgFill = defaultBgFill;
         if (C === headers.indexOf('Bracket')) {
           const bracketLabel = exportData[R - 1]?.Bracket || '-';

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3329,14 +3329,14 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                   <p className="text-xs font-medium text-gray-700 mb-1">Status Code</p>
                   <div className="space-y-0.5">
                     {[
-                      ['D', 'Docketed'],
+                      ['D', 'Defend'],
                       ['S', 'Settled'],
                       ['H', 'Heard'],
                       ['W', 'Withdrawn'],
                       ['A', 'Assessor'],
                       ['AP', 'Affirmed Pending'],
                       ['AWP', 'Affirmed w/ Prejudice'],
-                      ['NA', 'Not Applicable']
+                      ['NA', 'Nonappearance']
                     ].map(([code, label]) => (
                       <div key={code} className="flex items-center gap-1.5">
                         <code className="text-xs bg-white border border-gray-300 px-1.5 py-0.5 rounded font-mono select-all cursor-pointer" title="Click to select">{code}</code>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3317,9 +3317,53 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
             <p className="text-sm text-gray-600 mb-2">
               Upload a previously exported Appeal Log Excel file to update <strong>Status Code</strong>, <strong>Stip Status</strong>, and <strong>Hearing Date</strong> values.
             </p>
-            <p className="text-xs text-gray-500 mb-4">
+            <p className="text-xs text-gray-500 mb-3">
               Appeals are matched by Appeal # and Appeal Year. Only Status Code, Stip Status, and Hearing Date are imported — all other columns are ignored. Evidence Due is auto-calculated (7 days before hearing).
             </p>
+            <div className="mb-4 border border-gray-200 rounded-lg overflow-hidden">
+              <div className="bg-gray-50 px-3 py-2 border-b border-gray-200">
+                <p className="text-xs font-semibold text-gray-700">Accepted Values Reference</p>
+              </div>
+              <div className="p-3 grid grid-cols-2 gap-3">
+                <div>
+                  <p className="text-xs font-medium text-gray-700 mb-1">Status Code</p>
+                  <div className="space-y-0.5">
+                    {[
+                      ['D', 'Docketed'],
+                      ['S', 'Settled'],
+                      ['H', 'Heard'],
+                      ['W', 'Withdrawn'],
+                      ['A', 'Assessor'],
+                      ['AP', 'Affirmed Pending'],
+                      ['AWP', 'Affirmed w/ Prejudice'],
+                      ['NA', 'Not Applicable']
+                    ].map(([code, label]) => (
+                      <div key={code} className="flex items-center gap-1.5">
+                        <code className="text-xs bg-white border border-gray-300 px-1.5 py-0.5 rounded font-mono select-all cursor-pointer" title="Click to select">{code}</code>
+                        <span className="text-xs text-gray-500">{label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs font-medium text-gray-700 mb-1">Stip Status</p>
+                  <div className="space-y-0.5">
+                    {[
+                      ['not_started', 'Not Started'],
+                      ['drafted', 'Drafted'],
+                      ['sent', 'Sent to Taxpayer'],
+                      ['signed', 'Signed'],
+                      ['filed', 'Filed']
+                    ].map(([code, label]) => (
+                      <div key={code} className="flex items-center gap-1.5">
+                        <code className="text-xs bg-white border border-gray-300 px-1.5 py-0.5 rounded font-mono select-all cursor-pointer" title="Click to select">{code}</code>
+                        <span className="text-xs text-gray-500">{label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
             <input
               type="file"
               accept=".xlsx,.xls"

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1925,6 +1925,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       let updated = 0;
       let skipped = 0;
       let notFound = 0;
+      let invalid = 0;
 
       for (const row of rows) {
         const appealNumber = String(row['Appeal #'] || '').trim();
@@ -1951,11 +1952,19 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         const validStatuses = ['D', 'S', 'H', 'W', 'A', 'AP', 'AWP', 'NA'];
         const validStips = ['not_started', 'drafted', 'sent', 'signed', 'filed'];
 
-        if (newStatus && validStatuses.includes(newStatus) && newStatus !== (match.status_code || '')) {
-          updateData.status_code = newStatus;
+        if (newStatus && newStatus !== '-') {
+          if (validStatuses.includes(newStatus)) {
+            if (newStatus !== (match.status_code || '')) updateData.status_code = newStatus;
+          } else {
+            invalid++;
+          }
         }
-        if (newStip && validStips.includes(newStip) && newStip !== (match.stip_status || '')) {
-          updateData.stip_status = newStip;
+        if (newStip && newStip !== '-') {
+          if (validStips.includes(newStip)) {
+            if (newStip !== (match.stip_status || '')) updateData.stip_status = newStip;
+          } else {
+            invalid++;
+          }
         }
 
         // Hearing Date — parse from Excel and auto-calculate Evidence Due (7 days prior)
@@ -2038,7 +2047,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         saveSnapshot(enrichedAppeals);
       }
 
-      setImportExportResult({ updated, skipped, notFound, total: rows.length });
+      setImportExportResult({ updated, skipped, notFound, invalid, total: rows.length });
     } catch (error) {
       console.error('Import from export error:', error);
       alert(`Import failed: ${error.message}`);
@@ -2094,7 +2103,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           </button>
           <button
             onClick={() => { setShowImportExportModal(true); setImportExportResult(null); setImportExportFile(null); }}
-            className="px-4 py-2 bg-orange-600 text-white rounded-lg font-medium text-sm hover:bg-orange-700 flex items-center gap-2"
+            style={{ backgroundColor: '#ea580c', color: 'white' }}
+            className="px-4 py-2 rounded-lg font-medium text-sm hover:bg-orange-700 flex items-center gap-2"
           >
             <Upload className="w-4 h-4" />
             Import from Export
@@ -3322,6 +3332,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                 <p>Updated: <strong>{importExportResult.updated}</strong></p>
                 <p>Skipped (no changes): <strong>{importExportResult.skipped}</strong></p>
                 <p>Not found: <strong>{importExportResult.notFound}</strong></p>
+                {importExportResult.invalid > 0 && (
+                  <p className="text-red-600">Invalid values rejected: <strong>{importExportResult.invalid}</strong></p>
+                )}
                 <p className="text-gray-500 mt-1">Total rows: {importExportResult.total}</p>
               </div>
             )}

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1958,6 +1958,38 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
           updateData.stip_status = newStip;
         }
 
+        // Hearing Date — parse from Excel and auto-calculate Evidence Due (7 days prior)
+        const rawHearing = row['Hearing Date'];
+        if (rawHearing && String(rawHearing).trim() !== '-' && String(rawHearing).trim() !== '') {
+          let hearingDate = null;
+          const rawStr = String(rawHearing).trim();
+          // Handle Excel serial number dates
+          if (typeof rawHearing === 'number') {
+            const excelEpoch = new Date(1899, 11, 30);
+            hearingDate = new Date(excelEpoch.getTime() + rawHearing * 86400000);
+          } else {
+            hearingDate = new Date(rawStr);
+          }
+          if (hearingDate && !isNaN(hearingDate.getTime())) {
+            const hYear = hearingDate.getFullYear();
+            const hMonth = String(hearingDate.getMonth() + 1).padStart(2, '0');
+            const hDay = String(hearingDate.getDate()).padStart(2, '0');
+            const hearingDateStr = `${hYear}-${hMonth}-${hDay}`;
+            // Only update if different from current
+            const currentHearing = match.hearing_date ? match.hearing_date.split('T')[0] : '';
+            if (hearingDateStr !== currentHearing) {
+              updateData.hearing_date = hearingDateStr;
+              // Auto-calculate evidence due date (7 days prior)
+              const evidenceDue = new Date(hearingDate);
+              evidenceDue.setDate(evidenceDue.getDate() - 7);
+              const eYear = evidenceDue.getFullYear();
+              const eMonth = String(evidenceDue.getMonth() + 1).padStart(2, '0');
+              const eDay = String(evidenceDue.getDate()).padStart(2, '0');
+              updateData.evidence_due_date = `${eYear}-${eMonth}-${eDay}`;
+            }
+          }
+        }
+
         if (Object.keys(updateData).length === 0) {
           skipped++;
           continue;
@@ -3273,10 +3305,10 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
               </button>
             </div>
             <p className="text-sm text-gray-600 mb-2">
-              Upload a previously exported Appeal Log Excel file to update <strong>Status Code</strong> and <strong>Stip Status</strong> values.
+              Upload a previously exported Appeal Log Excel file to update <strong>Status Code</strong>, <strong>Stip Status</strong>, and <strong>Hearing Date</strong> values.
             </p>
             <p className="text-xs text-gray-500 mb-4">
-              Appeals are matched by Appeal # and Appeal Year. Only Status Code and Stip Status columns are imported — all other columns are ignored.
+              Appeals are matched by Appeal # and Appeal Year. Only Status Code, Stip Status, and Hearing Date are imported — all other columns are ignored. Evidence Due is auto-calculated (7 days before hearing).
             </p>
             <input
               type="file"

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -24,14 +24,14 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
   // Filter state - separates pending (UI) from active (applied)
   const [pendingFilters, setPendingFilters] = useState({
-    statuses: new Set(['D', 'S', 'H', 'W', 'A', 'AP', 'AWP', 'NA']),
+    statuses: new Set(['D', 'S', 'H', 'W', 'Z', 'A', 'AP', 'AWP', 'NA']),
     classes: new Set(['2,3A', '4A,4B,4C', '1,3B', 'other']),
     attorneys: new Set(),
     vcs: new Set()
   });
 
   const [filters, setFilters] = useState({
-    statuses: new Set(['D', 'S', 'H', 'W', 'A', 'AP', 'AWP', 'NA']),
+    statuses: new Set(['D', 'S', 'H', 'W', 'Z', 'A', 'AP', 'AWP', 'NA']),
     classes: new Set(['2,3A', '4A,4B,4C', '1,3B', 'other']),
     attorneys: new Set(),
     vcs: new Set()
@@ -721,7 +721,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
     // Extract suffix (trailing letter(s): D, L, A, X - case insensitive)
     // Using the exact regex format with proper anchoring
-    const suffix = appealNumber.trim().match(/([DLAXdlax]+)$/)
+    const suffix = appealNumber.trim().match(/([DLAXZdlaxz]+)$/)
       ?.[1]?.toUpperCase();
 
     // Map suffix to appeal_type
@@ -729,7 +729,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       'D': 'petitioner',
       'L': 'represented',
       'A': 'assessor',
-      'X': 'cross'
+      'X': 'cross',
+      'Z': 'dismissed'
     };
 
     return {
@@ -1894,7 +1895,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         ref: `${XLSX.utils.encode_col(statusCodeColIndex)}2:${XLSX.utils.encode_col(statusCodeColIndex)}${range.e.r + 1}`,
         type: 'list',
         operator: 'equal',
-        formula1: '"D,S,H,W,A,AP,AWP,NA"',
+        formula1: '"D,S,H,W,Z,A,AP,AWP,NA"',
         showDropDown: true
       });
     }
@@ -1949,7 +1950,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         const updateData = {};
         const newStatus = String(row['Status Code'] || '').trim();
         const newStip = String(row['Stip Status'] || '').trim();
-        const validStatuses = ['D', 'S', 'H', 'W', 'A', 'AP', 'AWP', 'NA'];
+        const validStatuses = ['D', 'S', 'H', 'W', 'Z', 'A', 'AP', 'AWP', 'NA'];
         const validStips = ['not_started', 'drafted', 'sent', 'signed', 'filed'];
 
         if (newStatus && newStatus !== '-') {
@@ -2204,6 +2205,10 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
               <span className="text-lg font-bold text-gray-900">{stats.statusCounts['W'] || 0}</span>
             </div>
             <div className="flex justify-between items-center">
+              <span className="text-xs text-gray-600">Z:</span>
+              <span className="text-lg font-bold text-gray-900">{stats.statusCounts['Z'] || 0}</span>
+            </div>
+            <div className="flex justify-between items-center">
               <span className="text-xs text-gray-600">NA:</span>
               <span className="text-lg font-bold text-gray-900">{stats.statusCounts['NA'] || 0}</span>
             </div>
@@ -2290,6 +2295,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                 { code: 'S', label: 'Stipulated' },
                 { code: 'H', label: 'Heard' },
                 { code: 'W', label: 'Withdrawn' },
+                { code: 'Z', label: 'Dismissed' },
                 { code: 'A', label: 'Assessor' },
                 { code: 'AP', label: 'Affirmed w/Prejudice' },
                 { code: 'AWP', label: 'Affirmed w/o Prejudice' },
@@ -2685,7 +2691,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
               const ownerMismatch = hasOwnerMismatch(appeal);
               const acPercent = calculateACPercent(appeal);
               const evidenceDue = getEvidenceDueDate(appeal);
-              const isResolved = ['S', 'W', 'AWP', 'AP', 'NA', 'A'].includes(appeal.status);
+              const isResolved = ['S', 'W', 'Z', 'AWP', 'AP', 'NA', 'A'].includes(appeal.status);
               const resolvedBg = '#ecfdf5'; // pastel mint green
               const rowBg = selectedAppeals.has(appeal.id) ? 'bg-blue-50' : isResolved ? '' : 'hover:bg-gray-50';
               const textMuted = isResolved ? 'text-gray-500' : 'text-gray-600';
@@ -2714,6 +2720,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                       <option value="S">S</option>
                       <option value="H">H</option>
                       <option value="W">W</option>
+                      <option value="Z">Z</option>
                       <option value="A">A</option>
                       <option value="AP">AP</option>
                       <option value="AWP">AWP</option>
@@ -3336,6 +3343,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
                       ['A', 'Assessor'],
                       ['AP', 'Affirmed Pending'],
                       ['AWP', 'Affirmed w/ Prejudice'],
+                      ['Z', 'Dismissed'],
                       ['NA', 'Nonappearance']
                     ].map(([code, label]) => (
                       <div key={code} className="flex items-center gap-1.5">

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -271,9 +271,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
         if (error) throw error;
 
-        // DEBUG: Log raw data from DB
-        console.log('DEBUG: Raw appeals from DB:', data?.length);
-
         // Enrich with property data and re-parse appeal_type if null
         const enrichedAppeals = (data || []).map(appeal => {
           const property = properties.find(p => p.property_composite_key === appeal.property_composite_key);
@@ -302,7 +299,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         });
 
         setAppeals(enrichedAppeals);
-        console.log('DEBUG: Appeals state set with:', enrichedAppeals.length, 'records');
 
         // Emit stats on initial load
         computeAndEmitStats(enrichedAppeals);
@@ -474,7 +470,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
   // Filter and sort appeals
   const filteredAppeals = useMemo(() => {
     let result = appeals.filter(a => !a.appeal_year || a.appeal_year === selectedYear);
-    console.log('DEBUG: After year filter:', result.length);
 
     // Apply active filters
     result = result.filter(a => {
@@ -497,7 +492,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       return true;
     });
 
-    console.log('DEBUG: After all filters:', result.length);
 
     // Apply sorting
     if (sortState.column) {
@@ -1000,31 +994,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         evidence_due_date: sanitizeDate(calculatedEvidenceDueDate)
       };
 
-      // DEBUG: Check job_id
-      console.log('DEBUG: job_id present?', !!appealData.job_id, 'value:', appealData.job_id);
-
-      // DEBUG: Log payload keys before insert
-      console.log('DEBUG: Payload keys:', Object.keys(appealData).sort());
-
-      // DEBUG: Log full payload
-      console.log('DEBUG: Attempting insert with payload:', JSON.stringify(appealData, null, 2));
-
       const { data, error } = await supabase
         .from('appeal_log')
         .insert([appealData])
         .select()
         .single();
 
-      // DEBUG: Log insert results
-      console.log('DEBUG: Insert result - data:', data);
-      console.log('DEBUG: Insert result - error:', error);
-
-      if (error) {
-        console.error('SUPABASE INSERT ERROR:', error);
-        throw error;
-      }
-
-      console.log('DEBUG: Insert succeeded, reloading appeals...');
+      if (error) throw error;
 
       // Reload appeals
       const { data: fetchData, error: fetchError } = await supabase
@@ -1034,8 +1010,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
         .order('appeal_number', { ascending: true });
 
       if (fetchError) throw fetchError;
-
-      console.log('DEBUG: Fetched appeals count:', fetchData?.length || 0);
 
       const enrichedAppeals = (fetchData || []).map(appeal => {
         const property = properties.find(p => p.property_composite_key === appeal.property_composite_key);
@@ -1063,7 +1037,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
       });
 
       setAppeals(enrichedAppeals);
-      console.log('DEBUG: Appeals state updated with', enrichedAppeals.length, 'records');
       computeAndEmitStats(enrichedAppeals);
       saveSnapshot(enrichedAppeals);
       handleCloseModal();
@@ -1275,10 +1248,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], onNavigat
 
       // Column index helpers
       const col = (name) => headers.findIndex(h => h === name);
-
-      console.log('CSV Headers:', headers);
-      console.log('Entry col index:', col('Entry'));
-      console.log('Hearing Type col index:', col('Hearing Type'));
 
       const idxBLQ       = col('BLQ');
       const idxAppealNum = col('Appeal #');

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -31,7 +31,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
     return {
       start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0], // 10/1 prior year
-      end: new Date(assessmentYear, 11, 31).toISOString().split('T')[0] // 12/31 assessment year
+      end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0] // 10/31 assessment year
     };
   }, [jobData?.end_date, isLojikTenant]);
 
@@ -1940,7 +1940,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         // SUBJECT SALE PRIORITY: If subject sold in CSP, it becomes Comp #1 with 0% adjustment
         const assessmentYear = new Date(jobData.end_date).getFullYear();
         const cspStart = new Date(assessmentYear - 1, 9, 1);
-        const cspEnd = new Date(assessmentYear, 11, 31);
+        const cspEnd = new Date(assessmentYear, 9, 31);
 
         const subjectSaleDate = subject.sales_date ? new Date(subject.sales_date) : null;
         const subjectSaleCode = String(subject.sales_nu ?? '').trim();


### PR DESCRIPTION
### Summary
Updates the Sales Comparison (CME) default date range end from December 31 to October 31 of the assessment year, per user request. This PR also includes a suite of Appeal Log enhancements developed alongside the date fix.

### Problem
The "Dates Between" default end date in the Final Valuation – Sales Comparison (CME) search was set to 12/31 of the assessment year. Users requested this be amended to 10/31 to better reflect the correct comparable sales period.

### Solution
Changed the `end` date calculation in `SalesComparisonTab.jsx` from month index `11` (December) to `9` (October), applying to both the default date range and the subject sale CSP boundary check.

### Key Changes

**Sales Comparison (CME) – Date Fix**
- Updated default search end date from `12/31` to `10/31` of the assessment year in `SalesComparisonTab.jsx`
- Applied the same correction to the subject sale CSP priority boundary check

**Appeal Log – Enhancements**
- Added `Z` (Dismissed) as a new appeal suffix/status code, parsed from appeal numbers and available in the status dropdown and filter sets
- Added petitioner mailing address fields (`owner_street`, `owner_csz`) to enriched appeal data for use in exports
- Made `cme_projected_value` an inline-editable cell in the appeal log table, with fallback support for user-entered values
- Added Import from Export modal: allows users to upload a previously exported Excel file and update **Status Code**, **Stip Status**, and **Hearing Date** in bulk; includes an accepted values reference guide within the modal
- Switched Excel library import from `xlsx` to `xlsx-js-style` for styled export support
- Removed all debug/console log statements from `AppealLogTab.jsx`
- Updated Supabase project ID in `copilot-os.md` to the correct value (`zxvavttfvpsagzluqqwn`)


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/cotton-ohm-skemexdy"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-cotton-ohm-skemexdy_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 165`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>cotton-ohm-skemexdy</branchName>-->