### PR TITLE
Add PDF exports, year filter, and date fix for appeals/inspections

### DIFF
--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
-import { AlertCircle, Calendar, FileText, TrendingUp } from 'lucide-react';
+import { AlertCircle, Calendar, FileText, TrendingUp, FileDown } from 'lucide-react';
 
 const AppealsSummary = ({ jobs = [], onJobSelect }) => {
   const [jobAppealsSummary, setJobAppealsSummary] = useState([]);
@@ -221,6 +221,188 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
     }
   };
 
+  // PDF export — matches the Lojik invoice / proposal styling used elsewhere
+  const exportPDF = async () => {
+    if (jobAppealsSummary.length === 0) return;
+
+    const { default: jsPDF } = await import('jspdf');
+    const { default: autoTable } = await import('jspdf-autotable');
+
+    const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'letter' });
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const margin = 30;
+    const lojikBlue = [0, 102, 204];
+
+    // Load logo (best-effort)
+    let logoDataUrl = null;
+    try {
+      const response = await fetch('/lojik-logo.PNG');
+      const blob = await response.blob();
+      logoDataUrl = await new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.readAsDataURL(blob);
+      });
+    } catch (err) {
+      console.warn('Could not load logo:', err);
+    }
+
+    // Header
+    if (logoDataUrl) {
+      try { doc.addImage(logoDataUrl, 'PNG', margin, margin, 90, 40); }
+      catch {
+        doc.setTextColor(...lojikBlue);
+        doc.setFontSize(18);
+        doc.setFont('helvetica', 'bold');
+        doc.text('LOJIK', margin, margin + 26);
+      }
+    } else {
+      doc.setTextColor(...lojikBlue);
+      doc.setFontSize(18);
+      doc.setFont('helvetica', 'bold');
+      doc.text('LOJIK', margin, margin + 26);
+    }
+
+    // Title block (right)
+    doc.setTextColor(0, 0, 0);
+    doc.setFontSize(20);
+    doc.setFont('helvetica', 'bold');
+    doc.text('Appeals Summary by Job', pageWidth - margin, margin + 18, { align: 'right' });
+
+    doc.setFontSize(10);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(100, 100, 100);
+    doc.text(`Year: ${selectedYear}`, pageWidth - margin, margin + 34, { align: 'right' });
+    doc.text(`Generated: ${new Date().toLocaleDateString()}`, pageWidth - margin, margin + 48, { align: 'right' });
+
+    // Divider
+    doc.setDrawColor(...lojikBlue);
+    doc.setLineWidth(1.5);
+    doc.line(margin, margin + 60, pageWidth - margin, margin + 60);
+
+    // Subtitle
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'italic');
+    doc.setTextColor(100, 100, 100);
+    doc.text(
+      'Overview of all PPA appeals (active, archived, draft) with class and representation breakdown',
+      margin,
+      margin + 75
+    );
+
+    // Build rows. Track which rows are "all-CME" so we can tint them green to match the UI.
+    const head = [[
+      'Job Name', 'Total', 'Residential', 'Commercial', 'Vacant Land',
+      'Defend', 'Stipulated', 'Heard', 'Withdrawn', 'Assessor', 'Affirmed',
+      'Has CME', 'Pro Se', 'Attorney', 'Hearing'
+    ]];
+
+    const body = jobAppealsSummary.map((row) => ([
+      row.jobName,
+      row.totalAppeals,
+      row.residential !== null ? row.residential : '—',
+      row.commercial !== null ? row.commercial : '—',
+      row.vacant !== null ? row.vacant : '—',
+      row.statusBreakdown.defend,
+      row.statusBreakdown.stipulated,
+      row.statusBreakdown.heard,
+      row.statusBreakdown.withdrawn,
+      row.statusBreakdown.assessor,
+      row.statusBreakdown.affirmed,
+      row.statusBreakdown.hasCME,
+      row.proSeCount,
+      row.attorneyCount,
+      row.hearingDate ? `${row.hearingDate}${row.hasMultipleHearings ? '*' : ''}` : '—'
+    ]));
+
+    // Totals row
+    body.push([
+      'TOTALS',
+      totals.totalAppeals,
+      totals.residential, totals.commercial, totals.vacant,
+      totals.defend, totals.stipulated, totals.heard, totals.withdrawn,
+      totals.assessor, totals.affirmed, totals.hasCME,
+      totals.proSe, totals.attorney, '—'
+    ]);
+
+    autoTable(doc, {
+      head,
+      body,
+      startY: margin + 90,
+      margin: { left: margin, right: margin },
+      styles: {
+        fontSize: 8,
+        cellPadding: 4,
+        lineColor: [220, 220, 220],
+        lineWidth: 0.5,
+        overflow: 'linebreak'
+      },
+      headStyles: {
+        fillColor: lojikBlue,
+        textColor: [255, 255, 255],
+        fontStyle: 'bold',
+        halign: 'center'
+      },
+      columnStyles: {
+        0: { halign: 'left', fontStyle: 'bold', cellWidth: 110 },
+        1: { halign: 'center', fontStyle: 'bold' },
+        2: { halign: 'center' }, 3: { halign: 'center' }, 4: { halign: 'center' },
+        5: { halign: 'center' }, 6: { halign: 'center' }, 7: { halign: 'center' },
+        8: { halign: 'center' }, 9: { halign: 'center' }, 10: { halign: 'center' },
+        11: { halign: 'center' }, 12: { halign: 'center' }, 13: { halign: 'center' },
+        14: { halign: 'center', cellWidth: 60 }
+      },
+      didParseCell: (data) => {
+        const rowIndex = data.row.index;
+        const isTotalsRow = rowIndex === jobAppealsSummary.length;
+
+        if (isTotalsRow) {
+          // Blue tint + bold for totals row (matches UI)
+          data.cell.styles.fillColor = [219, 234, 254]; // bg-blue-50
+          data.cell.styles.fontStyle = 'bold';
+          data.cell.styles.textColor = [17, 24, 39]; // gray-900
+          return;
+        }
+
+        // Per-row green tint when Has CME equals Total Appeals (matches UI bg-green-50)
+        const summaryRow = jobAppealsSummary[rowIndex];
+        if (summaryRow && summaryRow.totalAppeals > 0
+            && summaryRow.statusBreakdown.hasCME === summaryRow.totalAppeals) {
+          data.cell.styles.fillColor = [240, 253, 244]; // bg-green-50
+          if (data.column.index === 11) {
+            data.cell.styles.textColor = [22, 101, 52]; // text-green-800
+            data.cell.styles.fontStyle = 'bold';
+          }
+        }
+      }
+    });
+
+    // Footer / legend
+    const finalY = doc.lastAutoTable.finalY + 14;
+    doc.setFontSize(8);
+    doc.setFont('helvetica', 'italic');
+    doc.setTextColor(100, 100, 100);
+    doc.text('* Multiple hearing dates on file (showing final/last hearing date)', margin, finalY);
+
+    // Page numbers
+    const pageCount = doc.internal.getNumberOfPages();
+    for (let i = 1; i <= pageCount; i++) {
+      doc.setPage(i);
+      doc.setFontSize(8);
+      doc.setFont('helvetica', 'normal');
+      doc.setTextColor(150, 150, 150);
+      doc.text(
+        `Page ${i} of ${pageCount}`,
+        pageWidth - margin,
+        doc.internal.pageSize.getHeight() - 16,
+        { align: 'right' }
+      );
+    }
+
+    const filename = `Appeals_Summary_${selectedYear}_${new Date().toISOString().split('T')[0].replace(/-/g, '')}.pdf`;
+    doc.save(filename);
+  };
+
   // Calculate totals
   const totals = jobAppealsSummary.reduce(
     (acc, row) => ({
@@ -280,6 +462,15 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                 </option>
               ))}
             </select>
+            <button
+              onClick={exportPDF}
+              disabled={jobAppealsSummary.length === 0}
+              className="px-3 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              title="Export this Appeals Summary snapshot as PDF"
+            >
+              <FileDown className="w-4 h-4" />
+              Export PDF
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -248,8 +248,14 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
     }
 
     // Header
+    // Wrap addImage in save/restoreGraphicsState — PNG alpha can leak a
+    // transparent fill state into subsequent text, making it render invisibly.
     if (logoDataUrl) {
-      try { doc.addImage(logoDataUrl, 'PNG', margin, margin, 90, 40); }
+      try {
+        if (typeof doc.saveGraphicsState === 'function') doc.saveGraphicsState();
+        doc.addImage(logoDataUrl, 'PNG', margin, margin, 90, 40);
+        if (typeof doc.restoreGraphicsState === 'function') doc.restoreGraphicsState();
+      }
       catch {
         doc.setTextColor(0, 102, 204);
         doc.setFontSize(18);
@@ -261,6 +267,13 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       doc.setFontSize(18);
       doc.setFont('helvetica', 'bold');
       doc.text('LOJIK', margin, margin + 26);
+    }
+
+    // Belt-and-suspenders: explicitly reset alpha via a fresh GState if available
+    if (typeof doc.setGState === 'function' && typeof doc.GState === 'function') {
+      try {
+        doc.setGState(new doc.GState({ opacity: 1, 'stroke-opacity': 1 }));
+      } catch (e) { /* ignore */ }
     }
 
     // Title block (right) — force dark gray-900 explicitly each line

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -375,6 +375,12 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
         14: { halign: 'center', cellWidth: 60 }
       },
       didParseCell: (data) => {
+        // Only apply body-row tinting to body cells. Without this guard,
+        // didParseCell also runs for the header row (data.row.index === 0)
+        // and was painting the column-header row with the green-50 tint
+        // from the first matching summary row, hiding the white header text.
+        if (data.section !== 'body') return;
+
         const rowIndex = data.row.index;
         const isTotalsRow = rowIndex === jobAppealsSummary.length;
 

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -251,39 +251,42 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
     if (logoDataUrl) {
       try { doc.addImage(logoDataUrl, 'PNG', margin, margin, 90, 40); }
       catch {
-        doc.setTextColor(...lojikBlue);
+        doc.setTextColor(0, 102, 204);
         doc.setFontSize(18);
         doc.setFont('helvetica', 'bold');
         doc.text('LOJIK', margin, margin + 26);
       }
     } else {
-      doc.setTextColor(...lojikBlue);
+      doc.setTextColor(0, 102, 204);
       doc.setFontSize(18);
       doc.setFont('helvetica', 'bold');
       doc.text('LOJIK', margin, margin + 26);
     }
 
-    // Title block (right)
-    doc.setTextColor(0, 0, 0);
-    doc.setFontSize(20);
+    // Title block (right) — force dark gray-900 explicitly each line
+    // (jsPDF can drop text color state after addImage of a PNG with alpha)
+    doc.setFillColor(255, 255, 255);
     doc.setFont('helvetica', 'bold');
+    doc.setFontSize(20);
+    doc.setTextColor(17, 24, 39); // gray-900
     doc.text('Appeals Summary by Job', pageWidth - margin, margin + 18, { align: 'right' });
 
-    doc.setFontSize(10);
     doc.setFont('helvetica', 'normal');
-    doc.setTextColor(100, 100, 100);
+    doc.setFontSize(10);
+    doc.setTextColor(55, 65, 81); // gray-700
     doc.text(`Year: ${selectedYear}`, pageWidth - margin, margin + 34, { align: 'right' });
+    doc.setTextColor(55, 65, 81);
     doc.text(`Generated: ${new Date().toLocaleDateString()}`, pageWidth - margin, margin + 48, { align: 'right' });
 
     // Divider
-    doc.setDrawColor(...lojikBlue);
+    doc.setDrawColor(0, 102, 204);
     doc.setLineWidth(1.5);
     doc.line(margin, margin + 60, pageWidth - margin, margin + 60);
 
     // Subtitle
-    doc.setFontSize(9);
     doc.setFont('helvetica', 'italic');
-    doc.setTextColor(100, 100, 100);
+    doc.setFontSize(9);
+    doc.setTextColor(75, 85, 99); // gray-600
     doc.text(
       'Overview of all PPA appeals (active, archived, draft) with class and representation breakdown',
       margin,

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -247,38 +247,12 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       console.warn('Could not load logo:', err);
     }
 
-    // Header
-    // Wrap addImage in save/restoreGraphicsState — PNG alpha can leak a
-    // transparent fill state into subsequent text, making it render invisibly.
-    if (logoDataUrl) {
-      try {
-        if (typeof doc.saveGraphicsState === 'function') doc.saveGraphicsState();
-        doc.addImage(logoDataUrl, 'PNG', margin, margin, 90, 40);
-        if (typeof doc.restoreGraphicsState === 'function') doc.restoreGraphicsState();
-      }
-      catch {
-        doc.setTextColor(0, 102, 204);
-        doc.setFontSize(18);
-        doc.setFont('helvetica', 'bold');
-        doc.text('LOJIK', margin, margin + 26);
-      }
-    } else {
-      doc.setTextColor(0, 102, 204);
-      doc.setFontSize(18);
-      doc.setFont('helvetica', 'bold');
-      doc.text('LOJIK', margin, margin + 26);
-    }
+    // IMPORTANT: draw all header TEXT first, then the logo image LAST.
+    // PNG addImage with an alpha channel corrupts the text rendering state
+    // for whatever is drawn next, so we draw text up front to guarantee it
+    // renders dark.
 
-    // Belt-and-suspenders: explicitly reset alpha via a fresh GState if available
-    if (typeof doc.setGState === 'function' && typeof doc.GState === 'function') {
-      try {
-        doc.setGState(new doc.GState({ opacity: 1, 'stroke-opacity': 1 }));
-      } catch (e) { /* ignore */ }
-    }
-
-    // Title block (right) — force dark gray-900 explicitly each line
-    // (jsPDF can drop text color state after addImage of a PNG with alpha)
-    doc.setFillColor(255, 255, 255);
+    // Title block (right)
     doc.setFont('helvetica', 'bold');
     doc.setFontSize(20);
     doc.setTextColor(17, 24, 39); // gray-900
@@ -288,7 +262,6 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
     doc.setFontSize(10);
     doc.setTextColor(55, 65, 81); // gray-700
     doc.text(`Year: ${selectedYear}`, pageWidth - margin, margin + 34, { align: 'right' });
-    doc.setTextColor(55, 65, 81);
     doc.text(`Generated: ${new Date().toLocaleDateString()}`, pageWidth - margin, margin + 48, { align: 'right' });
 
     // Divider
@@ -305,6 +278,39 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       margin,
       margin + 75
     );
+
+    // Logo / brand mark — draw LAST so any state leak doesn't affect text above.
+    // Convert PNG → JPEG via canvas to strip the alpha channel that causes
+    // jsPDF to leak a transparent GState into subsequent operations.
+    let logoRendered = false;
+    if (logoDataUrl) {
+      try {
+        const img = await new Promise((resolve, reject) => {
+          const i = new Image();
+          i.onload = () => resolve(i);
+          i.onerror = reject;
+          i.src = logoDataUrl;
+        });
+        const canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth || 360;
+        canvas.height = img.naturalHeight || 160;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#FFFFFF';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, 0, 0);
+        const jpegDataUrl = canvas.toDataURL('image/jpeg', 0.95);
+        doc.addImage(jpegDataUrl, 'JPEG', margin, margin, 90, 40);
+        logoRendered = true;
+      } catch (err) {
+        console.warn('Logo render failed, falling back to text:', err);
+      }
+    }
+    if (!logoRendered) {
+      doc.setTextColor(0, 102, 204);
+      doc.setFontSize(18);
+      doc.setFont('helvetica', 'bold');
+      doc.text('LOJIK', margin, margin + 26);
+    }
 
     // Build rows. Track which rows are "all-CME" so we can tint them green to match the UI.
     const head = [[

--- a/src/components/job-modules/InspectionInfo.jsx
+++ b/src/components/job-modules/InspectionInfo.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Database, CheckCircle, AlertCircle, TrendingUp, Users, FileText, Home, Calendar } from 'lucide-react';
+import { Database, CheckCircle, AlertCircle, TrendingUp, Users, FileText, Home, Calendar, FileDown } from 'lucide-react';
 
 const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
   // Year filter — gates everything on inspection_measure_date year so a measure
@@ -337,6 +337,223 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
   const sortedInspectors = Object.entries(metrics.inspectorBreakdown)
     .sort(([, a], [, b]) => b - a);
 
+  // PDF export — annual reassessment audit snapshot for LOJIK clients to
+  // submit to the state. Mirrors the styling used in AppealsSummary.
+  const exportPDF = async () => {
+    if (!yearFilteredProperties || yearFilteredProperties.length === 0) return;
+
+    const { default: jsPDF } = await import('jspdf');
+    const { default: autoTable } = await import('jspdf-autotable');
+
+    const doc = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'letter' });
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const margin = 36;
+    const lojikBlue = [0, 102, 204];
+
+    const yearLbl = selectedYear === 'all' ? 'All Years' : String(selectedYear);
+    const jobName = jobData?.job_name || jobData?.name || 'Job';
+    const ccdd = jobData?.ccdd_code ? ` (${jobData.ccdd_code})` : '';
+
+    // Try to load logo
+    let logoDataUrl = null;
+    try {
+      const response = await fetch('/lojik-logo.PNG');
+      const blob = await response.blob();
+      logoDataUrl = await new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.readAsDataURL(blob);
+      });
+    } catch (err) {
+      console.warn('Could not load logo:', err);
+    }
+
+    // Draw all header TEXT first (so PNG state corruption can't affect it).
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(18);
+    doc.setTextColor(17, 24, 39); // gray-900
+    doc.text('Inspection Info Report', pageWidth - margin, margin + 18, { align: 'right' });
+
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(55, 65, 81);
+    doc.text(`${jobName}${ccdd}`, pageWidth - margin, margin + 34, { align: 'right' });
+    doc.text(`Year: ${yearLbl}`, pageWidth - margin, margin + 48, { align: 'right' });
+    doc.text(`Generated: ${new Date().toLocaleDateString()}`, pageWidth - margin, margin + 62, { align: 'right' });
+
+    // Divider
+    doc.setDrawColor(0, 102, 204);
+    doc.setLineWidth(1.5);
+    doc.line(margin, margin + 74, pageWidth - margin, margin + 74);
+
+    // Subtitle
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(9);
+    doc.setTextColor(75, 85, 99);
+    doc.text(
+      'Annual reassessment inspection summary — gated on measure date',
+      margin,
+      margin + 88
+    );
+
+    // Logo LAST (PNG → JPEG via canvas to strip alpha and avoid GState leak)
+    let logoRendered = false;
+    if (logoDataUrl) {
+      try {
+        const img = await new Promise((resolve, reject) => {
+          const i = new Image();
+          i.onload = () => resolve(i);
+          i.onerror = reject;
+          i.src = logoDataUrl;
+        });
+        const canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth || 360;
+        canvas.height = img.naturalHeight || 160;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#FFFFFF';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, 0, 0);
+        const jpegDataUrl = canvas.toDataURL('image/jpeg', 0.95);
+        doc.addImage(jpegDataUrl, 'JPEG', margin, margin, 90, 40);
+        logoRendered = true;
+      } catch (err) {
+        console.warn('Logo render failed, falling back to text:', err);
+      }
+    }
+    if (!logoRendered) {
+      doc.setTextColor(0, 102, 204);
+      doc.setFontSize(18);
+      doc.setFont('helvetica', 'bold');
+      doc.text('LOJIK', margin, margin + 26);
+    }
+
+    // Summary metrics table
+    const fmtDate = (d) => d ? d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '—';
+    const summaryRows = [
+      ['Total Properties (filtered)', metrics.totalProperties.toLocaleString()],
+      ['Improved Properties', metrics.improvedTotal.toLocaleString()],
+      ['Improved Entries', metrics.improvedInspected.toLocaleString()],
+      ['Improved No Entry', metrics.improvedNotInspected.toLocaleString()],
+      ['Improved Entry Rate', `${metrics.improvedEntryRate}%`],
+      ['Improved Interior Entries', `${metrics.improvedInteriorEntries.toLocaleString()} / ${metrics.improvedTotal.toLocaleString()} (${metrics.improvedInteriorRate}%)`],
+      ['Avg Measured Date (2/3A)', fmtDate(metrics.avgInspectionDate)],
+      ['Latest Interior Entry (2/3A)', fmtDate(metrics.mostRecentInteriorEntry)]
+    ];
+
+    autoTable(doc, {
+      head: [['Metric', 'Value']],
+      body: summaryRows,
+      startY: margin + 100,
+      margin: { left: margin, right: margin },
+      styles: { fontSize: 9, cellPadding: 5, lineColor: [220, 220, 220], lineWidth: 0.5 },
+      headStyles: { fillColor: lojikBlue, textColor: [255, 255, 255], fontStyle: 'bold' },
+      columnStyles: {
+        0: { fontStyle: 'bold', cellWidth: 220 },
+        1: { halign: 'right' }
+      },
+      didParseCell: (data) => { if (data.section !== 'body') return; }
+    });
+
+    // Property class breakdown
+    const classBody = sortedClasses.map(([cls, data]) => {
+      const rate = data.total > 0 ? ((data.inspected / data.total) * 100).toFixed(1) : '0.0';
+      const imprRate = data.improvedTotal > 0
+        ? ((data.improvedInspected / data.improvedTotal) * 100).toFixed(1)
+        : '—';
+      return [
+        cls,
+        data.total.toLocaleString(),
+        data.inspected.toLocaleString(),
+        `${rate}%`,
+        data.improvedTotal.toLocaleString(),
+        data.improvedTotal > 0 ? `${imprRate}%` : '—'
+      ];
+    });
+
+    autoTable(doc, {
+      head: [['Class', 'Total', 'Entries', 'Rate', 'Improved', 'Impr Rate']],
+      body: classBody,
+      startY: doc.lastAutoTable.finalY + 18,
+      margin: { left: margin, right: margin },
+      styles: { fontSize: 9, cellPadding: 5, lineColor: [220, 220, 220], lineWidth: 0.5 },
+      headStyles: { fillColor: lojikBlue, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'center' },
+      columnStyles: {
+        0: { fontStyle: 'bold' },
+        1: { halign: 'right' }, 2: { halign: 'right' }, 3: { halign: 'right' },
+        4: { halign: 'right' }, 5: { halign: 'right' }
+      }
+    });
+
+    // VCS breakdown (residential)
+    if (sortedVCS.length > 0) {
+      const vcsBody = sortedVCS.map(([vcs, data]) => {
+        const rate = data.total > 0 ? ((data.inspected / data.total) * 100).toFixed(1) : '0.0';
+        return [
+          vcs,
+          data.total.toLocaleString(),
+          data.inspected.toLocaleString(),
+          `${rate}%`,
+          data.refusals.toLocaleString()
+        ];
+      });
+
+      autoTable(doc, {
+        head: [['VCS Code', 'Total', 'Entries', 'Rate', 'Refusals']],
+        body: vcsBody,
+        startY: doc.lastAutoTable.finalY + 18,
+        margin: { left: margin, right: margin },
+        styles: { fontSize: 9, cellPadding: 5, lineColor: [220, 220, 220], lineWidth: 0.5 },
+        headStyles: { fillColor: lojikBlue, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'center' },
+        columnStyles: {
+          0: { fontStyle: 'bold' },
+          1: { halign: 'right' }, 2: { halign: 'right' }, 3: { halign: 'right' },
+          4: { halign: 'right' }
+        }
+      });
+    }
+
+    // Inspector breakdown
+    if (sortedInspectors.length > 0) {
+      const inspectorBody = sortedInspectors.map(([name, count]) => [
+        name,
+        count.toLocaleString(),
+        metrics.inspected > 0 ? `${((count / metrics.inspected) * 100).toFixed(1)}%` : '0.0%'
+      ]);
+
+      autoTable(doc, {
+        head: [['Inspector', 'Entries', '% of Total']],
+        body: inspectorBody,
+        startY: doc.lastAutoTable.finalY + 18,
+        margin: { left: margin, right: margin },
+        styles: { fontSize: 9, cellPadding: 5, lineColor: [220, 220, 220], lineWidth: 0.5 },
+        headStyles: { fillColor: lojikBlue, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'center' },
+        columnStyles: {
+          0: { fontStyle: 'bold' },
+          1: { halign: 'right' }, 2: { halign: 'right' }
+        }
+      });
+    }
+
+    // Page numbers
+    const pageCount = doc.internal.getNumberOfPages();
+    for (let i = 1; i <= pageCount; i++) {
+      doc.setPage(i);
+      doc.setFontSize(8);
+      doc.setFont('helvetica', 'normal');
+      doc.setTextColor(150, 150, 150);
+      doc.text(
+        `Page ${i} of ${pageCount}`,
+        pageWidth - margin,
+        doc.internal.pageSize.getHeight() - 18,
+        { align: 'right' }
+      );
+    }
+
+    const safeJob = jobName.replace(/[^a-z0-9]+/gi, '_');
+    const filename = `Inspection_Info_${safeJob}_${yearLbl}_${new Date().toISOString().split('T')[0].replace(/-/g, '')}.pdf`;
+    doc.save(filename);
+  };
+
   if (!properties || properties.length === 0) {
     return (
       <div className="max-w-6xl mx-auto p-6">
@@ -376,6 +593,15 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
               <option key={y} value={y}>{y}</option>
             ))}
           </select>
+          <button
+            onClick={exportPDF}
+            disabled={yearFilteredProperties.length === 0}
+            className="px-3 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            title="Export this Inspection Info snapshot as PDF (state audit ready)"
+          >
+            <FileDown className="w-4 h-4" />
+            Export PDF
+          </button>
         </div>
       </div>
 

--- a/src/components/job-modules/InspectionInfo.jsx
+++ b/src/components/job-modules/InspectionInfo.jsx
@@ -1,7 +1,33 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Database, CheckCircle, AlertCircle, TrendingUp, Users, FileText, Home, Calendar } from 'lucide-react';
 
 const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
+  // Year filter — gates everything on inspection_measure_date year so a measure
+  // done in a prior year doesn't count toward this year's entry rate (matches
+  // how the state audits annual reassessment compliance).
+  const [selectedYear, setSelectedYear] = useState('all');
+
+  // Build the list of years that actually appear in the data (by measure_date)
+  const availableYears = useMemo(() => {
+    const years = new Set();
+    (properties || []).forEach(p => {
+      if (p.inspection_measure_date) {
+        const y = new Date(p.inspection_measure_date).getFullYear();
+        if (!Number.isNaN(y)) years.add(y);
+      }
+    });
+    return Array.from(years).sort((a, b) => b - a);
+  }, [properties]);
+
+  // Apply the year gate before any metric is computed.
+  const yearFilteredProperties = useMemo(() => {
+    if (selectedYear === 'all' || !selectedYear) return properties;
+    const target = parseInt(selectedYear, 10);
+    return (properties || []).filter(p => {
+      if (!p.inspection_measure_date) return false;
+      return new Date(p.inspection_measure_date).getFullYear() === target;
+    });
+  }, [properties, selectedYear]);
   // Extract refusal codes from parsed code definitions
   const getRefusalCodesFromCodeFile = () => {
     const vendor = jobData?.vendor_type || 'BRT';
@@ -56,7 +82,7 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
   const vendor = jobData?.vendor_type || 'BRT';
 
   const metrics = useMemo(() => {
-    if (!properties || properties.length === 0) {
+    if (!yearFilteredProperties || yearFilteredProperties.length === 0) {
       return {
         totalProperties: 0,
         inspected: 0,
@@ -66,6 +92,9 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
         improvedInspected: 0,
         improvedNotInspected: 0,
         improvedEntryRate: 0,
+        interiorEntries: 0,
+        improvedInteriorEntries: 0,
+        improvedInteriorRate: 0,
         byClass: {},
         byVCS: {},
         missingInspections: [],
@@ -78,6 +107,8 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
     let improvedTotal = 0;
     let improvedInspected = 0;
     let improvedNotInspected = 0;
+    let interiorEntries = 0;          // entries whose info_by_code is in the configured "entry" category
+    let improvedInteriorEntries = 0;  // same, restricted to improved properties
     const residentialEntryDates = [];
     let mostRecentInteriorEntry = null;
     const entryCodes = jobData?.infoby_category_config?.entry || [];
@@ -86,7 +117,7 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
     const missingInspections = [];
     const inspectorBreakdown = {};
 
-    properties.forEach(prop => {
+    yearFilteredProperties.forEach(prop => {
       const propertyClass = prop.property_m4_class || 'Unknown';
       if (!byClass[propertyClass]) {
         byClass[propertyClass] = { total: 0, inspected: 0, improvedTotal: 0, improvedInspected: 0 };
@@ -177,6 +208,16 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
         inspected++;
         byClass[propertyClass].inspected++;
 
+        // Interior-entry tally: only when info_by_code is in the configured entry category.
+        // If no entry codes are configured, treat any non-refusal listing as interior.
+        const infoByForInterior = vendor === 'Microsystems' ? prop.info_by_code : prop.inspection_info_by;
+        const isInteriorEntry = entryCodes.length > 0
+          ? (infoByForInterior && entryCodes.includes(infoByForInterior))
+          : true;
+        if (isInteriorEntry) {
+          interiorEntries++;
+        }
+
         if (isResidential) {
           const vcsLabel = vcsCode || 'Unknown';
           byVCS[vcsLabel].inspected++;
@@ -185,6 +226,9 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
         if (isImproved) {
           improvedInspected++;
           byClass[propertyClass].improvedInspected++;
+          if (isInteriorEntry) {
+            improvedInteriorEntries++;
+          }
         }
 
         // Track residential (2/3A) dates for average measured + most recent interior entry
@@ -254,8 +298,12 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
       avgInspectionDate = new Date(totalMs / residentialEntryDates.length);
     }
 
+    const improvedInteriorRate = improvedTotal > 0
+      ? ((improvedInteriorEntries / improvedTotal) * 100).toFixed(1)
+      : 0;
+
     return {
-      totalProperties: properties.length,
+      totalProperties: yearFilteredProperties.length,
       inspected,
       notInspected,
       entryRate: parseFloat(entryRate),
@@ -263,6 +311,9 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
       improvedInspected,
       improvedNotInspected,
       improvedEntryRate: parseFloat(improvedEntryRate),
+      interiorEntries,
+      improvedInteriorEntries,
+      improvedInteriorRate: parseFloat(improvedInteriorRate),
       byClass,
       byVCS,
       missingInspections,
@@ -270,7 +321,7 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
       avgInspectionDate,
       mostRecentInteriorEntry
     };
-  }, [properties, refusalCodes, vendor]);
+  }, [yearFilteredProperties, refusalCodes, vendor, jobData]);
 
   const sortedClasses = Object.entries(metrics.byClass)
     .sort(([a], [b]) => a.localeCompare(b));
@@ -298,12 +349,41 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
     );
   }
 
+  const yearLabel = selectedYear === 'all' ? 'All Years' : selectedYear;
+
   return (
     <div className="max-w-6xl mx-auto p-6">
-      <h2 className="text-xl font-bold text-gray-800 mb-6 flex items-center gap-2">
-        <Database className="w-5 h-5 text-blue-600" />
-        Inspection Info
-      </h2>
+      <div className="flex items-start justify-between mb-6 gap-4 flex-wrap">
+        <div>
+          <h2 className="text-xl font-bold text-gray-800 flex items-center gap-2">
+            <Database className="w-5 h-5 text-blue-600" />
+            Inspection Info
+            <span className="text-sm font-normal text-gray-500">— {yearLabel}</span>
+          </h2>
+          <p className="text-xs text-gray-500 mt-1">
+            Year filter gates on <span className="font-medium">measure date</span> — a property measured in a prior year doesn't count toward this year's entry rate, even if a later listing exists.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-gray-700">Year:</label>
+          <select
+            value={selectedYear}
+            onChange={(e) => setSelectedYear(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-900 bg-white hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="all">All Years</option>
+            {availableYears.map(y => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {yearFilteredProperties.length === 0 && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6 text-sm text-amber-800">
+          No properties have a measure date in <span className="font-semibold">{yearLabel}</span>. Pick a different year to see metrics.
+        </div>
+      )}
 
       {/* Summary Cards - Improved Properties (entry rate only matters for improved) */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
@@ -378,6 +458,28 @@ const InspectionInfo = ({ jobData, properties = [], inspectionData = [] }) => {
               </p>
             </div>
             <Home className="w-8 h-8 text-purple-400" />
+          </div>
+        </div>
+
+        <div className="bg-white p-5 rounded-lg border-2 border-rose-200 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-500">Improved Interior Entries</p>
+              <p className="text-3xl font-bold text-rose-600">
+                {metrics.improvedInteriorEntries.toLocaleString()}
+                <span className="text-base font-medium text-gray-400 ml-2">/ {metrics.improvedTotal.toLocaleString()}</span>
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                {metrics.improvedInteriorRate}% interior entry rate
+              </p>
+            </div>
+            <CheckCircle className="w-8 h-8 text-rose-400" />
+          </div>
+          <div className="mt-2 bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-rose-500 h-2 rounded-full transition-all"
+              style={{ width: `${Math.min(metrics.improvedInteriorRate, 100)}%` }}
+            />
           </div>
         </div>
       </div>

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1572,10 +1572,11 @@ const ProductionTracker = ({
           addValidationIssue(`Residential inspector on commercial property`);
         }
 
-        // Zero improvement validation - only check primary cards
+        // Zero improvement validation - only check primary cards, and skip Special codes
         // (additional cards always store $0 in values_mod_improvement by vendor design;
-        //  the real improvement value lives on the M card for Microsystems / card 1 for BRT)
-        if (isPrimary && record.values_mod_improvement === 0 && !hasListingData) {
+        //  the real improvement value lives on the M card for Microsystems / card 1 for BRT;
+        //  Special codes bypass all business-rule validation by design)
+        if (isPrimary && !isSpecialCode && record.values_mod_improvement === 0 && !hasListingData) {
           addValidationIssue('Zero improvement property missing listing data');
         }
         

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -25,6 +25,7 @@ const ProductionTracker = ({
   const [validationReport, setValidationReport] = useState(null);
   const [missingPropertiesReport, setMissingPropertiesReport] = useState(null);
   const [missingPricedReport, setMissingPricedReport] = useState(null);
+  const [pricingOverrideUpdating, setPricingOverrideUpdating] = useState({});
   const [sessionHistory, setSessionHistory] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const notificationCounterRef = useRef(0);
@@ -117,6 +118,61 @@ const ProductionTracker = ({
   // Check if analytics need reprocessing - uses database flag set by file uploads
   const isAnalyticsStale = jobData?.needs_reprocessing === true;
 
+  // Toggle the per-property pricing override (option 2: explicit "N/A" exemption)
+  const setPricingOverride = async (compositeKey, value) => {
+    if (!compositeKey) return;
+    setPricingOverrideUpdating(prev => ({ ...prev, [compositeKey]: true }));
+    try {
+      const { error } = await supabase
+        .from('property_records')
+        .update({ pricing_required_override: value })
+        .eq('property_composite_key', compositeKey);
+
+      if (error) throw error;
+
+      // Patch local state without a full reload
+      setMissingPricedReport(prev => {
+        if (!prev) return prev;
+        // If marking as N/A (false), drop the row from the list and bump the counters
+        if (value === false) {
+          const remaining = prev.detailed_missing.filter(p => p.composite_key !== compositeKey);
+          const removed = prev.detailed_missing.length - remaining.length;
+          return {
+            ...prev,
+            detailed_missing: remaining,
+            summary: {
+              ...prev.summary,
+              total_missing: Math.max((prev.summary.total_missing || 0) - removed, 0),
+              total_commercial: Math.max((prev.summary.total_commercial || 0) - removed, 0),
+              total_pricing_exempt: (prev.summary.total_pricing_exempt || 0) + removed
+            }
+          };
+        }
+        return prev;
+      });
+
+      // Update header tile counts
+      setCommercialCounts(prev => ({
+        ...prev,
+        total: value === false ? Math.max((prev.total || 0) - 1, 0) : (prev.total || 0) + 1
+      }));
+
+      addNotification(
+        value === false ? 'Marked as not requiring pricing' : 'Pricing requirement restored',
+        'success'
+      );
+    } catch (err) {
+      console.error('Failed to update pricing override:', err);
+      addNotification(`Failed to update: ${err.message || err}`, 'error');
+    } finally {
+      setPricingOverrideUpdating(prev => {
+        const next = { ...prev };
+        delete next[compositeKey];
+        return next;
+      });
+    }
+  };
+
   const addNotification = (message, type = 'info') => {
     const id = `${Date.now()}-${notificationCounterRef.current++}`;
     const notification = { id, message, type, timestamp: new Date() };
@@ -138,8 +194,14 @@ const ProductionTracker = ({
       return;
     }
 
+    const exemptKeys = new Set(
+      (properties || [])
+        .filter(p => p.pricing_required_override === false)
+        .map(p => p.property_composite_key)
+    );
+
     const commercialProps = inspectionData.filter(d =>
-      ['4A', '4B', '4C'].includes(d.property_class)
+      ['4A', '4B', '4C'].includes(d.property_class) && !exemptKeys.has(d.property_composite_key)
     );
 
     const inspected = commercialProps.filter(d =>
@@ -632,7 +694,7 @@ const ProductionTracker = ({
         // Restore commercial counts from saved analytics
         if (loadedAnalytics.totalCommercialProperties) {
           setCommercialCounts({
-            total: loadedAnalytics.totalCommercialProperties,
+            total: loadedAnalytics.commercialPricingDenominator ?? loadedAnalytics.totalCommercialProperties,
             inspected: loadedAnalytics.commercialInspections || 0,
             priced: loadedAnalytics.commercialPricing || 0
           });
@@ -1668,6 +1730,7 @@ const ProductionTracker = ({
           // Pricing logic with vendor detection
           if (isCommercialProperty) {
             const currentVendor = actualVendor || jobData.vendor_type;
+            const pricingExempt = record.pricing_required_override === false;
 
             if (currentVendor === 'BRT' &&
                 record.inspection_price_by &&
@@ -1685,6 +1748,11 @@ const ProductionTracker = ({
               inspectorStats[inspector].priced++;
               if (classBreakdown[propertyClass]) {
                 classBreakdown[propertyClass].priced++;
+              }
+            } else if (pricingExempt) {
+              // Explicitly marked N/A — exclude from both denominator and missing list
+              if (classBreakdown[propertyClass]) {
+                classBreakdown[propertyClass].pricingExempt = (classBreakdown[propertyClass].pricingExempt || 0) + 1;
               }
             } else {
               // Track commercial properties not yet priced
@@ -1998,6 +2066,8 @@ const ProductionTracker = ({
       // FIX: Use classBreakdown for commercial pricing (fresh data from processing loop)
       // NOT commercialCounts.priced which uses stale inspectionData prop
       const totalCommercialPriced = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0);
+      const totalPricingExempt = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.pricingExempt || 0), 0);
+      const pricingDenominator = Math.max(totalCommercialProperties - totalPricingExempt, 0);
 
       const validationReportData = {
         summary: {
@@ -2050,8 +2120,9 @@ const ProductionTracker = ({
             acc[insp] = (acc[insp] || 0) + 1;
             return acc;
           }, {}),
-          total_commercial: ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.total || 0), 0),
-          total_priced: ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0)
+          total_commercial: pricingDenominator,
+          total_priced: totalCommercialPriced,
+          total_pricing_exempt: totalPricingExempt
         },
         detailed_missing: missingPricedProperties
       };
@@ -2073,8 +2144,10 @@ const ProductionTracker = ({
         commercialInspections: totalCommercialInspected,
         commercialPricing: totalCommercialPriced,
         totalCommercialProperties,
+        commercialPricingDenominator: pricingDenominator,
+        commercialPricingExempt: totalPricingExempt,
         commercialCompletePercent: totalCommercialProperties > 0 ? Math.round((totalCommercialInspected / totalCommercialProperties) * 100) : 0,
-        pricingCompletePercent: totalCommercialProperties > 0 ? Math.round((totalCommercialPriced / totalCommercialProperties) * 100) : 0,
+        pricingCompletePercent: pricingDenominator > 0 ? Math.round((totalCommercialPriced / pricingDenominator) * 100) : 0,
 
         // Track overrides applied during processing
         overridesAppliedCount: decisionsToApply.length
@@ -2342,7 +2415,7 @@ const ProductionTracker = ({
 
       // Update commercial counts to match analytics
       setCommercialCounts({
-        total: analyticsResult.totalCommercialProperties,
+        total: analyticsResult.commercialPricingDenominator ?? analyticsResult.totalCommercialProperties,
         inspected: analyticsResult.commercialInspections,
         priced: analyticsResult.commercialPricing
       });
@@ -4427,7 +4500,7 @@ const exportMissingPropertiesReport = () => {
                 ) : (
                   <>
                     {/* Summary Cards */}
-                    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+                    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
                       <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
                         <div className="flex items-center justify-between">
                           <div>
@@ -4469,6 +4542,17 @@ const exportMissingPropertiesReport = () => {
                             </p>
                           </div>
                           <TrendingUp className="w-8 h-8 text-yellow-500" />
+                        </div>
+                      </div>
+
+                      <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <p className="text-sm text-gray-600 font-medium">Marked N/A</p>
+                            <p className="text-2xl font-bold text-gray-800">{missingPricedReport.summary.total_pricing_exempt || 0}</p>
+                            <p className="text-xs text-gray-500">Excluded from denominator</p>
+                          </div>
+                          <Lock className="w-8 h-8 text-gray-400" />
                         </div>
                       </div>
                     </div>
@@ -4516,6 +4600,7 @@ const exportMissingPropertiesReport = () => {
                               <th className="px-3 py-2 text-left font-medium text-gray-700">Measure Date</th>
                               <th className="px-3 py-2 text-left font-medium text-gray-700">Price By</th>
                               <th className="px-3 py-2 text-left font-medium text-gray-700">Price Date</th>
+                              <th className="px-3 py-2 text-left font-medium text-gray-700">Action</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -4535,6 +4620,16 @@ const exportMissingPropertiesReport = () => {
                                 <td className="px-3 py-2">{property.measure_date ? new Date(property.measure_date).toLocaleDateString() : '-'}</td>
                                 <td className="px-3 py-2">{property.price_by || '-'}</td>
                                 <td className="px-3 py-2">{property.price_date ? new Date(property.price_date).toLocaleDateString() : '-'}</td>
+                                <td className="px-3 py-2">
+                                  <button
+                                    onClick={() => setPricingOverride(property.composite_key, false)}
+                                    disabled={!!pricingOverrideUpdating[property.composite_key]}
+                                    className="px-2 py-1 text-xs bg-gray-200 hover:bg-gray-300 text-gray-800 rounded disabled:opacity-50"
+                                    title="Mark as not requiring pricing (e.g. converting to non-commercial class)"
+                                  >
+                                    {pricingOverrideUpdating[property.composite_key] ? '...' : 'Mark N/A'}
+                                  </button>
+                                </td>
                               </tr>
                             ))}
                           </tbody>

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1572,8 +1572,10 @@ const ProductionTracker = ({
           addValidationIssue(`Residential inspector on commercial property`);
         }
 
-        // Zero improvement validation
-        if (record.values_mod_improvement === 0 && !hasListingData) {
+        // Zero improvement validation - only check primary cards
+        // (additional cards always store $0 in values_mod_improvement by vendor design;
+        //  the real improvement value lives on the M card for Microsystems / card 1 for BRT)
+        if (isPrimary && record.values_mod_improvement === 0 && !hasListingData) {
           addValidationIssue('Zero improvement property missing listing data');
         }
         

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1308,6 +1308,21 @@ const ProductionTracker = ({
               if (isCommercialProperty) {
                 inspectorStats[inspector].commercialInspected++;
                 inspectorStats[inspector].commercialWorkDays.add(workDayString);
+
+                // Commercial overrides also count as PRICED — the override is the user's stamp
+                // that this property is fully complete. Audit trail lives in override_reason.
+                inspectorStats[inspector].priced++;
+                inspectorStats[inspector].pricingWorkDays.add(workDayString);
+                if (classBreakdown[propertyClass]) {
+                  classBreakdown[propertyClass].priced++;
+                }
+              }
+            } else if (['4A', '4B', '4C'].includes(propertyClass)) {
+              // Override on commercial with no measure date — still credit pricing,
+              // but skip the work-day add since we don't have a date to attribute it to.
+              inspectorStats[inspector].priced++;
+              if (classBreakdown[propertyClass]) {
+                classBreakdown[propertyClass].priced++;
               }
             }
           }

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1762,6 +1762,7 @@ const ProductionTracker = ({
               block: record.property_block,
               lot: record.property_lot,
               qualifier: record.property_qualifier || '',
+              card: record.property_addl_card,
               property_location: record.property_location || '',
               property_class: propertyClass,
               reason: reasonNotAdded,

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -25,7 +25,6 @@ const ProductionTracker = ({
   const [validationReport, setValidationReport] = useState(null);
   const [missingPropertiesReport, setMissingPropertiesReport] = useState(null);
   const [missingPricedReport, setMissingPricedReport] = useState(null);
-  const [pricingOverrideUpdating, setPricingOverrideUpdating] = useState({});
   const [sessionHistory, setSessionHistory] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const notificationCounterRef = useRef(0);
@@ -118,61 +117,6 @@ const ProductionTracker = ({
   // Check if analytics need reprocessing - uses database flag set by file uploads
   const isAnalyticsStale = jobData?.needs_reprocessing === true;
 
-  // Toggle the per-property pricing override (option 2: explicit "N/A" exemption)
-  const setPricingOverride = async (compositeKey, value) => {
-    if (!compositeKey) return;
-    setPricingOverrideUpdating(prev => ({ ...prev, [compositeKey]: true }));
-    try {
-      const { error } = await supabase
-        .from('property_records')
-        .update({ pricing_required_override: value })
-        .eq('property_composite_key', compositeKey);
-
-      if (error) throw error;
-
-      // Patch local state without a full reload
-      setMissingPricedReport(prev => {
-        if (!prev) return prev;
-        // If marking as N/A (false), drop the row from the list and bump the counters
-        if (value === false) {
-          const remaining = prev.detailed_missing.filter(p => p.composite_key !== compositeKey);
-          const removed = prev.detailed_missing.length - remaining.length;
-          return {
-            ...prev,
-            detailed_missing: remaining,
-            summary: {
-              ...prev.summary,
-              total_missing: Math.max((prev.summary.total_missing || 0) - removed, 0),
-              total_commercial: Math.max((prev.summary.total_commercial || 0) - removed, 0),
-              total_pricing_exempt: (prev.summary.total_pricing_exempt || 0) + removed
-            }
-          };
-        }
-        return prev;
-      });
-
-      // Update header tile counts
-      setCommercialCounts(prev => ({
-        ...prev,
-        total: value === false ? Math.max((prev.total || 0) - 1, 0) : (prev.total || 0) + 1
-      }));
-
-      addNotification(
-        value === false ? 'Marked as not requiring pricing' : 'Pricing requirement restored',
-        'success'
-      );
-    } catch (err) {
-      console.error('Failed to update pricing override:', err);
-      addNotification(`Failed to update: ${err.message || err}`, 'error');
-    } finally {
-      setPricingOverrideUpdating(prev => {
-        const next = { ...prev };
-        delete next[compositeKey];
-        return next;
-      });
-    }
-  };
-
   const addNotification = (message, type = 'info') => {
     const id = `${Date.now()}-${notificationCounterRef.current++}`;
     const notification = { id, message, type, timestamp: new Date() };
@@ -194,14 +138,8 @@ const ProductionTracker = ({
       return;
     }
 
-    const exemptKeys = new Set(
-      (properties || [])
-        .filter(p => p.pricing_required_override === false)
-        .map(p => p.property_composite_key)
-    );
-
     const commercialProps = inspectionData.filter(d =>
-      ['4A', '4B', '4C'].includes(d.property_class) && !exemptKeys.has(d.property_composite_key)
+      ['4A', '4B', '4C'].includes(d.property_class)
     );
 
     const inspected = commercialProps.filter(d =>
@@ -694,7 +632,7 @@ const ProductionTracker = ({
         // Restore commercial counts from saved analytics
         if (loadedAnalytics.totalCommercialProperties) {
           setCommercialCounts({
-            total: loadedAnalytics.commercialPricingDenominator ?? loadedAnalytics.totalCommercialProperties,
+            total: loadedAnalytics.totalCommercialProperties,
             inspected: loadedAnalytics.commercialInspections || 0,
             priced: loadedAnalytics.commercialPricing || 0
           });
@@ -1730,7 +1668,6 @@ const ProductionTracker = ({
           // Pricing logic with vendor detection
           if (isCommercialProperty) {
             const currentVendor = actualVendor || jobData.vendor_type;
-            const pricingExempt = record.pricing_required_override === false;
 
             if (currentVendor === 'BRT' &&
                 record.inspection_price_by &&
@@ -1748,11 +1685,6 @@ const ProductionTracker = ({
               inspectorStats[inspector].priced++;
               if (classBreakdown[propertyClass]) {
                 classBreakdown[propertyClass].priced++;
-              }
-            } else if (pricingExempt) {
-              // Explicitly marked N/A — exclude from both denominator and missing list
-              if (classBreakdown[propertyClass]) {
-                classBreakdown[propertyClass].pricingExempt = (classBreakdown[propertyClass].pricingExempt || 0) + 1;
               }
             } else {
               // Track commercial properties not yet priced
@@ -2066,8 +1998,6 @@ const ProductionTracker = ({
       // FIX: Use classBreakdown for commercial pricing (fresh data from processing loop)
       // NOT commercialCounts.priced which uses stale inspectionData prop
       const totalCommercialPriced = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0);
-      const totalPricingExempt = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.pricingExempt || 0), 0);
-      const pricingDenominator = Math.max(totalCommercialProperties - totalPricingExempt, 0);
 
       const validationReportData = {
         summary: {
@@ -2120,9 +2050,8 @@ const ProductionTracker = ({
             acc[insp] = (acc[insp] || 0) + 1;
             return acc;
           }, {}),
-          total_commercial: pricingDenominator,
-          total_priced: totalCommercialPriced,
-          total_pricing_exempt: totalPricingExempt
+          total_commercial: ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.total || 0), 0),
+          total_priced: ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0)
         },
         detailed_missing: missingPricedProperties
       };
@@ -2144,10 +2073,8 @@ const ProductionTracker = ({
         commercialInspections: totalCommercialInspected,
         commercialPricing: totalCommercialPriced,
         totalCommercialProperties,
-        commercialPricingDenominator: pricingDenominator,
-        commercialPricingExempt: totalPricingExempt,
         commercialCompletePercent: totalCommercialProperties > 0 ? Math.round((totalCommercialInspected / totalCommercialProperties) * 100) : 0,
-        pricingCompletePercent: pricingDenominator > 0 ? Math.round((totalCommercialPriced / pricingDenominator) * 100) : 0,
+        pricingCompletePercent: totalCommercialProperties > 0 ? Math.round((totalCommercialPriced / totalCommercialProperties) * 100) : 0,
 
         // Track overrides applied during processing
         overridesAppliedCount: decisionsToApply.length
@@ -2415,7 +2342,7 @@ const ProductionTracker = ({
 
       // Update commercial counts to match analytics
       setCommercialCounts({
-        total: analyticsResult.commercialPricingDenominator ?? analyticsResult.totalCommercialProperties,
+        total: analyticsResult.totalCommercialProperties,
         inspected: analyticsResult.commercialInspections,
         priced: analyticsResult.commercialPricing
       });
@@ -4500,7 +4427,7 @@ const exportMissingPropertiesReport = () => {
                 ) : (
                   <>
                     {/* Summary Cards */}
-                    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+                    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
                       <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
                         <div className="flex items-center justify-between">
                           <div>
@@ -4542,17 +4469,6 @@ const exportMissingPropertiesReport = () => {
                             </p>
                           </div>
                           <TrendingUp className="w-8 h-8 text-yellow-500" />
-                        </div>
-                      </div>
-
-                      <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                        <div className="flex items-center justify-between">
-                          <div>
-                            <p className="text-sm text-gray-600 font-medium">Marked N/A</p>
-                            <p className="text-2xl font-bold text-gray-800">{missingPricedReport.summary.total_pricing_exempt || 0}</p>
-                            <p className="text-xs text-gray-500">Excluded from denominator</p>
-                          </div>
-                          <Lock className="w-8 h-8 text-gray-400" />
                         </div>
                       </div>
                     </div>
@@ -4600,7 +4516,6 @@ const exportMissingPropertiesReport = () => {
                               <th className="px-3 py-2 text-left font-medium text-gray-700">Measure Date</th>
                               <th className="px-3 py-2 text-left font-medium text-gray-700">Price By</th>
                               <th className="px-3 py-2 text-left font-medium text-gray-700">Price Date</th>
-                              <th className="px-3 py-2 text-left font-medium text-gray-700">Action</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -4620,16 +4535,6 @@ const exportMissingPropertiesReport = () => {
                                 <td className="px-3 py-2">{property.measure_date ? new Date(property.measure_date).toLocaleDateString() : '-'}</td>
                                 <td className="px-3 py-2">{property.price_by || '-'}</td>
                                 <td className="px-3 py-2">{property.price_date ? new Date(property.price_date).toLocaleDateString() : '-'}</td>
-                                <td className="px-3 py-2">
-                                  <button
-                                    onClick={() => setPricingOverride(property.composite_key, false)}
-                                    disabled={!!pricingOverrideUpdating[property.composite_key]}
-                                    className="px-2 py-1 text-xs bg-gray-200 hover:bg-gray-300 text-gray-800 rounded disabled:opacity-50"
-                                    title="Mark as not requiring pricing (e.g. converting to non-commercial class)"
-                                  >
-                                    {pricingOverrideUpdating[property.composite_key] ? '...' : 'Mark N/A'}
-                                  </button>
-                                </td>
                               </tr>
                             ))}
                           </tbody>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -2527,6 +2527,30 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       return;
     }
 
+    // Format a Postgres date (YYYY-MM-DD or YYYY-MM-DDT...) without any
+    // timezone shift. `new Date('2026-05-14')` parses as UTC midnight and
+    // toLocaleDateString() then shifts it back to local time, which in any
+    // tz west of UTC drops a day (5/14 -> 5/13). Matches the UI helper at
+    // line ~847.
+    const formatDateLocal = (dateVal) => {
+      if (!dateVal) return '-';
+      const str = String(dateVal);
+      const datePart = str.split('T')[0];
+      const parts = datePart.split('-');
+      if (parts.length === 3) {
+        const y = parseInt(parts[0], 10);
+        const m = parseInt(parts[1], 10);
+        const d = parseInt(parts[2], 10);
+        if (!isNaN(y) && !isNaN(m) && !isNaN(d)) {
+          const local = new Date(y, m - 1, d);
+          return local.toLocaleDateString();
+        }
+      }
+      // Fallback for non-ISO strings (e.g. already formatted)
+      const fallback = new Date(dateVal);
+      return isNaN(fallback.getTime()) ? '-' : fallback.toLocaleDateString();
+    };
+
     // Prepare data for export with all available fields
     const exportData = filteredAppeals.map(appeal => {
       // Get property for bracket and inspection data
@@ -2543,14 +2567,22 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         }
       }
 
-      // Get inspection info from property
+      // Get inspection info from property — parse YYYY-MM-DD locally
+      // (no timezone shift) so the date matches what's shown in the UI.
       let inspectionDate = null;
       if (property && property.inspection_list_by && property.inspection_list_date) {
-        const date = new Date(property.inspection_list_date);
-        const month = String(date.getMonth() + 1).padStart(2, '0');
-        const day = String(date.getDate()).padStart(2, '0');
-        const year = date.getFullYear();
-        inspectionDate = `${month}/${day}/${year}`;
+        const str = String(property.inspection_list_date).split('T')[0];
+        const parts = str.split('-');
+        if (parts.length === 3) {
+          const y = parseInt(parts[0], 10);
+          const mo = parseInt(parts[1], 10);
+          const d = parseInt(parts[2], 10);
+          if (!isNaN(y) && !isNaN(mo) && !isNaN(d)) {
+            const month = String(mo).padStart(2, '0');
+            const day = String(d).padStart(2, '0');
+            inspectionDate = `${month}/${day}/${y}`;
+          }
+        }
       }
 
       return {
@@ -2576,8 +2608,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         'Atty City/State': appeal.attorney_city_state || '-',
         'Atty Phone': appeal.attorney_phone || '-',
         'Atty Email': appeal.attorney_email || '-',
-        'Evidence Due': appeal.evidence_due_date ? new Date(appeal.evidence_due_date).toLocaleDateString() : '-',
-        'Hearing Date': appeal.hearing_date ? new Date(appeal.hearing_date).toLocaleDateString() : '-',
+        'Evidence Due': formatDateLocal(appeal.evidence_due_date),
+        'Hearing Date': formatDateLocal(appeal.hearing_date),
         'Evidence Status': appeal.evidence_status || '-',
         'Submission Type': appeal.submission_type || '-',
         'Stip Status': appeal.stip_status || '-',


### PR DESCRIPTION
### Summary
Adds PDF export capabilities to the Appeals Summary and Inspection Info components, introduces a year filter with interior inspection tracking to Inspection Info, and fixes an off-by-one date bug in the Appeal Log Excel export.

### Problem
Partners and state auditors needed shareable PDF snapshots of the Appeals Summary and Inspection Info reports. The Inspection Info component also lacked year-based filtering and interior inspection tracking required for annual state audits. Additionally, the Appeal Log Excel export was displaying dates one day behind what the UI showed due to UTC timezone shifting.

### Key Changes

- **Appeals Summary — PDF Export**
  - Added `exportPDF` function using `jsPDF` + `jspdf-autotable` matching the existing Lojik invoice/proposal styling (blue header, logo, landscape letter format)
  - PNG logo is converted to JPEG via canvas to strip the alpha channel that was causing jsPDF to corrupt text rendering (white header text bug)
  - Table includes all columns with color-coded rows: green tint for all-CME jobs, blue tint for the totals row
  - Added `Export PDF` button to the UI toolbar

- **Inspection Info — Year Filter & Interior Inspection Tracking**
  - Added `selectedYear` state with a year selector dropdown gating on measure date (a property measured in a prior year does not count toward the current year's entry rate)
  - Added `Improved Interior Entries` summary card with rate and progress bar
  - Added `exportPDF` function for a state-audit-ready PDF snapshot filtered by selected year
  - Displays a warning banner when no properties have a measure date in the selected year

- **ProductionTracker — Commercial Override Pricing Credit**
  - Commercial property overrides now also count toward pricing stats, since the override represents a completed inspection stamp
  - Zero-improvement validation now only fires on primary cards and skips Special codes (additional cards always store `$0` by vendor design)
  - Missing properties report now includes the `card` field for clearer identification

- **Appeal Log — Date Off-by-One Fix**
  - Replaced `new Date(dateString).toLocaleDateString()` with a local-date parser that splits the `YYYY-MM-DD` string directly, preventing UTC midnight → local timezone day-shift (e.g. `5/14` rendering as `5/13` in western timezones)
  - Applied to `Evidence Due`, `Hearing Date`, and `inspection_list_date` fields in the Excel export


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/fractal-nail-wmse7hnt"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-fractal-nail-wmse7hnt_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 187`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>fractal-nail-wmse7hnt</branchName>-->