### PR TITLE
Retire legacy PowerComp photo ripper from PDF output

### DIFF
--- a/copilot-os.md
+++ b/copilot-os.md
@@ -839,4 +839,4 @@ This codebase has been built iteratively over the course of a year. Every patter
 
 15. **Sales-pool window math is shared and Lojik-aware** — `SalesComparisonTab.getCSPDateRange`, `AppellantEvidencePanel.sampleRange`, `DetailedAppraisalGrid` (inline in the comps prep), the admin Geocoder's `csvSalesWindow`, and `CoordinatesSubTab.salesWindow` all anchor on `jobs.end_date` and all subtract one from the year when `organizations.org_type === 'assessor'` (Lojik). Don't fork this convention. If the window definition needs to change, change all five usages together — and confirm with the user, because that math is the basis for sales review, sales pool inclusion, comp date ranges, and the coordinate cleanup queue.
 
-😊
+😊📸

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -2270,8 +2270,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
     }
     const reportBytes = new Uint8Array(await rptBlob.arrayBuffer());
 
+    // Legacy PowerComp PDF photo-ripper output is no longer merged at print
+    // time. The Photos page emitted by DetailedAppraisalGrid / VacantLand from
+    // the picker is now the sole source of subject + comp photos. Old
+    // `appeal_powercomp_photos` rows / `powercomp-photos` blobs may still
+    // exist for legacy subjects but are intentionally ignored here.
     const key = compositeKeyForAppeal(appeal);
-    const photoBytes = await fetchPhotoPacketBytes(key);
 
     // Even with no photos, we still want to enforce the canonical section
     // order in the saved report:
@@ -2317,7 +2321,16 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         const idx = i - 1;
         if (text.includes('chapter 123')) {
           buckets.chapter123.push(idx);
-        } else if (text.includes('subject & comps photos') || text.includes('subject &amp; comps photos')) {
+        } else if (
+          text.includes('subject & comps photos') ||
+          text.includes('subject &amp; comps photos') ||
+          // The Photos page emitted by DetailedAppraisalGrid / VacantLandAppraisalTab
+          // intentionally has no visible "Subject & Comps Photos" header (it shrinks
+          // the photos and is redundant with the obvious layout). Lock onto the
+          // italic footer caption that's drawn on every Photos page instead — it
+          // doesn't appear on any other section.
+          text.includes('subject and comparable photographs')
+        ) {
           buckets.photos.push(idx);
         } else if (text.includes('subject & comps location map') || text.includes('subject &amp; comps location map')) {
           buckets.map.push(idx);
@@ -2355,17 +2368,10 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
     addReportRange(buckets.static);
     // 2. Dynamic Adjustments
     addReportRange(buckets.dynamic);
-    // 3a. Direct-from-folder Photos page (new appeal_photos workflow). Always
-    //     preferred over the legacy PowerComp packet when present.
+    // 3. Direct-from-folder Photos page (new appeal_photos workflow). Legacy
+    //    PowerComp packet merge has been retired — picker is the only source.
     addReportRange(buckets.photos);
-    // 3b. Legacy PowerComp photo packet (fallback for pre-appeal_photos reports)
-    let hasPhotos = buckets.photos.length > 0;
-    if (photoBytes && !hasPhotos) {
-      const photoDoc = await PDFDocument.load(photoBytes);
-      const photoPages = await out.copyPages(photoDoc, photoDoc.getPageIndices());
-      for (const p of photoPages) out.addPage(p);
-      hasPhotos = true;
-    }
+    const hasPhotos = buckets.photos.length > 0;
     // 4. Map
     addReportRange(buckets.map);
     // 5. Appellant Evidence
@@ -2379,12 +2385,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
     // sure we don't return an empty PDF.
     if (out.getPageCount() === 0) {
       for (const p of reportPages) out.addPage(p);
-      if (photoBytes) {
-        const photoDoc = await PDFDocument.load(photoBytes);
-        const photoPages = await out.copyPages(photoDoc, photoDoc.getPageIndices());
-        for (const p of photoPages) out.addPage(p);
-        hasPhotos = true;
-      }
     }
 
     return { bytes: await out.save(), hasPhotos };


### PR DESCRIPTION
### Summary
Removes the legacy PowerComp PDF photo-ripper from the appeal report PDF generation pipeline, making the photo picker (DetailedAppraisalGrid / VacantLandAppraisalTab) the sole source of subject and comp photos in all exported reports.

### Problem
When building appeal reports, the legacy PowerComp photo pages were still being embedded in the PDF alongside the new photo picker pages. This caused the new photo pages to be pushed to the end of the report, breaking the canonical section order established for the appeal report layout. Additionally, the legacy photo ripper was producing redundant and misplaced photo sections in both the appeal log and the export-to-PDF modal.

### Key Changes
- **Disabled legacy photo packet merge** — `fetchPhotoPacketBytes` is no longer called at print time; existing `appeal_powercomp_photos` rows and `powercomp-photos` blobs are intentionally ignored
- **Updated photo page detection** — Added a fallback anchor on the italic footer caption `'subject and comparable photographs'` so headerless photo pages (the header was removed to avoid shrinking photos) are still correctly bucketed into the canonical section order
- **Simplified `hasPhotos` logic** — Removed the legacy fallback branches that conditionally merged the old PowerComp photo doc; `hasPhotos` is now a straightforward check on `buckets.photos`
- **Canonical section order preserved** — Static attributes → Dynamic adjustments → Photos → Map → Appellant evidence → Director's ratio, as reviewed and confirmed
- **Added 📸 emoji** to the Copilot OS guide footer


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/compact-junction-knep0rou"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-compact-junction-knep0rou_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 196`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>compact-junction-knep0rou</branchName>-->