### PR TITLE
Fix cover sale blocking, farm adjustments, and PDF map rendering

### DIFF
--- a/src/components/AppealMap.jsx
+++ b/src/components/AppealMap.jsx
@@ -187,8 +187,11 @@ const AppealMap = ({
         zoom={14}
         style={{ height: '100%', width: '100%' }}
         scrollWheelZoom={false}
-        // preferCanvas helps html2canvas capture cleanly
-        preferCanvas={false}
+        // Render vector layers (Polylines) on a Canvas overlay instead of
+        // SVG. html2canvas reliably captures <canvas> elements but mishandles
+        // Leaflet's SVG transform, which caused the dashed connector lines
+        // to drift away from the comp markers in the exported PDF.
+        preferCanvas={true}
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'

--- a/src/components/job-modules/final-valuation-tabs/AdjustmentsTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AdjustmentsTab.jsx
@@ -2153,16 +2153,44 @@ const AdjustmentsTab = ({ jobData = {}, isJobContainerLoading = false, propertie
                     })}
                     <td className="sticky right-0 z-10 bg-white px-2 py-2 text-center border-l border-gray-200">
                       <div className="flex items-center justify-center gap-2">
-                        <select
-                          value={adj.adjustment_type}
-                          onChange={(e) => handleTypeChange(adj.adjustment_id, e.target.value)}
-                          className="text-xs border rounded px-2 py-1"
-                        >
-                          <option value="flat">Flat ($)</option>
-                          <option value="per_sqft">Per SF ($/SF)</option>
-                          <option value="count">Count (#)</option>
-                          <option value="percent">Percent (%)</option>
-                        </select>
+                        {/* Lot-size adjustments have an implicit unit baked into
+                            the row (FF / SF / Acre), so the type selector
+                            doesn't apply. Gray it out to remove the
+                            confusion — the math always uses per-unit. */}
+                        {(() => {
+                          const isLotSize =
+                            adj.adjustment_id === 'lot_size_ff' ||
+                            adj.adjustment_id === 'lot_size_sf' ||
+                            adj.adjustment_id === 'lot_size_acre';
+                          if (isLotSize) {
+                            const unitLabel =
+                              adj.adjustment_id === 'lot_size_ff' ? 'Per FF ($/FF)' :
+                              adj.adjustment_id === 'lot_size_sf' ? 'Per SF ($/SF)' :
+                              'Per Acre ($/Ac)';
+                            return (
+                              <select
+                                disabled
+                                value={adj.adjustment_type}
+                                className="text-xs border rounded px-2 py-1 bg-gray-100 text-gray-500 cursor-not-allowed"
+                                title="Lot-size adjustments are always applied per unit (FF / SF / Acre)."
+                              >
+                                <option value={adj.adjustment_type}>{unitLabel}</option>
+                              </select>
+                            );
+                          }
+                          return (
+                            <select
+                              value={adj.adjustment_type}
+                              onChange={(e) => handleTypeChange(adj.adjustment_id, e.target.value)}
+                              className="text-xs border rounded px-2 py-1"
+                            >
+                              <option value="flat">Flat ($)</option>
+                              <option value="per_sqft">Per SF ($/SF)</option>
+                              <option value="count">Count (#)</option>
+                              <option value="percent">Percent (%)</option>
+                            </select>
+                          );
+                        })()}
                         {!adj.is_default && (
                           <button
                             onClick={() => handleDeleteAdjustment(adj.adjustment_id)}

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -39,7 +39,7 @@ const EditableInput = React.memo(function EditableInput({
   );
 });
 
-const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null }) => {
+const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null }) => {
   const subject = result.subject;
   // Real comps coming from the comparables search. Manual "M" comps (entered
   // directly in the export modal for out-of-town properties) are layered on
@@ -3159,6 +3159,16 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                   )}
                 </td>
                 <td className={`px-3 py-2 text-center bg-slate-50 ${attr.bold ? 'font-semibold' : 'text-xs'}`}>
+                  {attr.id === 'sales_date' && aggregatedSubject?.property_composite_key && (
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); openSalesHistoryModal('subject', applySalesHistoryPatch(aggregatedSubject)); }}
+                      title={aggregatedSubject.sales_override ? 'Manually selected sale — view/change history' : 'Sales history (swap hidden sale)'}
+                      className={`float-right p-0.5 rounded hover:bg-blue-100 ${aggregatedSubject.sales_override ? 'text-amber-600' : 'text-gray-400 hover:text-blue-600'}`}
+                    >
+                      {aggregatedSubject.sales_override ? <Flag size={12} /> : <History size={12} />}
+                    </button>
+                  )}
                   {(() => {
                     // Use aggregated subject data for properties with additional cards
                     let value = attr.render(aggregatedSubject);
@@ -3260,7 +3270,19 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
                   return (
                     <div>
-                      <div className={attr.bold ? 'font-semibold' : 'text-xs'}>{value}</div>
+                      <div className={`flex items-center justify-center gap-1 ${attr.bold ? 'font-semibold' : 'text-xs'}`}>
+                        <span>{value}</span>
+                        {attr.id === 'sales_date' && comp?.property_composite_key && !comp.is_manual_comp && (
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); openSalesHistoryModal(`comp_${idx}`, applySalesHistoryPatch(comp)); }}
+                            title={comp.sales_override ? 'Manually selected sale — view/change history' : 'Sales history (swap hidden sale)'}
+                            className={`shrink-0 p-0.5 rounded hover:bg-blue-100 ${comp.sales_override ? 'text-amber-600' : 'text-gray-400 hover:text-blue-600'}`}
+                          >
+                            {comp.sales_override ? <Flag size={12} /> : <History size={12} />}
+                          </button>
+                        )}
+                      </div>
                       {adj && adj.amount !== 0 && (
                         <div className={`text-xs font-bold mt-1 ${adj.amount > 0 ? 'text-green-700' : 'text-red-700'}`}>
                           {adj.amount > 0 ? '+' : ''}${Math.round(adj.amount).toLocaleString()}
@@ -3578,26 +3600,12 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                             />
                           )}
                           {cfg.type === 'date' && (
-                            <div className="flex items-center gap-1">
-                              <EditableInput
-                                type="date"
-                                initialValue={editedVal ?? (prop ? prop[cfg.field] : '') ?? ''}
-                                onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
-                                className="flex-1 min-w-0 px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
-                              />
-                              {attr.id === 'sales_date' && prop?.property_composite_key && (
-                                <button
-                                  type="button"
-                                  onClick={() => openSalesHistoryModal(propKey, prop)}
-                                  title={prop.sales_override ? 'Manually selected sale — view/change history' : 'Sales history (swap hidden sale)'}
-                                  className={`shrink-0 p-0.5 rounded hover:bg-blue-100 ${prop.sales_override ? 'text-amber-600' : 'text-gray-400 hover:text-blue-600'}`}
-                                >
-                                  {prop.sales_override
-                                    ? <Flag size={12} />
-                                    : <History size={12} />}
-                                </button>
-                              )}
-                            </div>
+                            <EditableInput
+                              type="date"
+                              initialValue={editedVal ?? (prop ? prop[cfg.field] : '') ?? ''}
+                              onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
+                              className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
+                            />
                           )}
                           {cfg.type === 'yesno' && (
                             <select
@@ -3881,10 +3889,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
           property={salesHistoryModal.property}
           onClose={closeSalesHistoryModal}
           onApply={(patch) => {
+            const compositeKey = salesHistoryModal.property.property_composite_key;
             // Local UI patch so the cell shows the new sale immediately
             setSalesHistoryPatches((prev) => ({
               ...prev,
-              [salesHistoryModal.property.property_composite_key]: patch
+              [compositeKey]: patch
             }));
             // Also push the new sale into the editable export-modal overlay so
             // recalc and PDF export see the swapped values without retyping.
@@ -3893,11 +3902,17 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
             if (patch.sales_price !== undefined) updateEditedValue(pk, 'sales_price', patch.sales_price ?? '');
             if (patch.sales_nu !== undefined) updateEditedValue(pk, 'sales_code', patch.sales_nu || '');
             closeSalesHistoryModal();
-            // Auto-trigger recalc so the swapped sale's adjustments propagate
-            // immediately — saves the user a manual click.
+            // Auto-trigger recalc inside the export modal (covers the case
+            // where the swap was initiated from inside the export modal).
             setTimeout(() => {
-              try { recalculateAdjustments(); } catch (e) { console.warn('Auto-recalc after sale swap failed:', e); }
+              try { recalculateAdjustments(); } catch (e) { /* ignore — export modal not open */ }
             }, 0);
+            // Notify parent so it can refresh the in-memory property and
+            // re-run the comp evaluation. This is what makes the main
+            // Detailed grid update its adjustments without a manual rerun.
+            if (typeof onSalesSwapped === 'function') {
+              try { onSalesSwapped(compositeKey, patch); } catch (e) { console.warn('onSalesSwapped failed:', e); }
+            }
           }}
         />
       )}

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { interpretCodes, supabase } from '../../../lib/supabaseClient';
-import { FileDown, X, Eye, EyeOff, Printer, Map as MapIcon } from 'lucide-react';
+import { FileDown, X, Eye, EyeOff, Printer, Map as MapIcon, History, Flag } from 'lucide-react';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import html2canvas from 'html2canvas';
@@ -259,6 +259,26 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     if (!compositeKey) return;
     setGeocodePatches((prev) => ({ ...prev, [compositeKey]: patch }));
   }, []);
+
+  // ==================== SALES HISTORY (Hidden / Cover Sale Swap) ====================
+  // When a property's current sale is a cover ($1, family transfer, estate, etc.)
+  // and `prev_sales` from the BRT file contains a real arm's-length sale, the
+  // user can swap that prior sale into the current slot via this modal. The
+  // selection is persisted to property_records with sales_override=true so the
+  // file updater (see DB trigger respect_sales_override) won't clobber it on
+  // re-upload — unless a strictly newer usable sale arrives later.
+  const [salesHistoryModal, setSalesHistoryModal] = useState(null); // { propKey, property }
+  const [salesHistoryPatches, setSalesHistoryPatches] = useState({}); // composite_key -> { sales_date, sales_price, sales_nu, sales_book, sales_page, sales_override }
+  const applySalesHistoryPatch = useCallback((p) => {
+    if (!p || !p.property_composite_key) return p;
+    const patch = salesHistoryPatches[p.property_composite_key];
+    return patch ? { ...p, ...patch } : p;
+  }, [salesHistoryPatches]);
+  const openSalesHistoryModal = useCallback((propKey, property) => {
+    if (!property?.property_composite_key) return;
+    setSalesHistoryModal({ propKey, property: applySalesHistoryPatch(property) });
+  }, [applySalesHistoryPatch]);
+  const closeSalesHistoryModal = useCallback(() => setSalesHistoryModal(null), []);
 
   // Build the subject + comps payload for AppealMap. Pulls lat/lng off the
   // already-aggregated subject/comps. If the subject is not geocoded, the
@@ -3558,12 +3578,26 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                             />
                           )}
                           {cfg.type === 'date' && (
-                            <EditableInput
-                              type="date"
-                              initialValue={editedVal ?? (prop ? prop[cfg.field] : '') ?? ''}
-                              onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
-                              className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
-                            />
+                            <div className="flex items-center gap-1">
+                              <EditableInput
+                                type="date"
+                                initialValue={editedVal ?? (prop ? prop[cfg.field] : '') ?? ''}
+                                onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
+                                className="flex-1 min-w-0 px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
+                              />
+                              {attr.id === 'sales_date' && prop?.property_composite_key && (
+                                <button
+                                  type="button"
+                                  onClick={() => openSalesHistoryModal(propKey, prop)}
+                                  title={prop.sales_override ? 'Manually selected sale — view/change history' : 'Sales history (swap hidden sale)'}
+                                  className={`shrink-0 p-0.5 rounded hover:bg-blue-100 ${prop.sales_override ? 'text-amber-600' : 'text-gray-400 hover:text-blue-600'}`}
+                                >
+                                  {prop.sales_override
+                                    ? <Flag size={12} />
+                                    : <History size={12} />}
+                                </button>
+                              )}
+                            </div>
                           )}
                           {cfg.type === 'yesno' && (
                             <select
@@ -3839,6 +3873,216 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
           </div>
         </div>
       )}
+
+      {/* Sales History (Hidden Sale Swap) Modal */}
+      {salesHistoryModal && (
+        <SalesHistoryModal
+          propKey={salesHistoryModal.propKey}
+          property={salesHistoryModal.property}
+          onClose={closeSalesHistoryModal}
+          onApply={(patch) => {
+            // Local UI patch so the cell shows the new sale immediately
+            setSalesHistoryPatches((prev) => ({
+              ...prev,
+              [salesHistoryModal.property.property_composite_key]: patch
+            }));
+            // Also push the new sale into the editable export-modal overlay so
+            // recalc and PDF export see the swapped values without retyping.
+            const pk = salesHistoryModal.propKey;
+            if (patch.sales_date !== undefined) updateEditedValue(pk, 'sales_date', patch.sales_date || '');
+            if (patch.sales_price !== undefined) updateEditedValue(pk, 'sales_price', patch.sales_price ?? '');
+            if (patch.sales_nu !== undefined) updateEditedValue(pk, 'sales_code', patch.sales_nu || '');
+            closeSalesHistoryModal();
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// SalesHistoryModal
+// Lists the property's prev_sales (vendor-supplied prior arm's-length sales)
+// plus the current sale. User can promote a prior sale to "current" — this
+// writes to property_records with sales_override=true so the file updater
+// won't overwrite it on re-upload (see DB trigger respect_sales_override).
+// "Revert to file sale" clears the override so the next file upload restores
+// vendor data.
+// ---------------------------------------------------------------------------
+const SalesHistoryModal = ({ propKey, property, onClose, onApply }) => {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const prevSales = Array.isArray(property?.prev_sales) ? property.prev_sales : [];
+  // Filter obvious BRT garbage: 1901-01-01 placeholder dates and absurd prices.
+  const cleanPrev = prevSales.filter(s => {
+    if (!s) return false;
+    if (s.date === '1901-01-01') return false;
+    const yr = s.date ? parseInt(String(s.date).slice(0, 4), 10) : 0;
+    if (yr && yr < 1950) return false;
+    return true;
+  });
+
+  const promote = async (entry) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const patch = {
+        sales_date: entry.date || null,
+        sales_price: entry.price ?? null,
+        sales_nu: entry.nu || null,
+        sales_book: entry.book || null,
+        sales_page: entry.page || null,
+        sales_override: true,
+        sales_override_meta: {
+          promoted_from: entry.source || 'prev_sales',
+          source_entry: entry,
+          original_sale: {
+            date: property.sales_date || null,
+            price: property.sales_price ?? null,
+            nu: property.sales_nu || null,
+            book: property.sales_book || null,
+            page: property.sales_page || null
+          },
+          decided_at: new Date().toISOString(),
+          decided_by: 'user'
+        }
+      };
+      const { error: upErr } = await supabase
+        .from('property_records')
+        .update(patch)
+        .eq('property_composite_key', property.property_composite_key);
+      if (upErr) throw upErr;
+      onApply(patch);
+    } catch (e) {
+      console.error('Promote sale failed:', e);
+      setError(e.message || 'Failed to save');
+      setSaving(false);
+    }
+  };
+
+  const revert = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      // Restore the original sale (from sales_override_meta) and clear the flag
+      const meta = property.sales_override_meta || {};
+      const orig = meta.original_sale || {};
+      const patch = {
+        sales_date: orig.date || null,
+        sales_price: orig.price ?? null,
+        sales_nu: orig.nu || null,
+        sales_book: orig.book || null,
+        sales_page: orig.page || null,
+        sales_override: false,
+        sales_override_meta: null
+      };
+      const { error: upErr } = await supabase
+        .from('property_records')
+        .update(patch)
+        .eq('property_composite_key', property.property_composite_key);
+      if (upErr) throw upErr;
+      onApply(patch);
+    } catch (e) {
+      console.error('Revert sale failed:', e);
+      setError(e.message || 'Failed to save');
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900">Sales History</h3>
+            <p className="text-xs text-gray-500">
+              Block {property.property_block} Lot {property.property_lot}
+              {property.property_qualifier ? ` Qual ${property.property_qualifier}` : ''}
+              {property.property_location ? ` — ${property.property_location}` : ''}
+            </p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+          {/* Current sale */}
+          <div>
+            <div className="text-xs font-semibold text-gray-700 mb-1">Current Sale</div>
+            <div className={`flex items-center justify-between border rounded p-2 ${property.sales_override ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-gray-50'}`}>
+              <div className="text-sm">
+                <span className="font-medium">{property.sales_date || '—'}</span>
+                <span className="ml-3">${property.sales_price ? Number(property.sales_price).toLocaleString() : '—'}</span>
+                <span className="ml-3 text-gray-600">NU {property.sales_nu || '—'}</span>
+                {property.sales_override && (
+                  <span className="ml-3 inline-flex items-center gap-1 text-xs text-amber-700">
+                    <Flag size={12} /> manually selected
+                  </span>
+                )}
+              </div>
+              {property.sales_override && (
+                <button
+                  onClick={revert}
+                  disabled={saving}
+                  className="text-xs px-2 py-1 border border-gray-300 rounded hover:bg-white disabled:opacity-50"
+                >
+                  Revert to file sale
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Prior sales from prev_sales */}
+          <div>
+            <div className="text-xs font-semibold text-gray-700 mb-1">
+              Prior Sales {cleanPrev.length > 0 && <span className="text-gray-500 font-normal">({cleanPrev.length})</span>}
+            </div>
+            {cleanPrev.length === 0 ? (
+              <div className="text-sm text-gray-500 italic border border-dashed border-gray-200 rounded p-3 text-center">
+                No prior sales available for this property.
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {cleanPrev.map((s, i) => (
+                  <div key={i} className="flex items-center justify-between border border-gray-200 rounded p-2 hover:bg-blue-50">
+                    <div className="text-sm">
+                      <span className="font-medium">{s.date || '—'}</span>
+                      <span className="ml-3">${s.price ? Number(s.price).toLocaleString() : '—'}</span>
+                      {s.nu && <span className="ml-3 text-gray-600">NU {s.nu}</span>}
+                      <span className="ml-3 text-xs text-gray-400">{s.source}</span>
+                    </div>
+                    <button
+                      onClick={() => promote(s)}
+                      disabled={saving}
+                      className="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      Use this sale
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{error}</div>
+          )}
+
+          <div className="text-xs text-gray-500 italic">
+            Promoted sales persist across file uploads. They are only auto-replaced if a strictly newer, usable arm's-length sale arrives in a future file.
+          </div>
+        </div>
+
+        <div className="px-4 py-2 border-t border-gray-200 flex justify-end">
+          <button
+            onClick={onClose}
+            className="text-sm px-3 py-1.5 border border-gray-300 rounded hover:bg-gray-50"
+          >
+            Close
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -2474,6 +2474,12 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
             };
             const lotDisplay = (p) => {
               if (!p) return '\u2014';
+              // Farm-mode: use combined 3A+3B acreage so PDF matches Detailed.
+              // Mirrors the lot_size_acre attribute render and SalesComparisonTab's
+              // farm-package logic; see Bug 1 (Bethlehem) for context.
+              if (compFilters?.farmSalesMode && p._pkg?.is_farm_package && p._pkg?.combined_lot_acres > 0) {
+                return `${parseFloat(p._pkg.combined_lot_acres).toFixed(2)} ac (Farm)`;
+              }
               if (p.asset_lot_acre && parseFloat(p.asset_lot_acre) > 0) return `${parseFloat(p.asset_lot_acre).toFixed(2)} ac`;
               if (p.market_manual_lot_acre && parseFloat(p.market_manual_lot_acre) > 0) return `${parseFloat(p.market_manual_lot_acre).toFixed(2)} ac`;
               if (p.asset_lot_sf && parseFloat(p.asset_lot_sf) > 0) return `${parseInt(p.asset_lot_sf, 10).toLocaleString()} sf`;
@@ -3588,13 +3594,30 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                         return 'Yes';
                       };
 
+                      // Farm-mode: source lot_size_acre from the combined
+                      // 3A+3B package value when available, mirroring the
+                      // Detailed view's lot_size_acre render. Without this
+                      // the export modal would seed only the 3A acreage.
+                      const numberInitial = (() => {
+                        if (editedVal !== undefined) return editedVal;
+                        if (!prop) return '';
+                        if (
+                          attr.id === 'lot_size_acre' &&
+                          compFilters?.farmSalesMode &&
+                          prop._pkg?.is_farm_package &&
+                          prop._pkg.combined_lot_acres > 0
+                        ) {
+                          return prop._pkg.combined_lot_acres;
+                        }
+                        return (prop[cfg.altField] || prop[cfg.field]) ?? '';
+                      })();
                       return (
                         <td key={propKey} className={`px-1 py-1 text-center ${bgClass} border-r border-gray-200`}>
                           {cfg.type === 'number' && (
                             <EditableInput
                               type="text"
                               inputMode="decimal"
-                              initialValue={editedVal ?? (prop ? (prop[cfg.altField] || prop[cfg.field]) : '') ?? ''}
+                              initialValue={numberInitial}
                               onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
                               className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
                             />

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -3893,6 +3893,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
             if (patch.sales_price !== undefined) updateEditedValue(pk, 'sales_price', patch.sales_price ?? '');
             if (patch.sales_nu !== undefined) updateEditedValue(pk, 'sales_code', patch.sales_nu || '');
             closeSalesHistoryModal();
+            // Auto-trigger recalc so the swapped sale's adjustments propagate
+            // immediately — saves the user a manual click.
+            setTimeout(() => {
+              try { recalculateAdjustments(); } catch (e) { console.warn('Auto-recalc after sale swap failed:', e); }
+            }, 0);
           }}
         />
       )}
@@ -3990,7 +3995,10 @@ const SalesHistoryModal = ({ propKey, property, onClose, onApply }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60] p-4">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4"
+      style={{ zIndex: 9999 }}
+    >
       <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col">
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
           <div>

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1659,6 +1659,27 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
         }
       });
 
+      // Preserve dynamic adjustment rows (detached items, miscellaneous,
+      // positive/negative land) that aren't in EDITABLE_CONFIG. These come
+      // from SalesComparisonTab.calculateAdjustment and aren't user-editable
+      // in the export modal, so they should pass through unchanged when a
+      // comp is recalculated due to edits on other fields.
+      const dynamicPrefixes = ['barn_', 'pole_barn_', 'stable_', 'miscellaneous_', 'land_positive_', 'land_negative_'];
+      const dynamicAdjustmentNames = new Set(
+        (adjustmentGrid || [])
+          .filter(adj => adj?.adjustment_id && dynamicPrefixes.some(p => adj.adjustment_id.startsWith(p)))
+          .map(adj => (adj.adjustment_name || '').toLowerCase())
+          .filter(Boolean)
+      );
+      const originalAdjustments = comp.adjustments || [];
+      originalAdjustments.forEach(orig => {
+        if (!orig?.name) return;
+        if (dynamicAdjustmentNames.has(String(orig.name).toLowerCase())) {
+          compAdjustments.push({ name: orig.name, amount: orig.amount || 0 });
+          totalAdjustment += (orig.amount || 0);
+        }
+      });
+
       const adjustedPrice = compSalesPrice + totalAdjustment;
       const adjustmentPercent = compSalesPrice > 0 ? (totalAdjustment / compSalesPrice) * 100 : 0;
 

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -8,6 +8,37 @@ import { evaluateAppellantComp, getNuShortForm } from '../../../lib/appellantCom
 import AppealMap, { distanceMiles } from '../../AppealMap';
 import GeocodeStatusChip from '../../GeocodeStatusChip';
 
+// Locally-controlled input for the export-modal cells. Holding the typed value
+// in component-local state means each keystroke only re-renders this one cell
+// instead of the entire 6-column x ~50-row grid (which would otherwise re-run
+// every attr.render(...) on every key, causing visible lag in sales_nu /
+// sales_date / sales_price). The committed value is pushed to the parent on
+// blur or when the user presses Enter. The modal is conditionally mounted, so
+// remounting on each open is enough to reset state — no external sync needed.
+const EditableInput = React.memo(function EditableInput({
+  initialValue,
+  onCommit,
+  type = 'text',
+  inputMode,
+  className,
+}) {
+  const [value, setValue] = useState(initialValue ?? '');
+  const commit = useCallback(() => {
+    onCommit(value);
+  }, [value, onCommit]);
+  return (
+    <input
+      type={type}
+      inputMode={inputMode}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.currentTarget.blur(); } }}
+      className={className}
+    />
+  );
+});
+
 const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null }) => {
   const subject = result.subject;
   // Real comps coming from the comparables search. Manual "M" comps (entered
@@ -1368,17 +1399,6 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     return prop[config.field];
   }, []);
 
-  // Get edited value or fall back to original
-  const getEditedValue = useCallback((propKey, attrId) => {
-    const edited = editableProperties[propKey];
-    if (edited && edited[attrId] !== undefined) {
-      return edited[attrId];
-    }
-    // Get original value
-    const prop = propKey === 'subject' ? subject : comps[parseInt(propKey.replace('comp_', ''))];
-    return getRawValue(prop, attrId);
-  }, [editableProperties, subject, comps, getRawValue]);
-
   // Update a single cell value
   const updateEditedValue = useCallback((propKey, attrId, value) => {
     setEditableProperties(prev => ({
@@ -1473,19 +1493,101 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     }
   }, [getBracketIndex]);
 
-  // Recalculate all adjustments based on edited values
+  // Recalculate all adjustments based on edited values.
+  //
+  // Two correctness rules baked in here (see history of bugs around NCOVR
+  // condition + missing amenity flags causing spurious adjustments on Recalc):
+  //
+  // 1. We read each attribute's value the SAME way the cell displays it,
+  //    not from the raw DB column. This matters for:
+  //      - yes/no amenity rows (deck/patio/porches/pool/basement/AC), where
+  //        the raw `asset_*` flag may be null even though the area field is
+  //        populated. The cell uses `attr.render(prop)` to decide Yes vs No;
+  //        recalc must use the same source or amenities flip from Yes->No
+  //        and adjustments invert.
+  //      - condition rows on jobs using NCOVR overrides, where the displayed
+  //        condition is mapped from `net_condition_pct`. Reading raw
+  //        `asset_ext_cond` ranks against a different value than what is
+  //        on screen and produces phantom condition adjustments.
+  //
+  // 2. We only recompute adjustments for comps that the user actually edited
+  //    (or all comps if the subject was edited, since that affects every
+  //    comp's diff). Untouched comps keep their original adjustments from
+  //    the canonical pipeline, so re-deriving them through the editable
+  //    shadow data can't introduce drift.
   const recalculateAdjustments = useCallback(() => {
-    const newAdjustments = {};
+    // Render-aware value reader. Uses the same logic the cell uses for
+    // display when no edit exists, so recalc and display can never disagree.
+    const getRecalcValue = (propKey, attrId, attrObj, config) => {
+      const edited = editableProperties[propKey];
+      if (edited && edited[attrId] !== undefined) return edited[attrId];
+
+      const prop = propKey === 'subject'
+        ? subject
+        : comps[parseInt(propKey.replace('comp_', ''))];
+      if (!prop) return null;
+
+      // Yes/No rows: derive from rendered value, mirroring getDefaultYesNo
+      // in the cell renderer. An empty / 'No' / 'None' / 'N/A' render means
+      // No; anything else (including a formatted area like "240 SF") is Yes.
+      if (config?.type === 'yesno') {
+        const rendered = attrObj?.render ? attrObj.render(prop) : null;
+        if (!rendered) return 'No';
+        const renderedStr = String(rendered).toLowerCase();
+        if (renderedStr === 'no' || renderedStr === 'none' || renderedStr === 'n/a') return 'No';
+        return 'Yes';
+      }
+
+      // Condition rows: use the rendered condition name so NCOVR-mapped
+      // values flow through. getConditionRank already accepts names.
+      if (config?.type === 'condition' && attrObj?.render) {
+        const rendered = attrObj.render(prop);
+        if (rendered && rendered !== 'N/A') return rendered;
+      }
+
+      return getRawValue(prop, attrId);
+    };
+
+    // Did the user edit anything on the subject row? If so every comp's
+    // diff is potentially affected and we have to recalc all of them.
+    const subjectEdits = editableProperties['subject'];
+    const subjectWasEdited = !!subjectEdits && Object.keys(subjectEdits).length > 0;
+
+    // Start from any previously-recalculated state so repeated Recalcs
+    // don't lose work, then layer fresh entries on top.
+    const newAdjustments = { ...editedAdjustments };
 
     comps.forEach((comp, idx) => {
       if (!comp) return;
 
       const compKey = `comp_${idx}`;
+      const compEdits = editableProperties[compKey];
+      const compWasEdited = !!compEdits && Object.keys(compEdits).length > 0;
+
+      // Untouched comp + untouched subject => leave its original adjustments
+      // alone. If we already have a recalculated entry from a prior pass,
+      // keep that (the user may have edited and reverted edits since).
+      if (!compWasEdited && !subjectWasEdited) {
+        if (!newAdjustments[compKey]) {
+          // Mirror canonical pipeline values into our local map so the
+          // projected-assessment loop below can treat all slots uniformly.
+          newAdjustments[compKey] = {
+            adjustments: comp.adjustments || [],
+            totalAdjustment: comp.totalAdjustment || 0,
+            adjustedPrice: comp.adjustedPrice || (comp.sales_price || 0),
+            adjustmentPercent: comp.adjustmentPercent || 0
+          };
+        }
+        return;
+      }
+
       const compAdjustments = [];
       let totalAdjustment = 0;
 
       // Get comp's sales price (edited or original), parsed as number
-      const compSalesPrice = parseFloat(getEditedValue(compKey, 'sales_price')) || parseFloat(comp.sales_price) || 0;
+      const compSalesPrice = parseFloat(getRecalcValue(compKey, 'sales_price', null, EDITABLE_CONFIG.sales_price))
+        || parseFloat(comp.sales_price)
+        || 0;
 
       // Calculate adjustments for each adjustable attribute
       Object.keys(EDITABLE_CONFIG).forEach(attrId => {
@@ -1501,9 +1603,9 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
         );
         if (!adjustmentDef) return;
 
-        // Get subject and comp values (edited or original)
-        let subjectVal = getEditedValue('subject', attrId);
-        let compVal = getEditedValue(compKey, attrId);
+        // Get subject and comp values (edited or render-equivalent)
+        let subjectVal = getRecalcValue('subject', attrId, attrObj, config);
+        let compVal = getRecalcValue(compKey, attrId, attrObj, config);
 
         // Convert Yes/No to 1/0 for flat adjustments
         if (config.type === 'yesno') {
@@ -1573,7 +1675,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
     setEditedAdjustments(newAdjustments);
     setHasEdits(false);
-  }, [comps, getEditedValue, calculateSingleAdjustment, allAttributes, adjustmentGrid, getConditionRank]);
+  }, [comps, subject, editableProperties, editedAdjustments, getRawValue, calculateSingleAdjustment, allAttributes, adjustmentGrid, getConditionRank]);
 
   const openExportModal = useCallback(async () => {
     setEditableProperties({});
@@ -3447,19 +3549,19 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                       return (
                         <td key={propKey} className={`px-1 py-1 text-center ${bgClass} border-r border-gray-200`}>
                           {cfg.type === 'number' && (
-                            <input
+                            <EditableInput
                               type="text"
                               inputMode="decimal"
-                              value={editedVal ?? (prop ? (prop[cfg.altField] || prop[cfg.field]) : '') ?? ''}
-                              onChange={(e) => updateEditedValue(propKey, attr.id, e.target.value)}
+                              initialValue={editedVal ?? (prop ? (prop[cfg.altField] || prop[cfg.field]) : '') ?? ''}
+                              onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
                               className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
                             />
                           )}
                           {cfg.type === 'date' && (
-                            <input
+                            <EditableInput
                               type="date"
-                              value={editedVal ?? (prop ? prop[cfg.field] : '') ?? ''}
-                              onChange={(e) => updateEditedValue(propKey, attr.id, e.target.value)}
+                              initialValue={editedVal ?? (prop ? prop[cfg.field] : '') ?? ''}
+                              onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
                               className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
                             />
                           )}
@@ -3509,10 +3611,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                             </select>
                           )}
                           {cfg.type === 'text' && (
-                            <input
+                            <EditableInput
                               type="text"
-                              value={editedVal ?? (prop ? (prop[cfg.field] || prop[cfg.altField] || '') : '') ?? ''}
-                              onChange={(e) => updateEditedValue(propKey, attr.id, e.target.value)}
+                              initialValue={editedVal ?? (prop ? (prop[cfg.field] || prop[cfg.altField] || '') : '') ?? ''}
+                              onCommit={(v) => updateEditedValue(propKey, attr.id, v)}
                               className="w-full px-1 py-0.5 text-xs text-center border rounded focus:ring-1 focus:ring-blue-500"
                             />
                           )}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5839,12 +5839,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     if (target) {
                       Object.assign(target, patch);
                     }
-                    // Re-run the evaluation as a sandbox preview only. If the
-                    // user is happy with the result, they can use Evaluate &
-                    // Update to push it back to Search & Results and any
-                    // active saved set. We don't want a swap to silently
-                    // mutate persisted data.
-                    handleManualEvaluate(false);
+                    // Re-run the evaluation. Pass syncToResults=true so the
+                    // swap propagates everywhere it logically should:
+                    //   - Sandbox (no editingResultIndex): just updates the
+                    //     in-grid preview — nothing to sync, no-op for the
+                    //     persistence branch.
+                    //   - Editing a Search & Results row: that row updates.
+                    //   - Active saved set loaded: also auto-persists to
+                    //     job_cme_result_sets.
+                    handleManualEvaluate(true);
                   }}
                 />
               </div>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -2768,9 +2768,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         break;
 
       case 'pole_barn':
-        // Use pole_barn_area column
-        subjectValue = subject.pole_barn_area > 0 ? 1 : 0;
-        compValue = comp.pole_barn_area > 0 ? 1 : 0;
+        // For per_sqft / count, use real area so the rate is multiplied by the
+        // actual square footage. Otherwise binary presence. See Bug 2 (Bethlehem).
+        if (adjustmentType === 'per_sqft' || adjustmentType === 'count') {
+          subjectValue = subject.pole_barn_area || 0;
+          compValue = comp.pole_barn_area || 0;
+        } else {
+          subjectValue = subject.pole_barn_area > 0 ? 1 : 0;
+          compValue = comp.pole_barn_area > 0 ? 1 : 0;
+        }
         break;
 
       case 'lot_size_ff':
@@ -2883,13 +2889,26 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         break;
 
       case 'barn':
-        subjectValue = (subject.barn_area && subject.barn_area > 0) ? 1 : 0;
-        compValue = (comp.barn_area && comp.barn_area > 0) ? 1 : 0;
+        // For per_sqft / count, use real area so the rate is multiplied by the
+        // actual square footage. Otherwise binary presence (matches legacy flat
+        // adjustment behavior). See Bug 2 (Bethlehem pole barn $15 issue).
+        if (adjustmentType === 'per_sqft' || adjustmentType === 'count') {
+          subjectValue = subject.barn_area || 0;
+          compValue = comp.barn_area || 0;
+        } else {
+          subjectValue = (subject.barn_area && subject.barn_area > 0) ? 1 : 0;
+          compValue = (comp.barn_area && comp.barn_area > 0) ? 1 : 0;
+        }
         break;
 
       case 'stable':
-        subjectValue = (subject.stable_area && subject.stable_area > 0) ? 1 : 0;
-        compValue = (comp.stable_area && comp.stable_area > 0) ? 1 : 0;
+        if (adjustmentType === 'per_sqft' || adjustmentType === 'count') {
+          subjectValue = subject.stable_area || 0;
+          compValue = comp.stable_area || 0;
+        } else {
+          subjectValue = (subject.stable_area && subject.stable_area > 0) ? 1 : 0;
+          compValue = (comp.stable_area && comp.stable_area > 0) ? 1 : 0;
+        }
         break;
 
       default:

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5839,13 +5839,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     if (target) {
                       Object.assign(target, patch);
                     }
-                    // Re-run the same evaluation with the patched data so the
-                    // adjustments, time corrections, and brackets recompute
-                    // automatically. Pass syncToResults=true so the swap also
-                    // propagates back to the Search & Results row (if the user
-                    // loaded a saved result set or is editing one) and is
-                    // auto-persisted to job_cme_result_sets.
-                    handleManualEvaluate(true);
+                    // Re-run the evaluation as a sandbox preview only. If the
+                    // user is happy with the result, they can use Evaluate &
+                    // Update to push it back to Search & Results and any
+                    // active saved set. We don't want a swap to silently
+                    // mutate persisted data.
+                    handleManualEvaluate(false);
                   }}
                 />
               </div>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1618,10 +1618,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           if (!compRaw) {
             // Property not found in database
             notFoundEntries.push(`Block ${compEntry.block} Lot ${compEntry.lot}${compEntry.qualifier ? ` Qual ${compEntry.qualifier}` : ''}`);
-          } else if (!compRaw.sales_price) {
-            // Property found but no sales data
-            noSalesDataEntries.push(`Block ${compEntry.block} Lot ${compEntry.lot} (${compRaw.property_location || 'N/A'})`);
           } else {
+            // Property found - if no sales data, still load it as a soft warning
+            // so the user can fill in sales_date / sales_price / sales_nu manually
+            // in the export modal (e.g. when the most recent sale is a "cover"
+            // and the real sampling-period sale needs to be entered by hand).
+            if (!compRaw.sales_price) {
+              noSalesDataEntries.push(`Block ${compEntry.block} Lot ${compEntry.lot} (${compRaw.property_location || 'N/A'})`);
+            }
+
             // Aggregate comp data across all cards (main + additional)
             const comp = aggregatePropertyData(compRaw);
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5841,8 +5841,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     }
                     // Re-run the same evaluation with the patched data so the
                     // adjustments, time corrections, and brackets recompute
-                    // automatically. No modal-on-modal needed.
-                    handleManualEvaluate(false);
+                    // automatically. Pass syncToResults=true so the swap also
+                    // propagates back to the Search & Results row (if the user
+                    // loaded a saved result set or is editing one) and is
+                    // auto-persisted to job_cme_result_sets.
+                    handleManualEvaluate(true);
                   }}
                 />
               </div>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5831,6 +5831,19 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                   allProperties={properties}
                   marketLandData={marketLandData}
                   tenantConfig={tenantConfig}
+                  onSalesSwapped={(compositeKey, patch) => {
+                    // Patch the in-memory properties array so the next
+                    // handleManualEvaluate run sees the swapped sale fields.
+                    // (The DB has already been updated by the swap modal.)
+                    const target = properties.find(p => p.property_composite_key === compositeKey);
+                    if (target) {
+                      Object.assign(target, patch);
+                    }
+                    // Re-run the same evaluation with the patched data so the
+                    // adjustments, time corrections, and brackets recompute
+                    // automatically. No modal-on-modal needed.
+                    handleManualEvaluate(false);
+                  }}
                 />
               </div>
             )}

--- a/src/lib/appellantCompEvaluator.js
+++ b/src/lib/appellantCompEvaluator.js
@@ -68,7 +68,7 @@ export const NU_CODE_DICTIONARY = {
   '07': 'added assessment',
   '08': 'undivided interest',
   '09': 'tax cert / gov lien',
-  '10': 'fiduciary sale',
+  '10': 'estate/fiduciary sale',
   '11': 'judicial / partition',
   '12': "sheriff's sale",
   '13': 'bankruptcy / short sale',

--- a/src/lib/data-pipeline/brt-processor.js
+++ b/src/lib/data-pipeline/brt-processor.js
@@ -602,6 +602,12 @@ export class BRTProcessor {
       sales_book: rawRecord.CURRENTSALE_DEEDBOOK,
       sales_page: rawRecord.CURRENTSALE_DEEDPAGE,
       sales_nu: rawRecord.CURRENTSALE_NUC,
+      // Vendor-supplied historical sales (BRT exposes up to 5 prior sales as
+      // PREV_SALE{1..5}DATE / PREV_SALE{1..5}AMT). NU codes are NOT exported
+      // by BRT for prior sales; consumers should treat missing nu as
+      // "unverified" rather than usable. Used by the cover-sale review flow
+      // to detect masked arm's-length sales hiding under a recent $1 deed.
+      prev_sales: this.extractPrevSales(rawRecord),
       
       // Values fields
       values_mod_land: this.parseNumeric(rawRecord.VALUES_LANDTAXABLEVALUE),
@@ -1283,6 +1289,22 @@ export class BRTProcessor {
     if (!dateString || dateString.trim() === '') return null;
     const date = new Date(dateString);
     return isNaN(date.getTime()) ? null : date.toISOString().split('T')[0];
+  }
+
+  // Build the prev_sales jsonb array from BRT's PREV_SALE{1..5}DATE/AMT pairs.
+  // Returns null when no prior sales exist so we don't write empty arrays.
+  // Each entry carries a `source` tag identifying the original BRT slot so
+  // downstream auditing knows exactly where the value came from.
+  extractPrevSales(rawRecord) {
+    const arr = [];
+    for (let i = 1; i <= 5; i++) {
+      const date = this.parseDate(rawRecord[`PREV_SALE${i}DATE`]);
+      const price = this.parseNumeric(rawRecord[`PREV_SALE${i}AMT`]);
+      if (date || price) {
+        arr.push({ date, price, source: `brt_prev_sale_${i}` });
+      }
+    }
+    return arr.length > 0 ? arr : null;
   }
 
   parseNumeric(value, decimals = null) {

--- a/src/lib/data-pipeline/brt-updater.js
+++ b/src/lib/data-pipeline/brt-updater.js
@@ -713,6 +713,11 @@ export class BRTUpdater {
       sales_book: rawRecord.CURRENTSALE_DEEDBOOK,
       sales_page: rawRecord.CURRENTSALE_DEEDPAGE,
       sales_nu: rawRecord.CURRENTSALE_NUC,
+      // Vendor-supplied historical sales (BRT PREV_SALE{1..5}DATE/AMT).
+      // See processor for full rationale; updater overwrites this on every
+      // re-upload so the array always reflects what the latest source file
+      // says about the property's prior sales.
+      prev_sales: this.extractPrevSales(rawRecord),
       
       // Values fields
       values_mod_land: this.parseNumeric(rawRecord.VALUES_LANDTAXABLEVALUE),
@@ -1516,6 +1521,23 @@ export class BRTUpdater {
     if (!dateString || String(dateString).trim() === '') return null;
     const date = new Date(dateString);
     return isNaN(date.getTime()) ? null : date.toISOString().split('T')[0];
+  }
+
+  // Build the prev_sales jsonb array from BRT's PREV_SALE{1..5}DATE/AMT pairs.
+  // Returns null when no prior sales exist so we don't write empty arrays.
+  // See brt-processor.extractPrevSales for full rationale; this is a duplicate
+  // because the processor and updater intentionally do not share code (per
+  // copilot-os ground rules — first-upload vs re-upload paths differ).
+  extractPrevSales(rawRecord) {
+    const arr = [];
+    for (let i = 1; i <= 5; i++) {
+      const date = this.parseDate(rawRecord[`PREV_SALE${i}DATE`]);
+      const price = this.parseNumeric(rawRecord[`PREV_SALE${i}AMT`]);
+      if (date || price) {
+        arr.push({ date, price, source: `brt_prev_sale_${i}` });
+      }
+    }
+    return arr.length > 0 ? arr : null;
   }
 
   parseNumeric(value, decimals = null) {


### PR DESCRIPTION
### Summary
Addresses several interconnected issues discovered during appraisal workflow testing: properties with "cover" sales (e.g. $1 deeds) blocking valid comps from loading, incorrect per-sqft farm structure adjustments, a drifting PDF map overlay, and a slow export modal typing experience. Also adds BRT historical sales extraction and updates the NU code label for code `10`.

### Problem
- Properties with a recent non-usable sale (e.g. $1 cover deed) were hard-blocked from loading as comps in Detailed, preventing appraisers from manually entering a valid historical sale.
- Farm structure adjustments (pole barn, barn, stable) were treated as binary (0/1) even when configured as `per_sqft` or `count`, causing the rate to not multiply by actual square footage (e.g. $15/sf pole barn showing as just $15).
- Dashed connector lines in the exported PDF map were drifting away from comp markers due to Leaflet's SVG transform being mishandled by html2canvas.
- Typing in the export modal's sales fields (NU, date, price) caused visible lag because every keystroke re-rendered the entire grid.
- NU code `10` was labeled "fiduciary sale" — updated to "estate/fiduciary sale" to match assessor terminology.
- BRT historical sales (up to 5 prior transactions) were not being extracted or stored, making it impossible to detect masked arm's-length sales hiding under a recent cover deed.
- Lot-size adjustment type selectors were editable despite the unit being implicit (FF/SF/Acre), causing confusion.

### Solution
- Changed the cover-sale block from a hard error to a soft warning, allowing the property to load so the appraiser can manually fill in sale details via the export modal.
- Added a `SalesHistoryModal` in Detailed that reads `prev_sales` from BRT and lets the user swap a hidden prior sale into the current slot, persisting it to the DB with `sales_override=true`.
- Fixed farm structure adjustment logic to use actual area values when `adjustment_type` is `per_sqft` or `count`.
- Switched Leaflet's `preferCanvas` to `true` so vector layers render on a `<canvas>` element that html2canvas captures reliably.
- Introduced a locally-controlled `EditableInput` component for export modal cells to isolate re-renders to a single cell per keystroke.
- Added `extractPrevSales()` to both the BRT processor and updater to populate a `prev_sales` JSONB array (up to 5 prior date/price pairs) on every file upload.
- Disabled (grayed out) the adjustment type selector for lot-size rows with a contextual label (Per FF / Per SF / Per Acre).

### Key Changes
- **`appellantCompEvaluator.js`** — Updated NU code `10` label from `"fiduciary sale"` to `"estate/fiduciary sale"`.
- **`SalesComparisonTab.jsx`** — Cover-sale no-data entries now emit a soft warning instead of blocking comp load; `pole_barn`, `barn`, and `stable` cases use real area for `per_sqft`/`count` adjustment types; `onSalesSwapped` callback triggers `handleManualEvaluate` with sync to Search & Results / saved sets.
- **`DetailedAppraisalGrid.jsx`** — Added `EditableInput` memo component for lag-free export modal typing; added `salesHistoryModal` state and `openSalesHistoryModal` / `closeSalesHistoryModal` handlers; accepts `onSalesSwapped` prop.
- **`AdjustmentsTab.jsx`** — Lot-size adjustment rows (`lot_size_ff`, `lot_size_sf`, `lot_size_acre`) render a disabled, labeled type selector instead of the editable dropdown.
- **`AppealMap.jsx`** — Set `preferCanvas={true}` to fix dashed connector line drift in exported PDFs.
- **`brt-processor.js` / `brt-updater.js`** — Added `extractPrevSales()` to parse `PREV_SALE{1..5}DATE` / `PREV_SALE{1..5}AMT` fields into a `prev_sales` JSONB array stored on `property_records`.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/knight-hand-ohotzndb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-knight-hand-ohotzndb_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 185`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>knight-hand-ohotzndb</branchName>-->