### PR TITLE
Fix farm comp lot sizes and multi-residence detection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,29 @@
   min-height: 0;
 }
 
+/* PowerComp CSV export modal — Tailwind v2 (CDN) does not support arbitrary
+   values like h-[80vh] / max-h-[80vh] / min-h-0, so size it explicitly here.
+   Mirrors the address-lookup modal pattern: fixed-height shell, scrollable
+   table body, pinned header + footer. */
+.csv-export-modal-overlay {
+  z-index: 55;
+}
+.csv-export-modal-box {
+  width: 100%;
+  max-width: 1024px;
+  height: 80vh;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.csv-export-modal-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: auto;
+}
+
 /* Management OS Color Variables */
 :root {
   /* Primary Blues from Management OS */

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -26,9 +26,10 @@ const enrichPropertiesWithPackageData = (properties) => {
       const propClass = p.property_m4_class || p.property_class;
       return propClass === '3B';
     });
+    // Prefer market_manual_* (unit-rate-config calculated values for BRT) over asset_lot_* (Microsystems direct extract)
     const combinedLotSF = group.reduce((sum, p) => {
-      const sf = parseFloat(p.asset_lot_sf) || 0;
-      const acres = parseFloat(p.asset_lot_acre) || 0;
+      const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
+      const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
       return sum + sf + (acres * 43560);
     }, 0);
     // Determine additional card vs multi-property package

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -27,10 +27,12 @@ const enrichPropertiesWithPackageData = (properties) => {
       return propClass === '3B';
     });
     // Prefer market_manual_* (unit-rate-config calculated values for BRT) over asset_lot_* (Microsystems direct extract)
+    // SF and acres represent the SAME measurement in different units, so use SF if available, otherwise convert acres
     const combinedLotSF = group.reduce((sum, p) => {
       const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
+      if (sf > 0) return sum + sf;
       const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
-      return sum + sf + (acres * 43560);
+      return sum + (acres * 43560);
     }, 0);
     // Determine additional card vs multi-property package
     const baseKeys = new Set();

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -61,6 +61,10 @@ const enrichPropertiesWithPackageData = (properties) => {
     // residence-bearing member so downstream consumers (sales comp / appellant
     // evidence) can warn or split the bundled price as needed.
     const residenceMemberKeys = [];
+    let combinedResidenceSFLA = 0;
+    let combinedResidenceImprovement = 0;
+    let primaryResidenceKey = null;
+    let primaryResidenceSFLA = 0;
     if (hasFarm) {
       for (const p of group) {
         const cls = (p.property_m4_class || p.property_class || '').toString().trim().toUpperCase();
@@ -68,19 +72,40 @@ const enrichPropertiesWithPackageData = (properties) => {
         const sfla = parseFloat(p.asset_sfla) || 0;
         if (sfla > 0 && p.property_composite_key) {
           residenceMemberKeys.push(p.property_composite_key);
+          combinedResidenceSFLA += sfla;
+          combinedResidenceImprovement += parseFloat(p.values_mod_improvement) || parseFloat(p.values_cama_improvement) || 0;
+          // Primary = residence with the largest SFLA (mirrors how the main
+          // additional-card holder is the one that absorbs the secondaries).
+          if (sfla > primaryResidenceSFLA) {
+            primaryResidenceSFLA = sfla;
+            primaryResidenceKey = p.property_composite_key;
+          }
         }
       }
     }
     const hasMultipleResidences = residenceMemberKeys.length >= 2;
     const residenceMemberSet = new Set(residenceMemberKeys);
 
+    // Multi-residence farms get treated as additional cards: same deed, same
+    // sale, multiple homes — downstream consolidation paths (MarketDataTab,
+    // RatableComparisonTab, attribute roll-ups, comp grids) already know how
+    // to merge SFLA and pick a primary card when this flag is true. Reusing
+    // it here means we don't have to fork every consumer.
+    const treatAsAdditionalCard = isAdditionalCard || hasMultipleResidences;
+
     const info = {
       is_package_sale: true,
       is_farm_package: hasFarm,
-      is_additional_card: isAdditionalCard,
+      is_additional_card: treatAsAdditionalCard,
       has_multiple_residences: hasMultipleResidences,
       residence_member_keys: residenceMemberKeys,
       residence_count: residenceMemberKeys.length,
+      // SFLA + improvement-value rollups so consumers can treat the bundle
+      // as "one combined improvement" the same way an additional-card stack
+      // already collapses into the main card.
+      combined_residence_sfla: combinedResidenceSFLA,
+      combined_residence_improvement: combinedResidenceImprovement,
+      primary_residence_key: primaryResidenceKey,
       package_count: group.length,
       combined_lot_sf: combinedLotSF,
       combined_lot_acres: combinedLotSF / 43560,
@@ -88,11 +113,19 @@ const enrichPropertiesWithPackageData = (properties) => {
       package_properties: group.map(p => p.property_composite_key)
     };
     group.forEach(p => {
+      const isResidenceMember = hasMultipleResidences && residenceMemberSet.has(p.property_composite_key);
+      const isPrimaryResidence = isResidenceMember && p.property_composite_key === primaryResidenceKey;
       p._pkg = {
         ...info,
-        // Per-parcel marker so a row knows it's one of N homes in a multi-
-        // residence farm package without having to re-check the keys array.
-        is_additional_residence: hasMultipleResidences && residenceMemberSet.has(p.property_composite_key)
+        // Per-parcel markers so a row knows whether it's one of N homes in a
+        // multi-residence farm package and whether it's the primary (largest
+        // SFLA) home that the bundle's combined SFLA / improvement value
+        // should be attached to during consolidation.
+        is_additional_residence: isResidenceMember,
+        is_primary_residence: isPrimaryResidence,
+        // The "secondary residences" in the bundle should be hidden by
+        // consolidation paths the same way additional cards already are.
+        is_secondary_residence: isResidenceMember && !isPrimaryResidence
       };
     });
   }

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -53,17 +53,48 @@ const enrichPropertiesWithPackageData = (properties) => {
     if (baseKeys.size === 1 && cardIds.size > 1) {
       isAdditionalCard = true;
     }
+    // Multi-residence farm detection: only meaningful when this is a farm
+    // package (has a 3B qfarm partner). Within the deed-group we look for
+    // Class 2 or 3A parcels that carry buildings (asset_sfla > 0). When the
+    // count is >= 2, the deed bundles more than one home (e.g. 85/20.01 with
+    // two houses on the same farm sale) — flag the group and stamp each
+    // residence-bearing member so downstream consumers (sales comp / appellant
+    // evidence) can warn or split the bundled price as needed.
+    const residenceMemberKeys = [];
+    if (hasFarm) {
+      for (const p of group) {
+        const cls = (p.property_m4_class || p.property_class || '').toString().trim().toUpperCase();
+        if (cls !== '2' && cls !== '3A') continue;
+        const sfla = parseFloat(p.asset_sfla) || 0;
+        if (sfla > 0 && p.property_composite_key) {
+          residenceMemberKeys.push(p.property_composite_key);
+        }
+      }
+    }
+    const hasMultipleResidences = residenceMemberKeys.length >= 2;
+    const residenceMemberSet = new Set(residenceMemberKeys);
+
     const info = {
       is_package_sale: true,
       is_farm_package: hasFarm,
       is_additional_card: isAdditionalCard,
+      has_multiple_residences: hasMultipleResidences,
+      residence_member_keys: residenceMemberKeys,
+      residence_count: residenceMemberKeys.length,
       package_count: group.length,
       combined_lot_sf: combinedLotSF,
       combined_lot_acres: combinedLotSF / 43560,
       package_id: `${group[0].sales_book}-${group[0].sales_page}-${group[0].sales_date}`,
       package_properties: group.map(p => p.property_composite_key)
     };
-    group.forEach(p => { p._pkg = info; });
+    group.forEach(p => {
+      p._pkg = {
+        ...info,
+        // Per-parcel marker so a row knows it's one of N homes in a multi-
+        // residence farm package without having to re-check the keys array.
+        is_additional_residence: hasMultipleResidences && residenceMemberSet.has(p.property_composite_key)
+      };
+    });
   }
 };
 

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -4864,8 +4864,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
 
       {/* ==================== EXPORT CSV (POWERCOMP) SELECTION MODAL ==================== */}
       {showExportCsvModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full p-6 max-h-[90vh] h-[90vh] flex flex-col overflow-hidden">
+        <div className="csv-export-modal-overlay fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
+          <div className="csv-export-modal-box bg-white rounded-lg shadow-xl p-6">
             <div className="flex justify-between items-center mb-3 flex-shrink-0">
               <h2 className="text-lg font-bold text-gray-900">
                 Select Result Sets for PowerComp Export
@@ -4903,7 +4903,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
                 </button>
               </div>
             </div>
-            <div className="flex-1 min-h-0 overflow-y-auto border border-gray-200 rounded">
+            <div className="csv-export-modal-scroll border border-gray-200 rounded">
               <table className="w-full text-sm">
                 <thead className="bg-gray-50 sticky top-0 z-10">
                   <tr className="text-left text-xs text-gray-600">

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3164,7 +3164,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
             <span className="text-[10px] text-gray-500 text-center leading-tight">
               {mynjAppealLastImport
                 ? `Last imported: ${formatLastImport(mynjAppealLastImport)}`
-                : 'Never imported'}
+                : (appeals.some(a => a.appeal_number) ? 'Previously imported' : 'Never imported')}
             </span>
           </div>
           <div className="flex flex-col items-stretch gap-0.5">
@@ -3178,7 +3178,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
             <span className="text-[10px] text-gray-500 text-center leading-tight">
               {pwrCamaLastImport
                 ? `Last imported: ${formatLastImport(pwrCamaLastImport)}`
-                : 'Never imported'}
+                : (appeals.some(a => a.appeal_number) ? 'Previously imported' : 'Never imported')}
             </span>
           </div>
           <button
@@ -4865,7 +4865,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       {/* ==================== EXPORT CSV (POWERCOMP) SELECTION MODAL ==================== */}
       {showExportCsvModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full p-6 h-[90vh] flex flex-col">
+          <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full p-6 max-h-[90vh] h-[90vh] flex flex-col overflow-hidden">
             <div className="flex justify-between items-center mb-3 flex-shrink-0">
               <h2 className="text-lg font-bold text-gray-900">
                 Select Result Sets for PowerComp Export
@@ -4903,9 +4903,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
                 </button>
               </div>
             </div>
-            <div className="flex-1 overflow-y-auto border border-gray-200 rounded">
+            <div className="flex-1 min-h-0 overflow-y-auto border border-gray-200 rounded">
               <table className="w-full text-sm">
-                <thead className="bg-gray-50 sticky top-0">
+                <thead className="bg-gray-50 sticky top-0 z-10">
                   <tr className="text-left text-xs text-gray-600">
                     <th className="px-2 py-2 w-8"></th>
                     <th className="px-2 py-2">Subject</th>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -111,6 +111,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
   const [pwrCamaProcessing, setPwrCamaProcessing] = useState(false);
   const [pwrCamaResult, setPwrCamaResult] = useState(null);
 
+  // Last-import timestamps (job_settings keys: appeal_log_mynjappeal_last_import / appeal_log_pwrcama_last_import)
+  // ISO strings or null. Rendered under each import button; updated after each successful import.
+  const [mynjAppealLastImport, setMynjAppealLastImport] = useState(null);
+  const [pwrCamaLastImport, setPwrCamaLastImport] = useState(null);
+
   // Import from export state
   const [showImportExportModal, setShowImportExportModal] = useState(false);
   const [importExportFile, setImportExportFile] = useState(null);
@@ -215,6 +220,49 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       console.warn('Appeal snapshot save failed:', e);
     }
   }, [jobData?.id]);
+
+  // Load last-import timestamps from job_settings on mount / job change
+  useEffect(() => {
+    if (!jobData?.id) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await supabase
+        .from('job_settings')
+        .select('setting_key, setting_value')
+        .eq('job_id', jobData.id)
+        .in('setting_key', ['appeal_log_mynjappeal_last_import', 'appeal_log_pwrcama_last_import']);
+      if (cancelled || !data) return;
+      const map = Object.fromEntries(data.map(r => [r.setting_key, r.setting_value]));
+      setMynjAppealLastImport(map.appeal_log_mynjappeal_last_import || null);
+      setPwrCamaLastImport(map.appeal_log_pwrcama_last_import || null);
+    })();
+    return () => { cancelled = true; };
+  }, [jobData?.id]);
+
+  // Helper: stamp a "last import" timestamp into job_settings and update local state
+  const stampLastImport = useCallback(async (settingKey, setter) => {
+    if (!jobData?.id) return;
+    const iso = new Date().toISOString();
+    try {
+      await supabase
+        .from('job_settings')
+        .upsert(
+          { job_id: jobData.id, setting_key: settingKey, setting_value: iso, updated_at: iso },
+          { onConflict: 'job_id,setting_key' }
+        );
+      setter(iso);
+    } catch (e) {
+      console.warn(`Failed to stamp ${settingKey}:`, e);
+    }
+  }, [jobData?.id]);
+
+  // Format an ISO timestamp for the "Last imported" labels under the import buttons
+  const formatLastImport = (iso) => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return null;
+    return d.toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' });
+  };
 
   // Compute VCS to bracket mapping on mount
   useEffect(() => {
@@ -1701,6 +1749,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       setImportResult({ imported, skipped, unmatched, mergedDrafts });
       setImportFile(null);
 
+      // Stamp last-import timestamp for the MyNJAppeal source
+      stampLastImport('appeal_log_mynjappeal_last_import', setMynjAppealLastImport);
+
     } catch (error) {
       console.error('Import error:', error);
       alert(`Import failed: ${error.message}`);
@@ -1935,6 +1986,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       saveSnapshot(enrichedAppeals);
       setPwrCamaResult({ imported, refreshed, unmatched, mergedDrafts });
       setPwrCamaFile(null);
+
+      // Stamp last-import timestamp for the PwrCama source
+      stampLastImport('appeal_log_pwrcama_last_import', setPwrCamaLastImport);
     } catch (error) {
       console.error('PowerCama import error:', error);
       alert(`Import failed: ${error.message}`);
@@ -3099,20 +3153,34 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
               ))}
             </select>
           </div>
-          <button
-            onClick={() => { setShowImportModal(true); setImportResult(null); setImportFile(null); }}
-            className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
-          >
-            <Upload className="w-4 h-4" />
-            Import MyNJAppeal
-          </button>
-          <button
-            onClick={() => { setShowPwrCamaModal(true); setPwrCamaResult(null); setPwrCamaFile(null); }}
-            className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
-          >
-            <Upload className="w-4 h-4" />
-            Import PwrCama Appeals
-          </button>
+          <div className="flex flex-col items-stretch gap-0.5">
+            <button
+              onClick={() => { setShowImportModal(true); setImportResult(null); setImportFile(null); }}
+              className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
+            >
+              <Upload className="w-4 h-4" />
+              Import MyNJAppeal
+            </button>
+            <span className="text-[10px] text-gray-500 text-center leading-tight">
+              {mynjAppealLastImport
+                ? `Last imported: ${formatLastImport(mynjAppealLastImport)}`
+                : 'Never imported'}
+            </span>
+          </div>
+          <div className="flex flex-col items-stretch gap-0.5">
+            <button
+              onClick={() => { setShowPwrCamaModal(true); setPwrCamaResult(null); setPwrCamaFile(null); }}
+              className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
+            >
+              <Upload className="w-4 h-4" />
+              Import PwrCama Appeals
+            </button>
+            <span className="text-[10px] text-gray-500 text-center leading-tight">
+              {pwrCamaLastImport
+                ? `Last imported: ${formatLastImport(pwrCamaLastImport)}`
+                : 'Never imported'}
+            </span>
+          </div>
           <button
             onClick={handleExportToExcel}
             className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium text-sm hover:bg-green-700 flex items-center gap-2"
@@ -4797,8 +4865,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       {/* ==================== EXPORT CSV (POWERCOMP) SELECTION MODAL ==================== */}
       {showExportCsvModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full p-6 max-h-[90vh] flex flex-col">
-            <div className="flex justify-between items-center mb-3">
+          <div className="bg-white rounded-lg shadow-xl max-w-6xl w-full p-6 h-[90vh] flex flex-col">
+            <div className="flex justify-between items-center mb-3 flex-shrink-0">
               <h2 className="text-lg font-bold text-gray-900">
                 Select Result Sets for PowerComp Export
               </h2>
@@ -4809,13 +4877,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
                 <X className="w-5 h-5" />
               </button>
             </div>
-            <p className="text-sm text-gray-600 mb-3">
+            <p className="text-sm text-gray-600 mb-3 flex-shrink-0">
               Everything is checked by default. Uncheck any saved runs you don't
               want to send to BRT — useful when a subject has both an assessor
               run and an appellant run, or a manager rebuttal you don't want
               shipped.
             </p>
-            <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center justify-between mb-2 flex-shrink-0">
               <div className="text-xs text-gray-500">
                 {exportCsvCandidates.filter(c => c.checked).length} of{' '}
                 {exportCsvCandidates.length} selected
@@ -4898,7 +4966,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
                 </tbody>
               </table>
             </div>
-            <div className="flex justify-end gap-2 mt-4">
+            <div className="flex justify-end gap-2 mt-4 flex-shrink-0">
               <button
                 onClick={() => setShowExportCsvModal(false)}
                 className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"

--- a/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
@@ -174,6 +174,7 @@ const buildEmptyDraft = () => Array.from({ length: 5 }, (_, i) => ({
   // is true, the read-only display cells (VCS/Design/T&U/Cond/Year Built/SFLA/
   // Lot Size) become editable inputs/dropdowns sourced from in-job code usage.
   is_manual: false,
+  manual_address: '',
   manual_vcs: '',
   manual_design: '',
   manual_type_use: '',
@@ -586,7 +587,7 @@ const AppellantEvidencePanel = ({
           s.block || s.lot || s.qualifier || s.card ||
           s.sales_date || s.sales_price || s.sales_nu || s.manual_notes ||
           // Keep manual rows even if BLQ is blank (out-of-town comps)
-          s.is_manual ||
+          s.is_manual || s.manual_address ||
           s.manual_vcs || s.manual_design || s.manual_type_use ||
           s.manual_condition || s.manual_year_built || s.manual_sfla || s.manual_lot_size
         ));
@@ -841,9 +842,23 @@ const AppellantEvidencePanel = ({
                       </button>
                     </div>
                   </td>
-                  <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'block')} onChange={e => setBlqPending(idx, 'block', e.target.value)} onBlur={() => commitBlq(idx, 'block')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'block'); }} className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
-                  <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'lot')} onChange={e => setBlqPending(idx, 'lot', e.target.value)} onBlur={() => commitBlq(idx, 'lot')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'lot'); }} className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
-                  <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'qualifier')} onChange={e => setBlqPending(idx, 'qualifier', e.target.value)} onBlur={() => commitBlq(idx, 'qualifier')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'qualifier'); }} className="w-14 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
+                  {slot.is_manual ? (
+                    <td className="px-2 py-1" colSpan={3}>
+                      <input
+                        type="text"
+                        value={slot.manual_address || ''}
+                        onChange={e => updateSlot(idx, 'manual_address', e.target.value)}
+                        placeholder="Street address (out-of-town)"
+                        className="w-full px-1 py-0.5 border border-gray-300 rounded text-xs bg-amber-50"
+                      />
+                    </td>
+                  ) : (
+                    <>
+                      <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'block')} onChange={e => setBlqPending(idx, 'block', e.target.value)} onBlur={() => commitBlq(idx, 'block')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'block'); }} className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
+                      <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'lot')} onChange={e => setBlqPending(idx, 'lot', e.target.value)} onBlur={() => commitBlq(idx, 'lot')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'lot'); }} className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
+                      <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'qualifier')} onChange={e => setBlqPending(idx, 'qualifier', e.target.value)} onBlur={() => commitBlq(idx, 'qualifier')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'qualifier'); }} className="w-14 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
+                    </>
+                  )}
                   <td className={cellCls('card')} title={cellTitle('card')}>
                     <input type="text" value={slot.card} onChange={e => updateSlot(idx, 'card', e.target.value)} placeholder={compProp ? String(compProp.property_addl_card || compProp.property_card || '') : ''} className="w-12 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
                   </td>
@@ -949,12 +964,15 @@ const AppellantEvidencePanel = ({
             })()}
             {evaluations.map(({ evalResult }, idx) => {
               const slot = draft[idx];
-              const hasAny = slot.block || slot.lot || slot.sales_date || slot.sales_price;
+              const hasAny = slot.block || slot.lot || slot.sales_date || slot.sales_price || slot.is_manual || slot.manual_address;
               if (!hasAny) return null;
+              const oot = slot.is_manual
+                ? `OUT OF TOWN${slot.manual_address ? ` (${slot.manual_address.toUpperCase()})` : ''} \u2014 `
+                : '';
               return (
                 <div key={idx} className="flex items-start gap-2">
                   <div className="flex-1">
-                    <span className="font-semibold">APPELLANT COMP#{idx + 1}</span> &mdash; {evalResult.autoNote}
+                    <span className="font-semibold">APPELLANT COMP#{idx + 1}</span> &mdash; {oot}{evalResult.autoNote}
                     {slot.manual_notes && (
                       <span className="text-gray-700"> &mdash; {slot.manual_notes}</span>
                     )}
@@ -971,7 +989,7 @@ const AppellantEvidencePanel = ({
             })}
             {evaluations.every(({ evalResult }, idx) => {
               const slot = draft[idx];
-              return !(slot.block || slot.lot || slot.sales_date || slot.sales_price);
+              return !(slot.block || slot.lot || slot.sales_date || slot.sales_price || slot.is_manual || slot.manual_address);
             }) && (
               <div className="text-gray-500 italic">No comps entered yet.</div>
             )}

--- a/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
@@ -168,7 +168,19 @@ const buildEmptyDraft = () => Array.from({ length: 5 }, (_, i) => ({
   sales_date: '',
   sales_price: '',
   sales_nu: '',
-  manual_notes: ''
+  manual_notes: '',
+  // Manual entry fields — used when the comp is out-of-district (no matching
+  // property_records row). Toggled per-row via the "M" button. When is_manual
+  // is true, the read-only display cells (VCS/Design/T&U/Cond/Year Built/SFLA/
+  // Lot Size) become editable inputs/dropdowns sourced from in-job code usage.
+  is_manual: false,
+  manual_vcs: '',
+  manual_design: '',
+  manual_type_use: '',
+  manual_condition: '',
+  manual_year_built: '',
+  manual_sfla: '',
+  manual_lot_size: ''
 }));
 
 const fmtCompDate = (d) => {
@@ -254,6 +266,33 @@ const AppellantEvidencePanel = ({
       return property[field] || null;
     }
   }, [codeDefinitions, vendorType]);
+
+  // ----- Manual entry dropdown options -----
+  // Build code-with-label option lists for the manual-entry dropdowns by
+  // walking the loaded properties and collecting unique values per field.
+  // We use the existing decodeField() helper so labels match what the
+  // read-only cells show for matched properties (consistent vocab).
+  const buildCodeOptions = useCallback((field) => {
+    const seen = new Map(); // code -> label
+    for (const p of properties) {
+      const code = p?.[field];
+      if (code == null || code === '') continue;
+      const key = String(code).trim();
+      if (!key || seen.has(key)) continue;
+      const decoded = decodeField(p, field);
+      const label = decoded && String(decoded).trim().toUpperCase() !== key.toUpperCase()
+        ? `${key} \u00b7 ${decoded}`
+        : key;
+      seen.set(key, label);
+    }
+    return Array.from(seen.entries())
+      .sort((a, b) => a[0].localeCompare(b[0], undefined, { numeric: true }))
+      .map(([code, label]) => ({ code, label }));
+  }, [properties, decodeField]);
+
+  const designOptions = useMemo(() => buildCodeOptions('asset_design_style'), [buildCodeOptions]);
+  const typeUseOptions = useMemo(() => buildCodeOptions('asset_type_use'), [buildCodeOptions]);
+  const conditionOptions = useMemo(() => buildCodeOptions('asset_int_cond'), [buildCodeOptions]);
 
   const codeWithName = (property, field) => {
     const code = property?.[field];
@@ -543,7 +582,14 @@ const AppellantEvidencePanel = ({
     try {
       const cleaned = draft
         .map((s, i) => ({ ...s, slot: i + 1 }))
-        .filter(s => s.block || s.lot || s.qualifier || s.card || s.sales_date || s.sales_price || s.sales_nu || s.manual_notes);
+        .filter(s => (
+          s.block || s.lot || s.qualifier || s.card ||
+          s.sales_date || s.sales_price || s.sales_nu || s.manual_notes ||
+          // Keep manual rows even if BLQ is blank (out-of-town comps)
+          s.is_manual ||
+          s.manual_vcs || s.manual_design || s.manual_type_use ||
+          s.manual_condition || s.manual_year_built || s.manual_sfla || s.manual_lot_size
+        ));
 
       const evidencePayload = {
         appellant_comps: cleaned.length > 0 ? cleaned : null,
@@ -785,6 +831,14 @@ const AppellantEvidencePanel = ({
                       >
                         <Search className="w-3.5 h-3.5" />
                       </button>
+                      <button
+                        type="button"
+                        onClick={() => updateSlot(idx, 'is_manual', !slot.is_manual)}
+                        className={`px-1 py-0.5 text-[10px] font-bold rounded border ${slot.is_manual ? 'bg-amber-200 text-amber-900 border-amber-400' : 'text-gray-500 border-gray-300 hover:bg-gray-50'}`}
+                        title={slot.is_manual ? 'Manual entry on \u2014 click to revert to property lookup' : 'Out-of-district comp \u2014 enable manual entry'}
+                      >
+                        M
+                      </button>
                     </div>
                   </td>
                   <td className="px-2 py-1"><input type="text" value={blqValue(idx, 'block')} onChange={e => setBlqPending(idx, 'block', e.target.value)} onBlur={() => commitBlq(idx, 'block')} onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Tab') commitBlq(idx, 'block'); }} className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs" /></td>
@@ -802,13 +856,50 @@ const AppellantEvidencePanel = ({
                   <td className={cellCls('sale_nu')} title={cellTitle('sale_nu')}>
                     <input type="text" value={slot.sales_nu || (compProp?.sales_nu || '')} onChange={e => updateSlot(idx, 'sales_nu', e.target.value)} placeholder={compProp?.sales_nu || ''} className="w-12 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
                   </td>
-                  <td className={cellCls('vcs')} title={cellTitle('vcs')}>{compProp ? (compProp.new_vcs || compProp.property_vcs || '\u2014') : '\u2014'}</td>
-                  <td className={cellCls('design')} title={cellTitle('design')}>{compProp ? codeWithName(compProp, 'asset_design_style') : '\u2014'}</td>
-                  <td className={cellCls('type_use')} title={cellTitle('type_use')}>{compProp ? codeWithName(compProp, 'asset_type_use') : '\u2014'}</td>
-                  <td className={cellCls('condition')} title={cellTitle('condition')}>{compProp ? codeWithName(compProp, 'asset_int_cond') : '\u2014'}</td>
-                  <td className={cellCls('year_built')} title={cellTitle('year_built')}>{compProp?.asset_year_built || '\u2014'}</td>
-                  <td className={cellCls('sfla')} title={cellTitle('sfla')}>{compProp?.asset_sfla || '\u2014'}</td>
-                  <td className={cellCls('lot_size')} title={cellTitle('lot_size')}>{compLotDisplay(compProp)}</td>
+                  <td className={cellCls('vcs')} title={cellTitle('vcs')}>
+                    {slot.is_manual
+                      ? <input type="text" value={slot.manual_vcs || ''} onChange={e => updateSlot(idx, 'manual_vcs', e.target.value)} placeholder="VCS" className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
+                      : (compProp ? (compProp.new_vcs || compProp.property_vcs || '\u2014') : '\u2014')}
+                  </td>
+                  <td className={cellCls('design')} title={cellTitle('design')}>
+                    {slot.is_manual ? (
+                      <select value={slot.manual_design || ''} onChange={e => updateSlot(idx, 'manual_design', e.target.value)} className="px-1 py-0.5 border border-gray-300 rounded text-xs bg-white max-w-[160px]">
+                        <option value="">{'\u2014'}</option>
+                        {designOptions.map(o => <option key={o.code} value={o.code}>{o.label}</option>)}
+                      </select>
+                    ) : (compProp ? codeWithName(compProp, 'asset_design_style') : '\u2014')}
+                  </td>
+                  <td className={cellCls('type_use')} title={cellTitle('type_use')}>
+                    {slot.is_manual ? (
+                      <select value={slot.manual_type_use || ''} onChange={e => updateSlot(idx, 'manual_type_use', e.target.value)} className="px-1 py-0.5 border border-gray-300 rounded text-xs bg-white max-w-[160px]">
+                        <option value="">{'\u2014'}</option>
+                        {typeUseOptions.map(o => <option key={o.code} value={o.code}>{o.label}</option>)}
+                      </select>
+                    ) : (compProp ? codeWithName(compProp, 'asset_type_use') : '\u2014')}
+                  </td>
+                  <td className={cellCls('condition')} title={cellTitle('condition')}>
+                    {slot.is_manual ? (
+                      <select value={slot.manual_condition || ''} onChange={e => updateSlot(idx, 'manual_condition', e.target.value)} className="px-1 py-0.5 border border-gray-300 rounded text-xs bg-white max-w-[160px]">
+                        <option value="">{'\u2014'}</option>
+                        {conditionOptions.map(o => <option key={o.code} value={o.code}>{o.label}</option>)}
+                      </select>
+                    ) : (compProp ? codeWithName(compProp, 'asset_int_cond') : '\u2014')}
+                  </td>
+                  <td className={cellCls('year_built')} title={cellTitle('year_built')}>
+                    {slot.is_manual
+                      ? <input type="number" value={slot.manual_year_built || ''} onChange={e => updateSlot(idx, 'manual_year_built', e.target.value)} placeholder="YYYY" className="w-16 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
+                      : (compProp?.asset_year_built || '\u2014')}
+                  </td>
+                  <td className={cellCls('sfla')} title={cellTitle('sfla')}>
+                    {slot.is_manual
+                      ? <input type="number" value={slot.manual_sfla || ''} onChange={e => updateSlot(idx, 'manual_sfla', e.target.value)} placeholder="sf" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
+                      : (compProp?.asset_sfla || '\u2014')}
+                  </td>
+                  <td className={cellCls('lot_size')} title={cellTitle('lot_size')}>
+                    {slot.is_manual
+                      ? <input type="text" value={slot.manual_lot_size || ''} onChange={e => updateSlot(idx, 'manual_lot_size', e.target.value)} placeholder="0.5 ac" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
+                      : compLotDisplay(compProp)}
+                  </td>
                   {onPromoteComp && (
                     <td className="px-2 py-1">
                       {compProp ? (

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -2259,23 +2259,55 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
               const evalResult = evaluateAppellantComp(subject, compProp, slot, { vendorType, landMethod, sampleRange, farmMode });
               return { slot, compProp, evalResult };
             });
-            const compRows = evaluations.map(({ slot, compProp }, i) => ([
-              `#${i + 1}`,
-              slot.block || (compProp?.property_block || ''),
-              slot.lot || (compProp?.property_lot || ''),
-              slot.qualifier || (compProp?.property_qualifier || ''),
-              slot.card || (compProp?.property_addl_card || compProp?.property_card || '\u2014'),
-              slot.sales_date || (compProp?.sales_date ? new Date(compProp.sales_date).toISOString().split('T')[0] : '\u2014'),
-              (slot.sales_price || compProp?.sales_price) ? `$${Number(slot.sales_price || compProp.sales_price).toLocaleString()}` : '\u2014',
-              slot.sales_nu || compProp?.sales_nu || '\u2014',
-              compProp ? (compProp.new_vcs || compProp.property_vcs || '\u2014') : '\u2014',
-              compProp ? codeWithName(compProp, 'asset_design_style') : '\u2014',
-              compProp ? codeWithName(compProp, 'asset_type_use') : '\u2014',
-              compProp ? codeWithName(compProp, 'asset_int_cond') : '\u2014',
-              compProp?.asset_year_built || '\u2014',
-              compProp?.asset_sfla || '\u2014',
-              lotDisplay(compProp)
-            ]));
+            // For manual (out-of-town) rows, decode dropdown codes through the
+            // same code-definitions path used for matched properties so the PDF
+            // shows "code-label" instead of just the raw code.
+            const manualCodeWithName = (code, field) => {
+              if (!code) return '\u2014';
+              const synthetic = { [field]: code };
+              const decoded = decodeField(synthetic, field);
+              if (!decoded || String(decoded).trim().toUpperCase() === String(code).trim().toUpperCase()) return String(code);
+              return `${code}-${decoded}`;
+            };
+            const compRows = evaluations.map(({ slot, compProp }, i) => {
+              if (slot.is_manual) {
+                const addr = slot.manual_address ? String(slot.manual_address).toUpperCase() : 'OUT OF TOWN';
+                const lotSize = slot.manual_lot_size || '\u2014';
+                return [
+                  `#${i + 1}`,
+                  // BLQ collapses into a single "OOT — address" cell across cols 1-3
+                  addr, '', '',
+                  slot.card || '\u2014',
+                  slot.sales_date || '\u2014',
+                  slot.sales_price ? `$${Number(slot.sales_price).toLocaleString()}` : '\u2014',
+                  slot.sales_nu || '\u2014',
+                  slot.manual_vcs || '\u2014',
+                  manualCodeWithName(slot.manual_design, 'asset_design_style'),
+                  manualCodeWithName(slot.manual_type_use, 'asset_type_use'),
+                  manualCodeWithName(slot.manual_condition, 'asset_int_cond'),
+                  slot.manual_year_built || '\u2014',
+                  slot.manual_sfla || '\u2014',
+                  lotSize
+                ];
+              }
+              return [
+                `#${i + 1}`,
+                slot.block || (compProp?.property_block || ''),
+                slot.lot || (compProp?.property_lot || ''),
+                slot.qualifier || (compProp?.property_qualifier || ''),
+                slot.card || (compProp?.property_addl_card || compProp?.property_card || '\u2014'),
+                slot.sales_date || (compProp?.sales_date ? new Date(compProp.sales_date).toISOString().split('T')[0] : '\u2014'),
+                (slot.sales_price || compProp?.sales_price) ? `$${Number(slot.sales_price || compProp.sales_price).toLocaleString()}` : '\u2014',
+                slot.sales_nu || compProp?.sales_nu || '\u2014',
+                compProp ? (compProp.new_vcs || compProp.property_vcs || '\u2014') : '\u2014',
+                compProp ? codeWithName(compProp, 'asset_design_style') : '\u2014',
+                compProp ? codeWithName(compProp, 'asset_type_use') : '\u2014',
+                compProp ? codeWithName(compProp, 'asset_int_cond') : '\u2014',
+                compProp?.asset_year_built || '\u2014',
+                compProp?.asset_sfla || '\u2014',
+                lotDisplay(compProp)
+              ];
+            });
 
             // Map PDF column index → evalResult.flags key. PDF columns now
             // mirror the on-screen modal (including the Card column) so the
@@ -2366,9 +2398,12 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
             }
 
             evaluations.forEach(({ slot, evalResult }, i) => {
-              const has = slot.block || slot.lot || slot.sales_date || slot.sales_price;
+              const has = slot.block || slot.lot || slot.sales_date || slot.sales_price || slot.is_manual || slot.manual_address;
               if (!has) return;
-              const note = `APPELLANT COMP#${i + 1} \u2014 ${evalResult.autoNote}${slot.manual_notes ? ` \u2014 ${slot.manual_notes}` : ''}`;
+              const oot = slot.is_manual
+                ? `OUT OF TOWN${slot.manual_address ? ` (${String(slot.manual_address).toUpperCase()})` : ''} \u2014 `
+                : '';
+              const note = `APPELLANT COMP#${i + 1} \u2014 ${oot}${evalResult.autoNote}${slot.manual_notes ? ` \u2014 ${slot.manual_notes}` : ''}`;
               const wrapped = doc.splitTextToSize(note, doc.internal.pageSize.getWidth() - 2 * margin);
               doc.text(wrapped, margin, commentsY);
               commentsY += wrapped.length * 10;

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -100,9 +100,28 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
   // ==================== PDF EXPORT STATE ====================
   const [showExportModal, setShowExportModal] = useState(false);
-  const [showAdjustments, setShowAdjustments] = useState(true); // Toggle for comps-only mode
+  // PDF section toggles persisted to localStorage. Each remembers the user's last pick across exports.
+  // Some assessors run the full detailed grid as the deliverable (no need for the inline appellant page),
+  // and others prefer to omit the Director's Ratio / Chapter 123 page when the new value drops sharply
+  // and they're settling somewhere in between.
+  const readToggle = (key, defaultValue) => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return defaultValue;
+      return raw === 'true';
+    } catch (e) { return defaultValue; }
+  };
+  const [showAdjustments, setShowAdjustments] = useState(() => readToggle('detailedExport_showAdjustments', true));
   const [rowVisibility, setRowVisibility] = useState({}); // { attrId: boolean }
-  const [includeMap, setIncludeMap] = useState(true); // Embed subject+comps map in PDF
+  const [includeMap, setIncludeMap] = useState(() => readToggle('detailedExport_includeMap', true)); // Embed subject+comps map in PDF
+  const [hideAppellantEvidence, setHideAppellantEvidence] = useState(() => readToggle('detailedExport_hideAppellantEvidence', false));
+  const [hideDirectorsRatio, setHideDirectorsRatio] = useState(() => readToggle('detailedExport_hideDirectorsRatio', false));
+
+  // Persist toggle state across sessions
+  useEffect(() => { try { localStorage.setItem('detailedExport_showAdjustments', String(showAdjustments)); } catch (e) {} }, [showAdjustments]);
+  useEffect(() => { try { localStorage.setItem('detailedExport_includeMap', String(includeMap)); } catch (e) {} }, [includeMap]);
+  useEffect(() => { try { localStorage.setItem('detailedExport_hideAppellantEvidence', String(hideAppellantEvidence)); } catch (e) {} }, [hideAppellantEvidence]);
+  useEffect(() => { try { localStorage.setItem('detailedExport_hideDirectorsRatio', String(hideDirectorsRatio)); } catch (e) {} }, [hideDirectorsRatio]);
   const mapCaptureRef = useRef(null); // DOM ref for html2canvas capture
   // Appellant-supplied comps (loaded from appeal_log on modal open). Each
   // entry is the saved slot enriched with the resolved property record so we
@@ -2072,10 +2091,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     // before Chapter 123. Only added if an appeal_log row exists for this subject.
     // If the appeal exists but no appellant_comps are saved, we still render the
     // page with a "No Evidence supplied by Appellant" line so the report shows
-    // that fact explicitly.
+    // that fact explicitly. User can suppress entirely via the export modal toggle.
     try {
       const compositeKey = subject?.property_composite_key;
-      if (compositeKey && jobData?.id) {
+      if (!hideAppellantEvidence && compositeKey && jobData?.id) {
         const { data: appealRow } = await supabase
           .from('appeal_log')
           .select('id, appeal_number, appeal_year, property_block, property_lot, property_qualifier, property_location, appellant_comps, farm_mode')
@@ -2362,7 +2381,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     }
 
     // ==================== CHAPTER 123 TEST ====================
-    // Add Chapter 123 Analysis on a new page
+    // Add Chapter 123 Analysis on a new page. User can suppress entirely via the
+    // export modal toggle (used when assessor doesn't want the taxpayer to see a
+    // huge ratio swing before settling).
+    if (!hideDirectorsRatio) {
     doc.addPage();
     addHeader(subjectBlockLot, true);
 
@@ -2501,6 +2523,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       margin,
       ch123TableEndY + 12
     );
+    } // end !hideDirectorsRatio
 
     // ============== Subject + Comps Map page (optional) ==============
     if (includeMap && mapHasSubject && mapCaptureRef.current) {
@@ -2722,7 +2745,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     if (shouldClose) {
       setShowExportModal(false);
     }
-  }, [allAttributes, rowVisibility, showAdjustments, subject, comps, result, editableProperties, editedAdjustments, recalculatedProjectedAssessment, getAdjustment, GARAGE_OPTIONS, jobData, marketLandData, allProperties, codeDefinitions, vendorType, includeMap, mapHasSubject, mapData, compDistances, appellantDistances, aggregatedSubject, aggregatedComps, applyGeocodePatch]);
+  }, [allAttributes, rowVisibility, showAdjustments, subject, comps, result, editableProperties, editedAdjustments, recalculatedProjectedAssessment, getAdjustment, GARAGE_OPTIONS, jobData, marketLandData, allProperties, codeDefinitions, vendorType, includeMap, hideAppellantEvidence, hideDirectorsRatio, mapHasSubject, mapData, compDistances, appellantDistances, aggregatedSubject, aggregatedComps, applyGeocodePatch]);
 
   return (
     <div className="bg-white border border-gray-300 rounded-lg overflow-hidden">
@@ -3064,6 +3087,32 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                     </span>
                   </label>
                 )}
+                {/* Hide Appellant Evidence Toggle - some assessors prefer to package only the detailed grids */}
+                <label className="flex items-center gap-2 cursor-pointer text-white text-sm">
+                  <input
+                    type="checkbox"
+                    checked={hideAppellantEvidence}
+                    onChange={(e) => setHideAppellantEvidence(e.target.checked)}
+                    className="rounded border-white text-blue-600"
+                  />
+                  <span className="flex items-center gap-1">
+                    {hideAppellantEvidence ? <EyeOff size={14} /> : <Eye size={14} />}
+                    Hide Appellant Evidence
+                  </span>
+                </label>
+                {/* Hide Director's Ratio Study Toggle - omit Chapter 123 page when settling */}
+                <label className="flex items-center gap-2 cursor-pointer text-white text-sm">
+                  <input
+                    type="checkbox"
+                    checked={hideDirectorsRatio}
+                    onChange={(e) => setHideDirectorsRatio(e.target.checked)}
+                    className="rounded border-white text-blue-600"
+                  />
+                  <span className="flex items-center gap-1">
+                    {hideDirectorsRatio ? <EyeOff size={14} /> : <Eye size={14} />}
+                    Hide Director's Ratio
+                  </span>
+                </label>
                 <button
                   onClick={() => setShowExportModal(false)}
                   className="text-white hover:text-blue-200 transition-colors p-1"

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -372,8 +372,49 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     det_garage_area: { type: 'garage', field: 'det_garage_area' },
     // Condition dropdown
     ext_condition: { type: 'condition', field: 'asset_ext_cond' },
-    int_condition: { type: 'condition', field: 'asset_int_cond' }
+    int_condition: { type: 'condition', field: 'asset_int_cond' },
+    // Code dropdowns - sourced from codes actually used in this job's properties
+    // so the user picks a real code that the rest of the system knows how to
+    // decode/display. Sales code is a free-text input since NU codes are public
+    // record and easily looked up by the assessor.
+    style_code: { type: 'code', field: 'asset_design_style', codeType: 'design' },
+    type_use_code: { type: 'code', field: 'asset_type_use', codeType: 'typeUse' },
+    story_height_code: { type: 'code', field: 'asset_stories', altField: 'asset_story_height', codeType: 'storyHeight' },
+    view_code: { type: 'code', field: 'asset_view', altField: 'asset_view_code', codeType: 'view' },
+    sales_code: { type: 'text', field: 'sales_nu', altField: 'sales_code' }
   };
+
+  // Build dropdown options for code-backed fields by walking allProperties to
+  // find every distinct code in use, then decoding it via interpretCodes so
+  // the user sees the same `CODE (Name)` pairing they're used to seeing in
+  // the cells.
+  const getCodeOptions = useCallback((codeType) => {
+    if (!Array.isArray(allProperties) || allProperties.length === 0) return [];
+    const seen = new Map();
+    for (const p of allProperties) {
+      let code = null;
+      let name = null;
+      if (codeType === 'design') {
+        code = p.asset_design_style;
+        if (code && codeDefinitions) name = interpretCodes.getDesignName(p, codeDefinitions, vendorType);
+      } else if (codeType === 'typeUse') {
+        code = p.asset_type_use;
+        if (code && codeDefinitions) name = interpretCodes.getTypeName(p, codeDefinitions, vendorType);
+      } else if (codeType === 'storyHeight') {
+        code = p.asset_stories || p.asset_story_height;
+        if (code && codeDefinitions) name = interpretCodes.getStoryHeightName(p, codeDefinitions, vendorType);
+      } else if (codeType === 'view') {
+        code = p.asset_view || p.asset_view_code;
+        if (code && codeDefinitions) name = interpretCodes.getViewName(p, codeDefinitions, vendorType);
+      }
+      if (!code) continue;
+      const key = String(code);
+      if (!seen.has(key)) {
+        seen.set(key, { value: key, label: name ? `${key} (${name})` : key });
+      }
+    }
+    return Array.from(seen.values()).sort((a, b) => a.value.localeCompare(b.value));
+  }, [allProperties, codeDefinitions, vendorType]);
 
   // Garage options
   const GARAGE_OPTIONS = [
@@ -673,7 +714,13 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     {
       id: 'block_lot_qual',
       label: 'Block/Lot/Qual',
-      render: (prop) => `${prop.property_block}/${prop.property_lot}${prop.property_qualifier ? '/' + prop.property_qualifier : ''}`,
+      render: (prop) => {
+        // Manual out-of-town comps don't have a Block/Lot - surface that
+        // explicitly so the assessor can see at a glance which column is
+        // a hand-entered comp vs. a real district parcel.
+        if (prop?.is_manual_comp) return 'Out of Town';
+        return `${prop.property_block}/${prop.property_lot}${prop.property_qualifier ? '/' + prop.property_qualifier : ''}`;
+      },
       adjustmentName: null,
       bold: true
     },
@@ -3448,6 +3495,26 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                                 <option key={opt.value} value={opt.value}>{opt.label}</option>
                               ))}
                             </select>
+                          )}
+                          {cfg.type === 'code' && (
+                            <select
+                              value={editedVal ?? (prop ? (prop[cfg.field] || prop[cfg.altField] || '') : '')}
+                              onChange={(e) => updateEditedValue(propKey, attr.id, e.target.value)}
+                              className="w-full px-1 py-0.5 text-xs border rounded focus:ring-1 focus:ring-blue-500"
+                            >
+                              <option value="">-</option>
+                              {getCodeOptions(cfg.codeType).map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.label}</option>
+                              ))}
+                            </select>
+                          )}
+                          {cfg.type === 'text' && (
+                            <input
+                              type="text"
+                              value={editedVal ?? (prop ? (prop[cfg.field] || prop[cfg.altField] || '') : '') ?? ''}
+                              onChange={(e) => updateEditedValue(propKey, attr.id, e.target.value)}
+                              className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
+                            />
                           )}
                           {compAdj && compAdj.amount !== 0 && (
                             <div className={`text-xs font-bold ${compAdj.amount > 0 ? 'text-green-600' : 'text-red-600'}`}>

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -248,7 +248,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       : null;
     const compsPayload = (comps || [])
       .map((rawC, idx) => {
+        // Slot may be null (padding) or a manual out-of-town comp without
+        // lat/lng - drop both so the map only paints geocoded real comps.
+        if (!rawC || rawC.is_manual_comp) return null;
         const c = applyGeocodePatch(rawC);
+        if (!c) return null;
         const lat = parseFloat(c.property_latitude);
         const lng = parseFloat(c.property_longitude);
         if (isNaN(lat) || isNaN(lng)) return null;
@@ -292,8 +296,13 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   const mapHasSubject = !!mapData.subject;
   const mapGeocodedCount =
     (mapData.subject ? 1 : 0) + mapData.comps.length + mapData.appellantComps.length;
+  // Only count real, non-manual comps toward the "X of Y geocoded" total -
+  // null padding slots and manual out-of-town comps are not expected to have
+  // coordinates and would otherwise inflate the denominator misleadingly.
   const mapTotalCount =
-    1 + (comps?.length || 0) + (appellantCompsState?.length || 0);
+    1 +
+    (comps?.filter(c => c && !c.is_manual_comp).length || 0) +
+    (appellantCompsState?.length || 0);
 
   // Per-comp distance (miles) from subject. Always 1 decimal.
   const compDistances = useMemo(() => {

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -10,7 +10,86 @@ import GeocodeStatusChip from '../../GeocodeStatusChip';
 
 const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null }) => {
   const subject = result.subject;
-  const comps = result.comparables || [];
+  // Real comps coming from the comparables search. Manual "M" comps (entered
+  // directly in the export modal for out-of-town properties) are layered on
+  // top of these via `manualComps` below to produce the unified `comps` array
+  // that every downstream consumer (cells, recalc, PDF) reads from.
+  const rawComps = result.comparables || [];
+
+  // ==================== MANUAL COMP STATE ====================
+  // Keyed by slot index 0..4. When set, this slot renders as a fully editable
+  // out-of-town manual comp instead of (or in place of) the corresponding
+  // rawComps entry. Manual comps participate in Recalculate exactly like real
+  // comps; the user fills attribute values via the existing editable cells.
+  const [manualComps, setManualComps] = useState({});
+
+  // Build a stable manual-comp record. Property-shaped so the rest of the grid
+  // can read fields off it. All attribute values start blank; the user fills
+  // them via the editable cells, which already overlay onto comps via
+  // editableProperties[`comp_${idx}`].
+  const buildManualComp = (idx) => ({
+    is_manual_comp: true,
+    property_composite_key: `__manual_comp_${idx}__`,
+    property_block: '',
+    property_lot: '',
+    property_qualifier: '',
+    property_card: '',
+    property_location: '',
+    property_class: '',
+    property_m4_class: '',
+    sales_date: '',
+    sales_price: 0,
+    sales_book: '',
+    sales_page: '',
+    sales_nu: '',
+    asset_year_built: '',
+    asset_sfla: 0,
+    asset_lot_acre: 0,
+    asset_lot_sf: 0,
+    asset_design: '',
+    asset_type_use: '',
+    asset_ext_cond: '',
+    asset_int_cond: '',
+    values_mod_total: 0,
+    adjustedPrice: 0,
+  });
+
+  const toggleManualComp = useCallback((idx) => {
+    setManualComps(prev => {
+      const next = { ...prev };
+      if (next[idx]) {
+        delete next[idx];
+      } else {
+        next[idx] = buildManualComp(idx);
+      }
+      return next;
+    });
+    // Clear edits/adjustments for that slot so old comp data does not bleed
+    // into a freshly-toggled manual comp (and vice versa).
+    setEditableProperties(prev => {
+      const next = { ...prev };
+      delete next[`comp_${idx}`];
+      return next;
+    });
+    setEditedAdjustments(prev => {
+      const next = { ...prev };
+      delete next[`comp_${idx}`];
+      return next;
+    });
+    setHasEdits(true);
+  }, []);
+
+  // Unified comps array: manual override wins per slot, otherwise rawComps.
+  // Length always matches max(rawComps.length, 5) so the 5-column grid is
+  // stable regardless of how many real comps came back.
+  const comps = useMemo(() => {
+    const len = Math.max(rawComps.length, 5);
+    const merged = [];
+    for (let i = 0; i < len; i++) {
+      merged.push(manualComps[i] || rawComps[i] || null);
+    }
+    return merged;
+  }, [rawComps, manualComps]);
 
   // ==================== ADDITIONAL CARDS DETECTION ====================
   // Helper to check if a card identifier is a main card
@@ -93,10 +172,13 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
   // Get aggregated subject and comps
   const aggregatedSubject = useMemo(() => getAggregatedPropertyData(subject), [subject, getAggregatedPropertyData]);
-  const aggregatedComps = useMemo(() => comps.map(comp => ({
-    ...comp,
-    ...getAggregatedPropertyData(comp)
-  })), [comps, getAggregatedPropertyData]);
+  const aggregatedComps = useMemo(() => comps.map(comp => {
+    if (!comp) return null;
+    // Manual comps are not in property_records, so skip the additional-cards
+    // aggregation pass entirely - just return them as-is.
+    if (comp.is_manual_comp) return comp;
+    return { ...comp, ...getAggregatedPropertyData(comp) };
+  }), [comps, getAggregatedPropertyData]);
 
   // ==================== PDF EXPORT STATE ====================
   const [showExportModal, setShowExportModal] = useState(false);
@@ -1649,6 +1731,13 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     const subjectHeader = subjectAdditionalCards > 0 ? `Subject (+${subjectAdditionalCards})` : 'Subject';
 
     const compHeaders = aggregatedComps.slice(0, 5).map((comp, idx) => {
+      // Manual out-of-town comps render with an OUT OF TOWN label and the
+      // user-entered street address (if provided) so the assessor / county
+      // reviewer can identify the parcel without a Block/Lot.
+      if (comp?.is_manual_comp) {
+        const addr = (editableProperties[`comp_${idx}`]?.property_location || '').trim();
+        return addr ? `OUT OF TOWN ${idx + 1}\n${addr}` : `OUT OF TOWN ${idx + 1}`;
+      }
       const additionalCards = comp?._additionalCardsCount || 0;
       const baseLabel = `Comparable ${idx + 1}`;
       return additionalCards > 0 ? `${baseLabel} (+${additionalCards})` : baseLabel;
@@ -3189,11 +3278,34 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                   <tr className="bg-blue-600 text-white">
                     <th className="px-2 py-2 text-left font-semibold border-r border-blue-500 w-40">Attribute</th>
                     <th className="px-2 py-2 text-center font-semibold bg-slate-600 border-r border-slate-500 w-28">Subject</th>
-                    {[0, 1, 2, 3, 4].map(idx => (
-                      <th key={idx} className="px-2 py-2 text-center font-semibold border-r border-blue-500 w-28">
-                        Comp {idx + 1}
-                      </th>
-                    ))}
+                    {[0, 1, 2, 3, 4].map(idx => {
+                      const isManual = !!manualComps[idx];
+                      const manualAddr = isManual ? (editableProperties[`comp_${idx}`]?.property_location || '') : '';
+                      return (
+                        <th key={idx} className={`px-2 py-2 text-center font-semibold border-r border-blue-500 w-28 ${isManual ? 'bg-amber-600' : ''}`}>
+                          <div className="flex items-center justify-center gap-1">
+                            <span>{isManual ? `OUT OF TOWN ${idx + 1}` : `Comp ${idx + 1}`}</span>
+                            <button
+                              type="button"
+                              onClick={() => toggleManualComp(idx)}
+                              title={isManual ? 'Switch back to real comp' : 'Enter a manual out-of-town comp in this slot'}
+                              className={`ml-1 inline-flex items-center justify-center rounded text-[10px] font-bold border px-1.5 py-0.5 ${isManual ? 'bg-white text-amber-700 border-white' : 'bg-blue-700 text-white border-blue-300 hover:bg-blue-800'}`}
+                            >
+                              M
+                            </button>
+                          </div>
+                          {isManual && (
+                            <input
+                              type="text"
+                              value={manualAddr}
+                              onChange={(e) => updateEditedValue(`comp_${idx}`, 'property_location', e.target.value)}
+                              placeholder="Street address"
+                              className="mt-1 w-full px-1 py-0.5 text-xs text-gray-900 rounded border border-amber-300 bg-amber-50"
+                            />
+                          )}
+                        </th>
+                      );
+                    })}
                   </tr>
                 </thead>
                 <tbody>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -4600,6 +4600,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       <input type="checkbox" checked={compFilters.sameZone} onChange={(e) => setCompFilters(prev => ({ ...prev, sameZone: e.target.checked }))} className="rounded" />
                     </label>
                   </div>
+                  {!compFilters.sameZone && compFilters.zone?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {compFilters.zone.map(z => (
+                        <span key={z} className="inline-flex items-center gap-1 px-2 py-0.5 bg-purple-100 text-purple-800 rounded text-xs">
+                          {z}<button onClick={() => toggleCompFilterChip('zone')(z)} className="text-purple-600 hover:text-purple-800"><X className="w-3 h-3" /></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 {/* Building Class */}
                 <div>
@@ -4619,6 +4628,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       <input type="checkbox" checked={compFilters.sameBuildingClass} onChange={(e) => setCompFilters(prev => ({ ...prev, sameBuildingClass: e.target.checked }))} className="rounded" />
                     </label>
                   </div>
+                  {!compFilters.sameBuildingClass && compFilters.buildingClass?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {compFilters.buildingClass.map(c => (
+                        <span key={c} className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-100 text-amber-800 rounded text-xs">
+                          {c}<button onClick={() => toggleCompFilterChip('buildingClass')(c)} className="text-amber-600 hover:text-amber-800"><X className="w-3 h-3" /></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 {/* Type/Use */}
                 <div>
@@ -4638,6 +4656,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       <input type="checkbox" checked={compFilters.sameTypeUse} onChange={(e) => setCompFilters(prev => ({ ...prev, sameTypeUse: e.target.checked }))} className="rounded" />
                     </label>
                   </div>
+                  {!compFilters.sameTypeUse && compFilters.typeUse?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {compFilters.typeUse.map(t => (
+                        <span key={t} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-100 text-indigo-800 rounded text-xs">
+                          {getCodeLabel('typeUse', t)}<button onClick={() => toggleCompFilterChip('typeUse')(t)} className="text-indigo-600 hover:text-indigo-800"><X className="w-3 h-3" /></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 {/* Style */}
                 <div>
@@ -4657,6 +4684,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       <input type="checkbox" checked={compFilters.sameStyle} onChange={(e) => setCompFilters(prev => ({ ...prev, sameStyle: e.target.checked }))} className="rounded" />
                     </label>
                   </div>
+                  {!compFilters.sameStyle && compFilters.style?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {compFilters.style.map(s => (
+                        <span key={s} className="inline-flex items-center gap-1 px-2 py-0.5 bg-pink-100 text-pink-800 rounded text-xs">
+                          {getCodeLabel('style', s)}<button onClick={() => toggleCompFilterChip('style')(s)} className="text-pink-600 hover:text-pink-800"><X className="w-3 h-3" /></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 {/* Story Height */}
                 <div>
@@ -4676,6 +4712,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       <input type="checkbox" checked={compFilters.sameStoryHeight} onChange={(e) => setCompFilters(prev => ({ ...prev, sameStoryHeight: e.target.checked }))} className="rounded" />
                     </label>
                   </div>
+                  {!compFilters.sameStoryHeight && compFilters.storyHeight?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {compFilters.storyHeight.map(h => (
+                        <span key={h} className="inline-flex items-center gap-1 px-2 py-0.5 bg-teal-100 text-teal-800 rounded text-xs">
+                          {getCodeLabel('storyHeight', h)}<button onClick={() => toggleCompFilterChip('storyHeight')(h)} className="text-teal-600 hover:text-teal-800"><X className="w-3 h-3" /></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 {/* View */}
                 <div>
@@ -4695,6 +4740,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       <input type="checkbox" checked={compFilters.sameView} onChange={(e) => setCompFilters(prev => ({ ...prev, sameView: e.target.checked }))} className="rounded" />
                     </label>
                   </div>
+                  {!compFilters.sameView && compFilters.view?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {compFilters.view.map(v => (
+                        <span key={v} className="inline-flex items-center gap-1 px-2 py-0.5 bg-cyan-100 text-cyan-800 rounded text-xs">
+                          {getCodeLabel('view', v)}<button onClick={() => toggleCompFilterChip('view')(v)} className="text-cyan-600 hover:text-cyan-800"><X className="w-3 h-3" /></button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -2028,10 +2028,31 @@ getTotalLotSize: async function(property, vendorType, codeDefinitions) {
         package_discount: p.sales_history.sales_decision.old_price - (p.sales_price / packageProperties.length)
       }));
     
+    // Multi-residence farm detection: only meaningful when this is a farm
+    // package (3B qfarm partner present). Within the deed-group, look for
+    // Class 2 or 3A parcels that carry buildings (asset_sfla > 0). When >= 2,
+    // the deed bundles more than one home (e.g. 85/20.01) — flag the group
+    // and stamp residence-bearing keys for downstream consumers.
+    const residenceMemberKeys = [];
+    if (hasFarmland) {
+      for (const p of packageProperties) {
+        const cls = (p.property_m4_class || p.property_class || '').toString().trim().toUpperCase();
+        if (cls !== '2' && cls !== '3A') continue;
+        const sfla = parseFloat(p.asset_sfla) || 0;
+        if (sfla > 0 && p.property_composite_key) {
+          residenceMemberKeys.push(p.property_composite_key);
+        }
+      }
+    }
+    const hasMultipleResidences = residenceMemberKeys.length >= 2;
+
     return {
       is_package_sale: true,
       is_farm_package: hasFarmland,
       is_additional_card: isAdditionalCard,
+      has_multiple_residences: hasMultipleResidences,
+      residence_member_keys: residenceMemberKeys,
+      residence_count: residenceMemberKeys.length,
       package_count: packageProperties.length,
       package_id: packageId,
       combined_lot_sf: combinedLotSF,

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1907,12 +1907,14 @@ getTotalLotSize: async function(property, vendorType, codeDefinitions) {
     
     const primary = sortedByClass[0];
     
-    // Calculate combined lot size (sum of sf and acres converted)
+    // Calculate combined lot size
     // Prefer market_manual_* (unit-rate-config calculated values for BRT) over asset_lot_* (Microsystems direct extract)
+    // SF and acres represent the SAME measurement in different units, so use SF if available, otherwise convert acres
     const combinedLotSF = packageProperties.reduce((sum, p) => {
       const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
+      if (sf > 0) return sum + sf;
       const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
-      return sum + sf + (acres * 43560); // Convert acres to SF
+      return sum + (acres * 43560); // Convert acres to SF
     }, 0);
     
     // Calculate combined assessed value

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1908,9 +1908,10 @@ getTotalLotSize: async function(property, vendorType, codeDefinitions) {
     const primary = sortedByClass[0];
     
     // Calculate combined lot size (sum of sf and acres converted)
+    // Prefer market_manual_* (unit-rate-config calculated values for BRT) over asset_lot_* (Microsystems direct extract)
     const combinedLotSF = packageProperties.reduce((sum, p) => {
-      const sf = parseFloat(p.asset_lot_sf) || 0;
-      const acres = parseFloat(p.asset_lot_acre) || 0;
+      const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
+      const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
       return sum + sf + (acres * 43560); // Convert acres to SF
     }, 0);
     

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -2034,6 +2034,10 @@ getTotalLotSize: async function(property, vendorType, codeDefinitions) {
     // the deed bundles more than one home (e.g. 85/20.01) — flag the group
     // and stamp residence-bearing keys for downstream consumers.
     const residenceMemberKeys = [];
+    let combinedResidenceSFLA = 0;
+    let combinedResidenceImprovement = 0;
+    let primaryResidenceKey = null;
+    let primaryResidenceSFLA = 0;
     if (hasFarmland) {
       for (const p of packageProperties) {
         const cls = (p.property_m4_class || p.property_class || '').toString().trim().toUpperCase();
@@ -2041,18 +2045,31 @@ getTotalLotSize: async function(property, vendorType, codeDefinitions) {
         const sfla = parseFloat(p.asset_sfla) || 0;
         if (sfla > 0 && p.property_composite_key) {
           residenceMemberKeys.push(p.property_composite_key);
+          combinedResidenceSFLA += sfla;
+          combinedResidenceImprovement += parseFloat(p.values_mod_improvement) || parseFloat(p.values_cama_improvement) || 0;
+          if (sfla > primaryResidenceSFLA) {
+            primaryResidenceSFLA = sfla;
+            primaryResidenceKey = p.property_composite_key;
+          }
         }
       }
     }
     const hasMultipleResidences = residenceMemberKeys.length >= 2;
+    // Multi-residence farms get treated as additional cards so downstream
+    // consolidation/merging logic (which already knows how to combine SFLA,
+    // pick a primary, and de-duplicate the parcel list) fires automatically.
+    const treatAsAdditionalCard = isAdditionalCard || hasMultipleResidences;
 
     return {
       is_package_sale: true,
       is_farm_package: hasFarmland,
-      is_additional_card: isAdditionalCard,
+      is_additional_card: treatAsAdditionalCard,
       has_multiple_residences: hasMultipleResidences,
       residence_member_keys: residenceMemberKeys,
       residence_count: residenceMemberKeys.length,
+      combined_residence_sfla: combinedResidenceSFLA,
+      combined_residence_improvement: combinedResidenceImprovement,
+      primary_residence_key: primaryResidenceKey,
       package_count: packageProperties.length,
       package_id: packageId,
       combined_lot_sf: combinedLotSF,


### PR DESCRIPTION
### Summary
Fixes incorrect lot size totals on farm sales comps by prioritizing BRT-calculated lot values, and adds multi-residence detection for farm packages where a single deed/book-page bundles more than one home.

### Problem
When Farm Sales Mode is ON and comps are Class 3A, the detailed comp view was not correctly summing lot sizes. For BRT districts (like Franklin Township), lot acreage and square footage are not directly extracted — they are calculated via the unit rate configuration tool and stored in `market_manual_lot_acre` / `market_manual_lot_sf`. The old logic was reading `asset_lot_*` fields (Microsystems direct extract) and also double-counting by adding both SF and acres-converted-to-SF for the same parcel. Additionally, farm packages containing multiple Class 2 or 3A parcels with buildings (e.g. a deed grouping two homes on the same farm) were not being flagged or handled for downstream consolidation.

### Solution
- Prioritize `market_manual_lot_sf` / `market_manual_lot_acre` over `asset_lot_*` fields when summing lot sizes, and treat SF and acres as the same measurement in different units (use one or the other, not both).
- Detect multi-residence farm packages by scanning deed-grouped parcels for Class 2/3A members with `asset_sfla > 0`. When two or more are found, flag the group and treat it like an additional-card stack so existing consolidation paths merge SFLA and improvement values automatically.
- Fix the CSV export modal to use a fixed-height, scrollable layout so it doesn't overflow the viewport on large result sets (e.g. Franklin Township).
- Add last-import timestamps for MyNJAppeal and PwrCAMA imports, persisted to `job_settings` and displayed under each import button in the Appeal Log.
- Render active filter chips under each "same" checkbox in the Sales Comparison filter panel so users can see and remove individual selections when "same" is unchecked.

### Key Changes
- **`JobContainer.jsx`** — Updated `enrichPropertiesWithPackageData` to prefer `market_manual_lot_*` fields; added multi-residence farm detection logic with per-parcel `is_additional_residence`, `is_primary_residence`, and `is_secondary_residence` markers; extended `_pkg` info object with `has_multiple_residences`, `residence_member_keys`, `combined_residence_sfla`, `combined_residence_improvement`, and `primary_residence_key`.
- **`supabaseClient.js`** — Mirrored the same lot-size priority fix and multi-residence detection in `getTotalLotSize` so the server-side package resolution path is consistent with the client-side enrichment.
- **`AppealLogTab.jsx`** — Added `mynjAppealLastImport` / `pwrCamaLastImport` state, a `job_settings` load effect on mount, a `stampLastImport` helper that upserts timestamps after successful imports, and a `formatLastImport` formatter rendered under each import button. Also added active filter chip displays for zone, building class, type/use, style, story height, and view filters in the Sales Comparison panel.
- **`App.css`** — Added `.csv-export-modal-box` / `.csv-export-modal-scroll` CSS classes to enforce a fixed `80vh` height with scrollable content area for the CSV export modal, mirroring the address-lookup modal pattern.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/haze-society-h41k6pij"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-haze-society-h41k6pij_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 180`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>haze-society-h41k6pij</branchName>-->