### PR TITLE
Show final hearing date in appeal summary

### DIFF
--- a/copilot-os.md
+++ b/copilot-os.md
@@ -1,4 +1,4 @@
-# Copilot OS — Internal Architecture Reference 🚀
+# Copilot OS — Internal Architecture Reference
 
 > Lean reference for the NJ property-assessment management platform.
 > Covers repo layout, component map, database schema, data pipeline, and vendor-specific business rules.

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -40,7 +40,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
 
   const getHearingDates = (snapshot) => {
     if (!snapshot || !Array.isArray(snapshot)) {
-      return { earliest: null, hasMultiple: false };
+      return { latest: null, hasMultiple: false };
     }
 
     const hearingDates = [...new Set(
@@ -51,19 +51,20 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
     )];
 
     if (hearingDates.length === 0) {
-      return { earliest: null, hasMultiple: false };
+      return { latest: null, hasMultiple: false };
     }
 
+    // Use the last (final) hearing date — billing event occurs after final hearing
     // Parse date locally to avoid timezone drift (same as AppealLogTab)
-    const [year, month, day] = hearingDates[0].split('-').map(Number);
+    const [year, month, day] = hearingDates[hearingDates.length - 1].split('-').map(Number);
     const date = new Date(year, month - 1, day);
-    const earliest = date.toLocaleDateString('en-US', {
+    const latest = date.toLocaleDateString('en-US', {
       month: 'numeric',
       day: 'numeric',
       year: '2-digit'
     });
 
-    return { earliest, hasMultiple: hearingDates.length > 1 };
+    return { latest, hasMultiple: hearingDates.length > 1 };
   };
 
   const loadAppealsByJob = async () => {
@@ -174,7 +175,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
             residential: classBreakdown.residential,
             commercial: classBreakdown.commercial,
             vacant: classBreakdown.vacant,
-            hearingDate: hearingInfo.earliest,
+            hearingDate: hearingInfo.latest,
             hasMultipleHearings: hearingInfo.hasMultiple,
             snapshotAvailable: !!job.appeal_summary_snapshot
           });
@@ -366,7 +367,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
 
             {/* Legend */}
             <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 text-xs text-gray-600">
-              <p>* Multiple hearing dates on file</p>
+              <p>* Multiple hearing dates on file (showing final/last hearing date)</p>
             </div>
           </>
         )}


### PR DESCRIPTION
### Summary
Updates the appeal summary component to display the final (last) hearing date instead of the earliest one when multiple hearing dates exist.

### Problem
The appeal summary was showing the earliest hearing date when multiple dates were on file. Since hearing dates are billing events, the final hearing date is the relevant one — billing for a task occurs the day after the final hearing.

### Key Changes
- Changed `getHearingDates` to return `latest` instead of `earliest`, selecting the last date in the sorted hearing dates array
- Updated the legend text to clarify that the asterisk (*) indicates multiple hearing dates and that the final/last date is being shown
- Removed rocket emoji from the `copilot-os.md` internal architecture reference header


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/alpha-continent-nkmwlbi9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-alpha-continent-nkmwlbi9_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 184`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>alpha-continent-nkmwlbi9</branchName>-->