### PR TITLE
Fix photo strip, PDF page order, and add VLA photo support

### DIFF
--- a/src/components/job-modules/ParcelPhotoStrip.jsx
+++ b/src/components/job-modules/ParcelPhotoStrip.jsx
@@ -52,9 +52,20 @@ function ParcelColumn({ parcel, jobId, savedPhoto, onSaved }) {
   const photos = useMemo(() => [...folderPhotos, ...extras], [folderPhotos, extras]);
 
   const [focusIdx, setFocusIdx] = useState(() => Math.max(0, photos.length - 1));
+  // Default the focused photo to the one already saved as Front (if any),
+  // otherwise fall back to the last photo in the list. Re-runs whenever the
+  // photo list changes or the saved Front pick changes so flipping the star
+  // immediately re-anchors the view.
   useEffect(() => {
+    if (savedPhoto?.original_filename && photos.length > 0) {
+      const idx = photos.findIndex((p) => p.name === savedPhoto.original_filename);
+      if (idx >= 0) {
+        setFocusIdx(idx);
+        return;
+      }
+    }
     setFocusIdx((i) => Math.min(Math.max(0, i), Math.max(0, photos.length - 1)));
-  }, [photos.length]);
+  }, [photos, savedPhoto?.original_filename]);
 
   const [previewUrl, setPreviewUrl] = useState(null);
   const previewUrlRef = useRef(null);

--- a/src/components/job-modules/ParcelPhotoStrip.jsx
+++ b/src/components/job-modules/ParcelPhotoStrip.jsx
@@ -40,7 +40,7 @@ function safeStorageKey(s) {
 // Per-parcel column
 // ---------------------------------------------------------------------------
 
-function ParcelColumn({ parcel, jobId, savedPhoto, onSaved }) {
+function ParcelColumn({ parcel, jobId, savedPhoto, onSaved, pickLabel = 'Front' }) {
   const { getPhotosFor, connected } = useJobPhotoSource();
   const folderPhotos = useMemo(
     () => getPhotosFor(parcel.block, parcel.lot, parcel.qualifier),
@@ -275,11 +275,11 @@ function ParcelColumn({ parcel, jobId, savedPhoto, onSaved }) {
               ? 'bg-green-100 text-green-800'
               : 'bg-yellow-400 text-yellow-900 hover:bg-yellow-500 disabled:opacity-40 disabled:bg-gray-100 disabled:text-gray-400'
           }`}
-          title="Use as front photo"
+          title={`Use as ${pickLabel.toLowerCase()} photo for the report`}
         >
           {saving ? <Loader2 size={10} className="animate-spin" />
             : isPicked ? <Check size={10} /> : <Star size={10} />}
-          {isPicked ? 'Front' : 'Use'}
+          {isPicked ? pickLabel : 'Use'}
         </button>
         <button
           type="button"
@@ -381,7 +381,7 @@ export function ExportPhotosPreview({ jobId, parcels = [], appealNumber = '' }) 
 // Main: compact horizontal strip aligned with the comp grid above
 // ---------------------------------------------------------------------------
 
-export default function ParcelPhotoStrip({ jobId, parcels = [] }) {
+export default function ParcelPhotoStrip({ jobId, parcels = [], pickLabel = 'Front' }) {
   const { connected, indexResult, source } = useJobPhotoSource();
   const [savedMap, setSavedMap] = useState({});
 
@@ -437,6 +437,7 @@ export default function ParcelPhotoStrip({ jobId, parcels = [] }) {
             key={`${p.roleLabel}::${p.composite_key}`}
             parcel={p}
             jobId={jobId}
+            pickLabel={pickLabel}
             savedPhoto={savedMap[p.composite_key]}
             onSaved={(row) => setSavedMap((m) => ({ ...m, [row.property_composite_key]: row }))}
           />

--- a/src/components/job-modules/ParcelPhotoStrip.jsx
+++ b/src/components/job-modules/ParcelPhotoStrip.jsx
@@ -358,7 +358,7 @@ export function ExportPhotosPreview({ jobId, parcels = [], appealNumber = '' }) 
         {parcels.map((p) => {
           const url = urls[p.composite_key];
           return (
-            <div key={p.composite_key} className="flex-1 min-w-0">
+            <div key={`${p.roleLabel}::${p.composite_key}`} className="flex-1 min-w-0">
               <div className="text-center mb-1">
                 <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${p.roleColor}`}>{p.roleLabel}</span>
               </div>
@@ -430,8 +430,11 @@ export default function ParcelPhotoStrip({ jobId, parcels = [] }) {
       >
         <div aria-hidden="true" />
         {parcels.map((p) => (
+          // Key must be role-scoped: when COMP 1 IS the subject sale, both
+          // SUBJECT and COMP 1 carry the same composite_key on purpose so they
+          // both render and both pull the same saved Front photo.
           <ParcelColumn
-            key={p.composite_key}
+            key={`${p.roleLabel}::${p.composite_key}`}
             parcel={p}
             jobId={jobId}
             savedPhoto={savedMap[p.composite_key]}

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3996,15 +3996,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
                                 <Camera className="w-4 h-4" />
                               </button>
                             )}
-                            {hasPacket && (
-                              <button
-                                onClick={() => handlePreviewPhotoPacket(key)}
-                                className="text-teal-600 hover:text-teal-800 p-1 hover:bg-teal-50 rounded"
-                                title={`PowerComp photo packet on file (legacy) (${photoPacketsByKey[key].page_count || '?'} pages) — click to preview`}
-                              >
-                                <ImageIcon className="w-4 h-4" />
-                              </button>
-                            )}
+                            {/* Legacy PowerComp photo-packet preview hidden per request —
+                                superseded by the local-folder photo workflow. The packet
+                                is still appended to printed reports when one is on file. */}
                             <button
                               onClick={() => handlePrintAppeal(appeal)}
                               disabled={printingAppealId === appeal.id || !printable}

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -387,14 +387,15 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     // Appellant comps intentionally NOT included here. They get their own
     // photos via the Appellant Evidence flow when those parcels are searched
     // separately as detailed-grid subjects.
-    // Dedupe only on real composite_keys (synthetic slot-N keys are unique by
-    // construction). Subject is preserved; only later duplicates are dropped.
+    // Dedupe by (roleLabel + composite_key) so a comp that is the subject
+    // sale (same composite_key as SUBJECT) still gets its own COMP cell —
+    // we only suppress true duplicates within the same role.
     const seen = new Set();
     return out.filter((p) => {
-      if (!p.composite_key.startsWith('slot-')) {
-        if (seen.has(p.composite_key)) return false;
-        seen.add(p.composite_key);
-      }
+      if (p.composite_key.startsWith('slot-')) return true;
+      const dedupeKey = `${p.roleLabel}::${p.composite_key}`;
+      if (seen.has(dedupeKey)) return false;
+      seen.add(dedupeKey);
       return true;
     });
   }, [subject, comps]);
@@ -1962,6 +1963,13 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     const subjectBlockLot = `${subject.property_block}/${subject.property_lot}${subject.property_qualifier ? '/' + subject.property_qualifier : ''}`;
     addHeader(subjectBlockLot);
 
+    // Section page-range tracker. We render sections in their existing order
+    // and use jsPDF.movePage at the end to put them in the report order:
+    // Static → Dynamic → Photos → Map → Evidence → Ch123. Each end-marker is
+    // captured right after its block runs (or skipped, in which case the
+    // section's start..end is empty and contributes no pages).
+    const sectionEnds = { initial: doc.getNumberOfPages() };
+
     // Prepare table data
     const visibleAttributes = allAttributes
       .filter(attr => rowVisibility[attr.id])
@@ -2238,6 +2246,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
         doc.setFontSize(prevSize);
       }
     });
+    sectionEnds.staticEnd = doc.getNumberOfPages();
 
     // Page 2: Dynamic adjustments (if any exist and are visible)
     if (dynamicAttrs.length > 0) {
@@ -2427,6 +2436,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
           }
         });
       }
+      sectionEnds.dynamicEnd = doc.getNumberOfPages();
     }
 
     // ==================== APPELLANT EVIDENCE SUMMARY PAGE ====================
@@ -2763,6 +2773,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     } catch (e) {
       console.error('Failed to render appellant evidence summary page:', e);
     }
+    sectionEnds.evidenceEnd = doc.getNumberOfPages();
 
     // ==================== CHAPTER 123 TEST ====================
     // Add Chapter 123 Analysis on a new page. User can suppress entirely via the
@@ -2908,6 +2919,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       ch123TableEndY + 12
     );
     } // end !hideDirectorsRatio
+    sectionEnds.ch123End = doc.getNumberOfPages();
 
     // ============== Subject + Comps Map page (optional) ==============
     if (includeMap && mapHasSubject && mapCaptureRef.current) {
@@ -3039,6 +3051,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
         console.warn('Map capture failed:', mapErr);
       }
     }
+    sectionEnds.mapEnd = doc.getNumberOfPages();
 
     // ============== Subject & Comps Photos page (optional) ==============
     // Pulls picked front photos from `appeal_photos` for every parcel in
@@ -3142,11 +3155,6 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
               doc.setFontSize(18);
               doc.setFont('helvetica', 'bold');
               doc.text(blqLabel, PAGE_W - lMargin, hY + 10, { align: 'right' });
-
-              doc.setFontSize(13);
-              doc.setTextColor(...lojikBlue);
-              doc.setFont('helvetica', 'bold');
-              doc.text('Subject & Comps Photos', PAGE_W / 2, lMargin + 28, { align: 'center' });
             };
             const drawPhotoPageFooter = () => {
               doc.setFontSize(7);
@@ -3241,6 +3249,59 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       } catch (photosErr) {
         console.warn('Photos page generation failed:', photosErr);
       }
+    }
+    sectionEnds.photosEnd = doc.getNumberOfPages();
+
+    // ==================== REORDER PAGES ====================
+    // Render order above is: Static → Dynamic → Evidence → Ch123 → Map → Photos.
+    // Final report order should be: Static → Dynamic → Photos → Map → Evidence → Ch123.
+    // We use doc.movePage to shuffle pages into the desired order without
+    // re-rendering anything.
+    try {
+      const rangeFor = (startEnd, endEnd) => {
+        const start = (startEnd || 0) + 1;
+        const end = endEnd || 0;
+        if (end < start) return [];
+        const out = [];
+        for (let p = start; p <= end; p++) out.push(p);
+        return out;
+      };
+      const staticPages   = rangeFor(0, sectionEnds.staticEnd);
+      const dynamicPages  = rangeFor(sectionEnds.staticEnd, sectionEnds.dynamicEnd ?? sectionEnds.staticEnd);
+      const evidencePages = rangeFor(sectionEnds.dynamicEnd ?? sectionEnds.staticEnd, sectionEnds.evidenceEnd);
+      const ch123Pages    = rangeFor(sectionEnds.evidenceEnd, sectionEnds.ch123End);
+      const mapPages      = rangeFor(sectionEnds.ch123End, sectionEnds.mapEnd);
+      const photosPages   = rangeFor(sectionEnds.mapEnd, sectionEnds.photosEnd);
+
+      // Desired order of original page numbers
+      const originalOrder = [
+        ...staticPages,
+        ...dynamicPages,
+        ...photosPages,
+        ...mapPages,
+        ...evidencePages,
+        ...ch123Pages,
+      ];
+
+      // Build current ordering as a list of "original page numbers" then walk
+      // each desired position and shuffle via movePage. Track shifts in our
+      // local array so the next move uses correct current-positions.
+      const total = doc.getNumberOfPages();
+      if (originalOrder.length === total) {
+        const current = [];
+        for (let i = 1; i <= total; i++) current.push(i);
+        for (let target = 0; target < originalOrder.length; target++) {
+          const wantedOrigPage = originalOrder[target];
+          const curIdx = current.indexOf(wantedOrigPage);
+          if (curIdx === target) continue;
+          // jsPDF.movePage(targetPage, beforePage) — both 1-indexed.
+          doc.movePage(curIdx + 1, target + 1);
+          const [moved] = current.splice(curIdx, 1);
+          current.splice(target, 0, moved);
+        }
+      }
+    } catch (reorderErr) {
+      console.warn('PDF page reorder failed:', reorderErr);
     }
 
     // Save the PDF with CME naming format: CME_ccdd_block_lot_qualifier.pdf

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -231,8 +231,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   const [hideAppellantEvidence, setHideAppellantEvidence] = useState(() => readToggle('detailedExport_hideAppellantEvidence', false));
   const [hideDirectorsRatio, setHideDirectorsRatio] = useState(() => readToggle('detailedExport_hideDirectorsRatio', false));
   const [includePhotos, setIncludePhotos] = useState(() => readToggle('detailedExport_includePhotos', true));
-  // Map preview is collapsed by default (it dominated the modal). Click to expand.
-  const [mapExpanded, setMapExpanded] = useState(() => readToggle('detailedExport_mapExpanded', false));
+  // Map preview defaults to expanded — easier to confirm the auto-zoom and
+  // marker placement at a glance before exporting. Persisted toggle still
+  // remembers the user's last choice across sessions.
+  const [mapExpanded, setMapExpanded] = useState(() => readToggle('detailedExport_mapExpanded', true));
 
   // Persist toggle state across sessions
   useEffect(() => { try { localStorage.setItem('detailedExport_showAdjustments', String(showAdjustments)); } catch (e) {} }, [showAdjustments]);

--- a/src/components/job-modules/final-valuation-tabs/VacantLandAppraisalTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/VacantLandAppraisalTab.jsx
@@ -6,6 +6,7 @@ import autoTable from 'jspdf-autotable';
 import html2canvas from 'html2canvas';
 import GeocodeStatusChip from '../../GeocodeStatusChip';
 import AppealMap from '../../AppealMap';
+import ParcelPhotoStrip from '../ParcelPhotoStrip';
 
 // Canonical category values matching Method 1 dropdown
 const CATEGORY_OPTIONS = [
@@ -98,7 +99,46 @@ const VacantLandAppraisalTab = ({
   // <AppealMap> rendered inside the export modal so html2canvas can snap
   // it during PDF generation without the user seeing a flash.
   const [includeMap, setIncludeMap] = useState(true);
+  // Vacant-land photos default to ON. For raw land, the picked Front photo
+  // is often a satellite/boundary screenshot the user pasted in via the
+  // strip below the grid.
+  const [includePhotos, setIncludePhotos] = useState(true);
   const mapCaptureRef = useRef(null);
+
+  // Build the per-parcel photo strip payload (Subject + populated Comps).
+  // Mirrors DetailedAppraisalGrid's pattern so a comp that happens to share
+  // the subject's composite_key still gets its own cell (role-scoped key).
+  const photoStripParcels = useMemo(() => {
+    const out = [];
+    const subj = loadedProperties?.subject;
+    if (subj?.property_composite_key) {
+      out.push({
+        composite_key: subj.property_composite_key,
+        block: subj.property_block,
+        lot: subj.property_lot,
+        qualifier: subj.property_qualifier,
+        address: subj.property_location || '',
+        roleLabel: 'SUBJECT',
+        roleColor: 'bg-red-100 text-red-800',
+      });
+    }
+    [0, 1, 2, 3, 4].forEach((i) => {
+      const c = loadedProperties?.[`comp_${i}`];
+      if (!c) return;
+      const slotKey = c.property_composite_key || `slot-${i + 1}`;
+      out.push({
+        composite_key: slotKey,
+        block: c.property_block,
+        lot: c.property_lot,
+        qualifier: c.property_qualifier,
+        address: c.property_location || '',
+        roleLabel: `COMP ${i + 1}`,
+        roleColor: 'bg-blue-100 text-blue-800',
+        hasParcelKey: !!c.property_composite_key,
+      });
+    });
+    return out;
+  }, [loadedProperties]);
 
   // Build subject + comp lat/lng payload for AppealMap. Uses applyGeocodePatch
   // so any inline edits made via the chip are reflected immediately.
@@ -857,11 +897,165 @@ const VacantLandAppraisalTab = ({
       }
     }
 
+    // ============== Subject + Comps Photos page (optional) ==============
+    // Pulls the picked Front photo from `appeal_photos` for every parcel in
+    // photoStripParcels (Subject + populated Comps). Skipped silently if
+    // includePhotos is off, no jobId, no parcels, or none have a saved pick.
+    if (includePhotos && jobData?.id && photoStripParcels.length > 0) {
+      try {
+        const keys = photoStripParcels.map((p) => p.composite_key).filter(Boolean);
+        const { data: photoRows } = await supabase
+          .from('appeal_photos')
+          .select('storage_path, property_composite_key, original_filename, capture_ts')
+          .eq('job_id', jobData.id)
+          .in('property_composite_key', keys);
+        const photoByKey = {};
+        (photoRows || []).forEach((r) => { photoByKey[r.property_composite_key] = r; });
+        const parcelsWithPhotos = photoStripParcels.filter((p) => photoByKey[p.composite_key]);
+
+        if (parcelsWithPhotos.length > 0) {
+          const photoCells = await Promise.all(parcelsWithPhotos.map(async (p) => {
+            const row = photoByKey[p.composite_key];
+            try {
+              const { data: blob } = await supabase.storage
+                .from('appeal-photos')
+                .download(row.storage_path);
+              if (!blob) return null;
+              const dataUrl = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onloadend = () => resolve(reader.result);
+                reader.onerror = reject;
+                reader.readAsDataURL(blob);
+              });
+              return { parcel: p, dataUrl };
+            } catch (_e) {
+              return null;
+            }
+          }));
+          const usable = photoCells.filter(Boolean);
+          const subjectCell = usable.find((u) => u.parcel.roleLabel === 'SUBJECT') || null;
+          const compCells = usable.filter((u) => u.parcel.roleLabel !== 'SUBJECT');
+
+          if (subjectCell || compCells.length > 0) {
+            // Portrait letter (612 x 792). One subject cell on top, comps on
+            // a row below (3 per page). Page repeats subject if more comps.
+            const PAGE_W = 612;
+            const PAGE_H = 792;
+            const lMargin = 36;
+            const headerH = 56;
+            const footerH = 22;
+            const captionGap = 4;
+            const captionH = 12;
+            const cellPad = 2;
+            const rowGap = 14;
+            const colGap = 14;
+
+            const contentTop = lMargin + headerH;
+            const contentBottom = PAGE_H - lMargin - footerH;
+            const contentH = contentBottom - contentTop;
+            const contentW = PAGE_W - lMargin * 2;
+
+            const subjRowH = Math.floor((contentH - rowGap) * 0.55);
+            const compRowH = contentH - rowGap - subjRowH;
+            const subjPhotoH = subjRowH - captionGap - captionH - cellPad * 2;
+            const compPhotoH = compRowH - captionGap - captionH - cellPad * 2;
+
+            const subjPhotoW = Math.min(contentW * 0.85, subjPhotoH * 1.5);
+            const subjCellW = subjPhotoW + cellPad * 2;
+            const subjCellH = subjPhotoH + cellPad * 2;
+            const subjX = lMargin + (contentW - subjCellW) / 2;
+            const subjY = contentTop;
+
+            const compPhotoW = (contentW - colGap * 2) / 3 - cellPad * 2;
+            const compCellW = compPhotoW + cellPad * 2;
+            const compsY = contentTop + subjRowH + rowGap;
+
+            const drawPhotoPageHeader = () => {
+              if (logoDataUrl) {
+                try { doc.addImage(logoDataUrl, 'PNG', lMargin, lMargin - 5, 80, 35); } catch (_e) {}
+              }
+              let hY = lMargin + 10;
+              if (currentAppealNumber) {
+                doc.setFontSize(10);
+                doc.setFont('helvetica', 'normal');
+                doc.setTextColor(80, 80, 80);
+                doc.text(`Appeal #: ${currentAppealNumber}`, PAGE_W - lMargin, hY, { align: 'right' });
+                hY += 14;
+              }
+              doc.setTextColor(0, 0, 0);
+              doc.setFontSize(16);
+              doc.setFont('helvetica', 'bold');
+              doc.text(subjectBLQ, PAGE_W - lMargin, hY + 10, { align: 'right' });
+            };
+            const drawPhotoPageFooter = () => {
+              doc.setFontSize(7);
+              doc.setTextColor(150, 150, 150);
+              doc.setFont('helvetica', 'italic');
+              doc.text('Subject and comparable photographs.', lMargin, PAGE_H - lMargin + 8);
+              doc.setFont('helvetica', 'normal');
+              doc.text(subjectBLQ, PAGE_W - lMargin, PAGE_H - lMargin + 8, { align: 'right' });
+            };
+            const drawSubjectCell = () => {
+              if (!subjectCell) return;
+              try {
+                doc.addImage(subjectCell.dataUrl, 'JPEG', subjX + cellPad, subjY + cellPad, subjPhotoW, subjPhotoH, undefined, 'FAST');
+              } catch (_e) {
+                try { doc.addImage(subjectCell.dataUrl, 'PNG', subjX + cellPad, subjY + cellPad, subjPhotoW, subjPhotoH, undefined, 'FAST'); } catch (_e2) {}
+              }
+              doc.setFontSize(11);
+              doc.setTextColor(140, 0, 0);
+              doc.setFont('helvetica', 'bold');
+              doc.text('Subject', subjX + subjCellW / 2, subjY + subjCellH + captionGap + captionH - 2, { align: 'center' });
+            };
+            const drawCompRow = (slots) => {
+              const totalW = compCellW * slots.length + colGap * Math.max(0, slots.length - 1);
+              const startX = lMargin + (contentW - totalW) / 2;
+              slots.forEach((cell, i) => {
+                const x = startX + i * (compCellW + colGap);
+                if (cell) {
+                  try {
+                    doc.addImage(cell.dataUrl, 'JPEG', x + cellPad, compsY + cellPad, compPhotoW, compPhotoH, undefined, 'FAST');
+                  } catch (_e) {
+                    try { doc.addImage(cell.dataUrl, 'PNG', x + cellPad, compsY + cellPad, compPhotoW, compPhotoH, undefined, 'FAST'); } catch (_e2) {}
+                  }
+                }
+                doc.setFontSize(10);
+                doc.setTextColor(30, 60, 140);
+                doc.setFont('helvetica', 'bold');
+                doc.text(
+                  cell ? cell.parcel.roleLabel : '',
+                  x + compCellW / 2,
+                  compsY + compPhotoH + cellPad * 2 + captionGap + captionH - 2,
+                  { align: 'center' },
+                );
+              });
+            };
+
+            doc.addPage([PAGE_W, PAGE_H], 'portrait');
+            drawPhotoPageHeader();
+            drawSubjectCell();
+            drawCompRow(compCells.slice(0, 3));
+            drawPhotoPageFooter();
+
+            if (compCells.length > 3) {
+              doc.addPage([PAGE_W, PAGE_H], 'portrait');
+              drawPhotoPageHeader();
+              drawSubjectCell();
+              drawCompRow(compCells.slice(3, 5));
+              drawPhotoPageFooter();
+            }
+          }
+        }
+      } catch (photosErr) {
+        console.warn('Vacant land photos page generation failed:', photosErr);
+      }
+    }
+
     const ccdd = jobData?.ccdd || 'UNKNOWN';
     const fileName = `VLA_${ccdd}_${vacantLandSubject.block}_${vacantLandSubject.lot}${vacantLandSubject.qualifier ? '_' + vacantLandSubject.qualifier : ''}.pdf`;
     doc.save(fileName);
     setShowExportModal(false);
-  }, [loadedProperties, vacantLandSubject, vacantLandResult, recalculatedValue, valuationMethod, jobData, appealNumber, getExportValue, getUnitLabel, applyGeocodePatch, includeMap, mapHasSubject]);
+  }, [loadedProperties, vacantLandSubject, vacantLandResult, recalculatedValue, valuationMethod, jobData, appealNumber, getExportValue, getUnitLabel, applyGeocodePatch, includeMap, mapHasSubject, includePhotos, photoStripParcels]);
 
   const subjectProp = loadedProperties.subject;
 
@@ -1556,6 +1750,15 @@ const VacantLandAppraisalTab = ({
               </tbody>
             </table>
           </div>
+
+          {/* Per-parcel photo strip (Subject + Comps). For vacant land most
+              parcels won't have a folder photo — the user typically pastes a
+              satellite/boundary capture or uploads a manual file via the cell. */}
+          {photoStripParcels.length > 0 && (
+            <div className="px-3 pb-3">
+              <ParcelPhotoStrip jobId={jobData?.id} parcels={photoStripParcels} />
+            </div>
+          )}
         </div>
       )}
 
@@ -1733,6 +1936,15 @@ const VacantLandAppraisalTab = ({
                     className="rounded border-gray-300"
                   />
                   Include map page
+                </label>
+                <label className="flex items-center gap-1.5 text-xs text-gray-700 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={includePhotos}
+                    onChange={(e) => setIncludePhotos(e.target.checked)}
+                    className="rounded border-gray-300"
+                  />
+                  Include photos page
                 </label>
               </div>
               <div className="flex gap-3">

--- a/src/components/job-modules/final-valuation-tabs/VacantLandAppraisalTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/VacantLandAppraisalTab.jsx
@@ -1756,7 +1756,7 @@ const VacantLandAppraisalTab = ({
               satellite/boundary capture or uploads a manual file via the cell. */}
           {photoStripParcels.length > 0 && (
             <div className="px-3 pb-3">
-              <ParcelPhotoStrip jobId={jobData?.id} parcels={photoStripParcels} />
+              <ParcelPhotoStrip jobId={jobData?.id} parcels={photoStripParcels} pickLabel="Selected" />
             </div>
           )}
         </div>


### PR DESCRIPTION
### Summary
This PR addresses several issues in the Detailed Appraisal and Vacant Land Appraisal export workflows: fixing duplicate-key bugs in the photo strip, reordering PDF export pages, hiding the legacy PowerComp photo preview, and extending the local-folder photo picker to the Vacant Land Appraisal component.

### Problem
- The photo strip rendered duplicate React keys when a comp shared the same composite key as the subject sale, causing React warnings and missing/duplicated cells.
- The PDF export page order was inconsistent — photos, map, evidence, and ratio study pages were not always in the correct sequence.
- The legacy PowerComp photo-packet preview button cluttered the Appeal Log UI despite being superseded by the local-folder workflow.
- The Vacant Land Appraisal had no photo picker or photo page in its PDF export, even though appraisers sometimes capture street or satellite images for vacant parcels.
- The map preview in the export modal defaulted to collapsed, making it hard to verify marker placement before exporting.
- The photo viewer did not default focus to the already-saved "Front" photo when reopening a parcel column.

### Solution
- Scope React keys by `roleLabel::composite_key` so subject and comp cells with the same parcel key each render independently.
- Track section page ranges during PDF generation and use `movePage` to enforce the correct order: Static Attributes → Dynamic Attributes → Photos → Map → Appellant Evidence → Director's Ratio Study.
- Hide the legacy PowerComp photo-packet preview button in the Appeal Log (packet still appends to printed reports when on file).
- Add `ParcelPhotoStrip` and a photos page to the Vacant Land Appraisal component and its PDF export, with the pick label changed to "Selected" (instead of "Front") to better reflect vacant land imagery.
- Default the map preview to expanded in the export modal.
- Default the focused photo in each parcel column to the already-saved pick, re-anchoring whenever the saved selection changes.

### Key Changes
- **`ParcelPhotoStrip.jsx`**: Added `pickLabel` prop (defaults to `'Front'`); scoped all React keys to `roleLabel::composite_key`; updated `useEffect` to default focus to the saved photo by filename; fixed deduplication logic in `DetailedAppraisalGrid` to use role-scoped keys.
- **`AppealLogTab.jsx`**: Removed the legacy PowerComp photo-packet preview button; replaced with a comment noting it is superseded by the local-folder workflow.
- **`DetailedAppraisalGrid.jsx`**: Added `sectionEnds` tracker to capture page ranges per section and reorder PDF pages correctly after generation; changed map preview default to expanded (`true`).
- **`VacantLandAppraisalTab.jsx`**: Built `photoStripParcels` memo for subject + comps; rendered `ParcelPhotoStrip` with `pickLabel="Selected"` below the comp table; added photos page generation to the PDF export (mirrors the detailed grid layout); added "Include photos page" checkbox to the export modal.

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/circular-rhythm-mpwjumkv"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-circular-rhythm-mpwjumkv_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 194`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>circular-rhythm-mpwjumkv</branchName>-->