### PR TITLE
Fix directory picker id exceeding 32-char limit

### DIFF
--- a/LOCAL_PHOTO_SOURCE.md
+++ b/LOCAL_PHOTO_SOURCE.md
@@ -7,6 +7,33 @@ up exactly where this one stops.
 
 ---
 
+## Next branch, do this first (post-merge picker fix)
+
+PR #189 merged before the picker fix landed. If `pickJobSource` throws or the
+folder picker never opens, it's because `showDirectoryPicker`'s `id` option is
+capped at 32 characters and only allows `[a-zA-Z0-9_-]`. The original code
+passed `lojik-photos-job-${jobId}` where `jobId` is a 36-char UUID — total
+length 53, which silently fails in Chrome.
+
+**Fix (one line) in `src/lib/localPhotoSource.js`, inside `pickJobSource`:**
+
+```js
+// before
+handle = await window.showDirectoryPicker({ id: `lojik-photos-job-${jobId}`, mode: 'read' });
+// after
+handle = await window.showDirectoryPicker({ id: `lojik-photos-${ccdd}`, mode: 'read' });
+```
+
+Why CCDD instead of jobId: the picker `id` only controls which "last folder"
+Chrome remembers between sessions. Scoping it by CCDD (4 digits) is short,
+stable, and actually more useful — every Job in the same Town will reopen to
+the same Pictures folder. The jobId scoping was over-specific and broke the
+length limit.
+
+This change has been applied on this branch.
+
+---
+
 ## Goal (what we're ultimately building)
 
 Replace the PowerComp PDF rip flow with a direct read of the photos already

--- a/src/lib/localPhotoSource.js
+++ b/src/lib/localPhotoSource.js
@@ -361,7 +361,7 @@ export async function pickJobSource(jobId, ccdd, opts = {}) {
   }
   let handle;
   try {
-    handle = await window.showDirectoryPicker({ id: `lojik-photos-job-${jobId}`, mode: 'read' });
+    handle = await window.showDirectoryPicker({ id: `lojik-photos-${ccdd}`, mode: 'read' });
   } catch (e) {
     if (e?.name === 'AbortError') return { ok: false, reason: 'cancelled' };
     return { ok: false, reason: e?.message || String(e) };


### PR DESCRIPTION
### Summary
Fixes a silent failure in the folder picker caused by passing an `id` string that exceeded Chrome's 32-character limit for `showDirectoryPicker`. The picker would silently fail to open, breaking the local photo source flow.

### Problem
The `pickJobSource` function passed `lojik-photos-job-${jobId}` as the `id` option to `showDirectoryPicker`. Since `jobId` is a 36-character UUID, the resulting string was 53 characters long — well over Chrome's 32-character cap (which also only allows `[a-zA-Z0-9_-]`). This caused the folder picker to silently fail, meaning users could never select a photo directory.

### Solution
Replace the `id` value with `lojik-photos-${ccdd}`, using the 4-digit CCDD code instead of the full UUID. This keeps the string well within the 32-character limit while still providing meaningful scoping per Town — so every Job in the same Town will reopen to the same last-used folder.

### Key Changes
- **`src/lib/localPhotoSource.js`**: Changed `showDirectoryPicker` `id` from `lojik-photos-job-${jobId}` (53 chars, broken) to `lojik-photos-${ccdd}` (short, valid, and more useful)
- **`LOCAL_PHOTO_SOURCE.md`**: Added a post-merge note documenting the root cause, the fix, and the rationale for using CCDD over jobId scoping

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/nova-fang-iff7kjwi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-nova-fang-iff7kjwi_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 190`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>nova-fang-iff7kjwi</branchName>-->