### PR TITLE
Add Chapter 91 commercial mailing audit and comp browser enhancements

### DIFF
--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -29,8 +29,16 @@ const ManagementChecklist = ({ jobData, onBackToJobs, activeSubModule = 'checkli
   const [generatingLists, setGeneratingLists] = useState({
     initial: false,
     second: false,
-    third: false
+    third: false,
+    chapter91: false
   }); // Separate loading states for each list
+
+  // Chapter 91 mailing audit. We open this modal whenever m4_class and cama_class
+  // disagree about whether a parcel is commercial (4A/4B/4C). Lisa's team needs to
+  // hand-audit those edge cases so we don't repeat the Harvey Cedars mistake of
+  // mailing 25 "commercial" parcels that were actually residential.
+  const [chapter91Audit, setChapter91Audit] = useState(null);
+  // Shape: { matched: [...], mismatches: [...], includedMismatchKeys: Set<string> }
   const [processingApprovals, setProcessingApprovals] = useState({}); // Track which approvals are being processed
 
   // Extract year from end_date - just grab first 4 characters to avoid timezone issues
@@ -752,6 +760,139 @@ useEffect(() => {
       alert('Failed to generate mailing list. Please ensure property data is loaded.');
     } finally {
       setGeneratingLists(prev => ({ ...prev, initial: false }));
+    }
+  };
+
+  // CHAPTER 91 — commercial mailing list (property class 4A/4B/4C). Before we
+  // export, we cross-check property_m4_class against property_cama_class and let
+  // the user audit the edge cases. Microsystems doesn't populate cama_class so
+  // those jobs only run the m4 side and skip the cross-check.
+  const buildChapter91Audit = async () => {
+    try {
+      setGeneratingLists(prev => ({ ...prev, chapter91: true }));
+
+      const COMMERCIAL = new Set(['4A', '4B', '4C']);
+      const vendorType = jobData?.vendor_type || jobData?.vendor_source;
+      const mailingData = await getAllPropertyRecords(jobData.id);
+
+      const matched = [];
+      const mismatches = [];
+
+      mailingData.forEach(record => {
+        // Primary cards only — same rule as the other mailers.
+        const card = record.property_addl_card;
+        const isMainCard = vendorType === 'BRT'
+          ? (!card || card === '1')
+          : (!card || String(card).toUpperCase() === 'M');
+        if (!isMainCard) return;
+
+        const m4 = (record.property_m4_class || '').toUpperCase().trim();
+        const cama = (record.property_cama_class || '').toUpperCase().trim();
+        const m4IsComm = COMMERCIAL.has(m4);
+        const camaIsComm = COMMERCIAL.has(cama);
+
+        // Either side commercial → in scope. Neither → ignore entirely.
+        if (!m4IsComm && !camaIsComm) return;
+
+        // Microsystems has no cama_class, so anything where m4 says commercial
+        // is treated as a clean match (no cross-check available).
+        if (!cama) {
+          if (m4IsComm) matched.push(record);
+          return;
+        }
+
+        // Both sides agree it's commercial AND they agree on which subclass.
+        if (m4IsComm && camaIsComm && m4 === cama) {
+          matched.push(record);
+          return;
+        }
+
+        // Anything else is an edge case for the audit list — covers:
+        //   m4 commercial, cama not (or different commercial subclass)
+        //   cama commercial, m4 not (or different commercial subclass)
+        mismatches.push({
+          ...record,
+          _m4: m4 || '(blank)',
+          _cama: cama || '(blank)',
+          _direction: m4IsComm && !camaIsComm ? 'm4→cama'
+            : !m4IsComm && camaIsComm ? 'cama→m4'
+            : 'subclass'
+        });
+      });
+
+      setChapter91Audit({
+        matched,
+        mismatches,
+        includedMismatchKeys: new Set(), // user opts in per row
+      });
+    } catch (error) {
+      console.error('Error building Chapter 91 audit:', error);
+      alert('Failed to build Chapter 91 audit list. Please ensure property data is loaded.');
+    } finally {
+      setGeneratingLists(prev => ({ ...prev, chapter91: false }));
+    }
+  };
+
+  const exportChapter91Excel = () => {
+    if (!chapter91Audit) return;
+    try {
+      const { matched, mismatches, includedMismatchKeys } = chapter91Audit;
+
+      const acceptedMismatches = mismatches.filter(r =>
+        includedMismatchKeys.has(r.property_composite_key || `${r.property_block}-${r.property_lot}-${r.property_qualifier || ''}`)
+      );
+      const rows = [...matched, ...acceptedMismatches];
+
+      const excelData = rows.map(record => {
+        const { cityState, zip } = parseCityStateZip(record.owner_csz);
+        return {
+          'Block': record.property_block,
+          'Lot': record.property_lot,
+          'Qual': record.property_qualifier || '',
+          'Property Class': record.property_m4_class || record.property_cama_class || '',
+          'Property Location': record.property_location || '',
+          'Owner': record.owner_name || '',
+          'Owner Address': record.owner_street || '',
+          'City/State/Zip': [cityState, zip].filter(Boolean).join(' ').trim()
+        };
+      });
+
+      const ws = XLSX.utils.json_to_sheet(excelData);
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, 'Chapter 91');
+
+      ws['!cols'] = [
+        { wch: 12 }, // Block
+        { wch: 12 }, // Lot
+        { wch: 10 }, // Qual
+        { wch: 14 }, // Property Class
+        { wch: 45 }, // Property Location
+        { wch: 35 }, // Owner
+        { wch: 40 }, // Owner Address
+        { wch: 30 }  // City/State/Zip
+      ];
+
+      const range = XLSX.utils.decode_range(ws['!ref']);
+      for (let R = range.s.r; R <= range.e.r; ++R) {
+        for (let C = range.s.c; C <= range.e.c; ++C) {
+          const addr = XLSX.utils.encode_cell({ r: R, c: C });
+          if (!ws[addr]) continue;
+          ws[addr].s = {
+            font: { name: 'Leelawadee', sz: 10, bold: R === 0 },
+            alignment: { horizontal: 'center', vertical: 'center' }
+          };
+        }
+      }
+
+      const fileName = jobData?.job_name
+        ? `${jobData.job_name.replace(/[^a-z0-9]/gi, '_')}_Chapter_91_Mailing.xlsx`
+        : `Chapter_91_Mailing_${new Date().toISOString().split('T')[0]}.xlsx`;
+      XLSX.writeFile(wb, fileName);
+
+      setChapter91Audit(null);
+    } catch (error) {
+      console.error('Error exporting Chapter 91 list:', error);
+      alert('Failed to export Chapter 91 list.');
     }
   };
 
@@ -1518,7 +1659,9 @@ useEffect(() => {
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
                       <h3 className={`font-medium ${isNotApplicableForReassessment ? 'text-gray-500' : 'text-gray-800'}`}>
-                        {item.item_text}
+                        {item.special_action === 'generate_mailing_list'
+                          ? 'Initial Mailing List / Chapter 91'
+                          : item.item_text}
                       </h3>
                       {/* Show Not Applicable badge for reassessment */}
                       {isNotApplicableForReassessment && (
@@ -1686,14 +1829,25 @@ useEffect(() => {
                     </button>
                   )}
                   {item.special_action === 'generate_mailing_list' && (
-                    <button
-                      onClick={generateMailingListExcel}
-                      disabled={generatingLists.initial}
-                      className="px-3 py-1 bg-green-500 text-white rounded-md text-sm hover:bg-green-600 disabled:bg-gray-400 flex items-center gap-1"
-                    >
-                      <Download className="w-4 h-4" />
-                      {generatingLists.initial ? 'Generating...' : 'Download Excel'}
-                    </button>
+                    <>
+                      <button
+                        onClick={generateMailingListExcel}
+                        disabled={generatingLists.initial}
+                        className="px-3 py-1 bg-green-500 text-white rounded-md text-sm hover:bg-green-600 disabled:bg-gray-400 flex items-center gap-1"
+                      >
+                        <Download className="w-4 h-4" />
+                        {generatingLists.initial ? 'Generating...' : 'Initial Mailing Excel'}
+                      </button>
+                      <button
+                        onClick={buildChapter91Audit}
+                        disabled={generatingLists.chapter91}
+                        className="px-3 py-1 bg-indigo-500 text-white rounded-md text-sm hover:bg-indigo-600 disabled:bg-gray-400 flex items-center gap-1"
+                        title="Build Chapter 91 mailing list (4A/4B/4C). Audits any m4 vs cama class disagreements before exporting."
+                      >
+                        <Download className="w-4 h-4" />
+                        {generatingLists.chapter91 ? 'Building...' : 'Chapter 91 Excel'}
+                      </button>
+                    </>
                   )}
                   {item.special_action === 'generate_second_attempt_mailer' && (
                     <button 
@@ -1731,6 +1885,161 @@ useEffect(() => {
           );
         })}
       </div>
+
+      {/* Chapter 91 Audit Modal — surfaces m4 vs cama class disagreements
+          so the user can hand-pick which edge cases get included in the export. */}
+      {chapter91Audit && (() => {
+        const { matched, mismatches, includedMismatchKeys } = chapter91Audit;
+        const total = matched.length + mismatches.length;
+        const includedCount = matched.length + includedMismatchKeys.size;
+        const keyOf = (r) => r.property_composite_key || `${r.property_block}-${r.property_lot}-${r.property_qualifier || ''}`;
+
+        const toggleRow = (row) => {
+          const key = keyOf(row);
+          setChapter91Audit(prev => {
+            if (!prev) return prev;
+            const next = new Set(prev.includedMismatchKeys);
+            if (next.has(key)) next.delete(key); else next.add(key);
+            return { ...prev, includedMismatchKeys: next };
+          });
+        };
+
+        const allChecked = mismatches.length > 0 && includedMismatchKeys.size === mismatches.length;
+        const toggleAll = () => {
+          setChapter91Audit(prev => {
+            if (!prev) return prev;
+            const next = allChecked ? new Set() : new Set(prev.mismatches.map(keyOf));
+            return { ...prev, includedMismatchKeys: next };
+          });
+        };
+
+        return (
+          <div
+            style={{
+              position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+              backgroundColor: 'rgba(0,0,0,0.5)', zIndex: 60,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16
+            }}
+            onClick={() => setChapter91Audit(null)}
+          >
+            <div
+              style={{
+                backgroundColor: '#fff', borderRadius: 8,
+                width: '95vw', maxWidth: 1100, height: '85vh',
+                display: 'flex', flexDirection: 'column', overflow: 'hidden',
+                boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)'
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div style={{ padding: '16px 20px', borderBottom: '1px solid #e5e7eb', flexShrink: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+                  <div>
+                    <h3 style={{ fontSize: 16, fontWeight: 600, color: '#111827', margin: 0 }}>Chapter 91 Mailing — Audit</h3>
+                    <p style={{ fontSize: 12, color: '#4b5563', marginTop: 4 }}>
+                      <strong>{matched.length} of {total} matched</strong>
+                      {mismatches.length > 0 && (
+                        <> · <span style={{ color: '#b45309' }}>{mismatches.length} edge case{mismatches.length === 1 ? '' : 's'} need review</span></>
+                      )}
+                      {' · '}<strong>{includedCount}</strong> will export
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => setChapter91Audit(null)}
+                    style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6b7280' }}
+                    title="Close"
+                  >
+                    <X className="w-5 h-5" />
+                  </button>
+                </div>
+              </div>
+
+              <div style={{ flex: '1 1 auto', overflow: 'auto', minHeight: 0 }}>
+                {mismatches.length === 0 ? (
+                  <div style={{ padding: 32, textAlign: 'center', color: '#374151' }}>
+                    <CheckCircle style={{ width: 48, height: 48, color: '#16a34a', margin: '0 auto 12px' }} />
+                    <p style={{ fontSize: 14, fontWeight: 600 }}>No mismatches — all {matched.length} parcels agree on class.</p>
+                    <p style={{ fontSize: 12, color: '#6b7280', marginTop: 4 }}>Click Export to download the Chapter 91 list.</p>
+                  </div>
+                ) : (
+                  <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse' }}>
+                    <thead style={{ position: 'sticky', top: 0, backgroundColor: '#f9fafb', zIndex: 1 }}>
+                      <tr>
+                        <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb', width: 40 }}>
+                          <input
+                            type="checkbox"
+                            checked={allChecked}
+                            onChange={toggleAll}
+                            title={allChecked ? 'Uncheck all' : 'Check all'}
+                          />
+                        </th>
+                        <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Block</th>
+                        <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Lot</th>
+                        <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Qual</th>
+                        <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Location</th>
+                        <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Owner</th>
+                        <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb' }}>M4</th>
+                        <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb' }}>CAMA</th>
+                        <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Conflict</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {mismatches.map((row, i) => {
+                        const k = keyOf(row);
+                        const checked = includedMismatchKeys.has(k);
+                        return (
+                          <tr key={k + '-' + i} style={{ backgroundColor: checked ? '#ECFDF5' : 'transparent', borderBottom: '1px solid #f3f4f6' }}>
+                            <td style={{ padding: '6px 8px', textAlign: 'center' }}>
+                              <input type="checkbox" checked={checked} onChange={() => toggleRow(row)} />
+                            </td>
+                            <td style={{ padding: '6px 8px' }}>{row.property_block}</td>
+                            <td style={{ padding: '6px 8px' }}>{row.property_lot}</td>
+                            <td style={{ padding: '6px 8px' }}>{row.property_qualifier || ''}</td>
+                            <td style={{ padding: '6px 8px' }}>{row.property_location || ''}</td>
+                            <td style={{ padding: '6px 8px' }}>{row.owner_name || ''}</td>
+                            <td style={{ padding: '6px 8px', textAlign: 'center', fontWeight: 600 }}>{row._m4}</td>
+                            <td style={{ padding: '6px 8px', textAlign: 'center', fontWeight: 600 }}>{row._cama}</td>
+                            <td style={{ padding: '6px 8px', color: '#b45309', fontSize: 11 }}>
+                              {row._direction === 'm4→cama' && 'M4 says commercial, CAMA disagrees'}
+                              {row._direction === 'cama→m4' && 'CAMA says commercial, M4 disagrees'}
+                              {row._direction === 'subclass' && 'Different commercial subclass'}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+
+              <div style={{ padding: '12px 20px', borderTop: '1px solid #e5e7eb', backgroundColor: '#f9fafb', flexShrink: 0, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+                <div style={{ fontSize: 12, color: '#4b5563' }}>
+                  {matched.length} matched + {includedMismatchKeys.size} edge case{includedMismatchKeys.size === 1 ? '' : 's'} = <strong>{includedCount}</strong> on export
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button
+                    onClick={() => setChapter91Audit(null)}
+                    style={{ padding: '6px 12px', fontSize: 13, backgroundColor: '#fff', border: '1px solid #d1d5db', borderRadius: 4, cursor: 'pointer' }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={exportChapter91Excel}
+                    disabled={includedCount === 0}
+                    style={{
+                      padding: '6px 12px', fontSize: 13, color: '#fff', borderRadius: 4, border: 'none',
+                      backgroundColor: includedCount === 0 ? '#9ca3af' : '#4f46e5',
+                      cursor: includedCount === 0 ? 'not-allowed' : 'pointer',
+                      fontWeight: 600
+                    }}
+                  >
+                    Export {includedCount} to Excel
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Archive Confirmation Modal */}
       {showArchiveConfirm && (

--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -844,16 +844,18 @@ useEffect(() => {
       const rows = [...matched, ...acceptedMismatches];
 
       const excelData = rows.map(record => {
+        // Zip stays in its own column so Lisa's mail merge can use it cleanly.
         const { cityState, zip } = parseCityStateZip(record.owner_csz);
         return {
           'Block': record.property_block,
           'Lot': record.property_lot,
-          'Qual': record.property_qualifier || '',
+          'Qualifier': record.property_qualifier || '',
           'Property Class': record.property_m4_class || record.property_cama_class || '',
-          'Property Location': record.property_location || '',
+          'Location': record.property_location || '',
           'Owner': record.owner_name || '',
-          'Owner Address': record.owner_street || '',
-          'City/State/Zip': [cityState, zip].filter(Boolean).join(' ').trim()
+          'Address': record.owner_street || '',
+          'City, State': cityState,
+          'Zip': zip
         };
       });
 
@@ -863,13 +865,14 @@ useEffect(() => {
 
       ws['!cols'] = [
         { wch: 12 }, // Block
-        { wch: 12 }, // Lot
-        { wch: 10 }, // Qual
-        { wch: 14 }, // Property Class
-        { wch: 45 }, // Property Location
+        { wch: 15 }, // Lot
+        { wch: 12 }, // Qualifier
+        { wch: 15 }, // Property Class
+        { wch: 45 }, // Location
         { wch: 35 }, // Owner
-        { wch: 40 }, // Owner Address
-        { wch: 30 }  // City/State/Zip
+        { wch: 40 }, // Address
+        { wch: 30 }, // City, State
+        { wch: 12 }  // Zip
       ];
 
       const range = XLSX.utils.decode_range(ws['!ref']);

--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -138,12 +138,16 @@ useEffect(() => {
       return [];
     }
     
-    // Return only the fields we need for mailing lists
+    // Return only the fields we need for mailing lists.
+    // property_addl_card is required so primary-card guards work.
+    // property_cama_class is required for the Chapter 91 m4↔cama audit.
     const mailingFields = properties.map(record => ({
       property_block: record.property_block,
       property_lot: record.property_lot,
       property_qualifier: record.property_qualifier,
+      property_addl_card: record.property_addl_card,
       property_m4_class: record.property_m4_class,
+      property_cama_class: record.property_cama_class,
       property_location: record.property_location,
       property_facility: record.property_facility,
       owner_name: record.owner_name,

--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -648,8 +648,18 @@ useEffect(() => {
       // Get ALL property records with pagination
       const mailingData = await getAllPropertyRecords(jobData.id);
 
+      const vendorType = jobData?.vendor_type || jobData?.vendor_source;
+
       // Filter for residential properties and specific class 15s
       const filteredData = mailingData.filter(record => {
+        // Skip additional cards — only mail the primary card per parcel.
+        // BRT primary = '1' (or null); Microsystems primary = 'M' (or null).
+        const card = record.property_addl_card;
+        const isMainCard = vendorType === 'BRT'
+          ? (!card || card === '1')
+          : (!card || String(card).toUpperCase() === 'M');
+        if (!isMainCard) return false;
+
         const propClass = record.property_m4_class?.toUpperCase() || '';
 
         // Include residential classes
@@ -778,24 +788,34 @@ useEffect(() => {
         }
       });
       
+      const vendorType = jobData?.vendor_type || jobData?.vendor_source;
+
       // Filter properties for 2nd attempt
       const secondAttemptProperties = propertyData.filter(property => {
+        // Skip additional cards — only mail the primary card per parcel.
+        // BRT primary = '1' (or null); Microsystems primary = 'M' (or null).
+        const card = property.property_addl_card;
+        const isMainCard = vendorType === 'BRT'
+          ? (!card || card === '1')
+          : (!card || String(card).toUpperCase() === 'M');
+        if (!isMainCard) return false;
+
         const propClass = property.property_m4_class?.toUpperCase() || '';
-        const inspection = property.property_composite_key ? 
+        const inspection = property.property_composite_key ?
           inspectionMap.get(property.property_composite_key) : null;
-        
+
         // Check if it's a refusal based on job config
         if (inspection && refusalCategories.includes(inspection.info_by_code)) {
           return true;
         }
-        
+
         // Check if it's class 2 or 3A with no inspection (list_by is null or empty)
         if (['2', '3A'].includes(propClass)) {
           if (!inspection || !inspection.list_by || inspection.list_by.trim() === '') {
             return true;
           }
         }
-        
+
         return false;
       });
       
@@ -914,24 +934,34 @@ useEffect(() => {
         }
       });
       
+      const vendorType = jobData?.vendor_type || jobData?.vendor_source;
+
       // Filter properties for 3rd attempt (same logic as 2nd for now)
       const thirdAttemptProperties = propertyData.filter(property => {
+        // Skip additional cards — only mail the primary card per parcel.
+        // BRT primary = '1' (or null); Microsystems primary = 'M' (or null).
+        const card = property.property_addl_card;
+        const isMainCard = vendorType === 'BRT'
+          ? (!card || card === '1')
+          : (!card || String(card).toUpperCase() === 'M');
+        if (!isMainCard) return false;
+
         const propClass = property.property_m4_class?.toUpperCase() || '';
-        const inspection = property.property_composite_key ? 
+        const inspection = property.property_composite_key ?
           inspectionMap.get(property.property_composite_key) : null;
-        
+
         // Check if it's a refusal based on job config
         if (inspection && refusalCategories.includes(inspection.info_by_code)) {
           return true;
         }
-        
+
         // Check if it's class 2 or 3A with no inspection (list_by is null or empty)
         if (['2', '3A'].includes(propClass)) {
           if (!inspection || !inspection.list_by || inspection.list_by.trim() === '') {
             return true;
           }
         }
-        
+
         return false;
       });
       

--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -160,6 +160,28 @@ useEffect(() => {
     console.log(`✅ Using ${mailingFields.length} property records from props`);
     return mailingFields;
   };
+
+  // Vendor-aware primary-card check used by every mailer (Initial, Chapter 91,
+  // 2nd Attempt, 3rd Attempt). Mirrors the SalesComparisonTab helper so the
+  // mailers, evaluator, and grouping logic all agree on what "main card" means.
+  //  - BRT: card '1' (or empty / non-numeric) is main; any other number is additional.
+  //  - Microsystems: typically 'M' / 'MAIN', but jobs can also use numeric main
+  //    cards, so we accept '1' / empty as well.
+  const isPrimaryCard = (cardValue) => {
+    const card = (cardValue || '').toString().trim();
+    const vendorType = jobData?.vendor_type || jobData?.vendor_source;
+    if (vendorType === 'Microsystems') {
+      const upper = card.toUpperCase();
+      if (upper === 'M' || upper === 'MAIN' || upper === '') return true;
+      const n = parseInt(card, 10);
+      return n === 1; // some Microsystems jobs key main as numeric 1
+    }
+    // BRT (default): blank or 1 is main; non-numeric tokens treated as main too.
+    if (card === '') return true;
+    const n = parseInt(card, 10);
+    return Number.isNaN(n) || n === 1;
+  };
+
   // Use inspection data from props instead of fetching
   const getAllInspectionData = async (jobId) => {
     console.log('🔍 Using inspection data from props');
@@ -665,12 +687,7 @@ useEffect(() => {
       // Filter for residential properties and specific class 15s
       const filteredData = mailingData.filter(record => {
         // Skip additional cards — only mail the primary card per parcel.
-        // BRT primary = '1' (or null); Microsystems primary = 'M' (or null).
-        const card = record.property_addl_card;
-        const isMainCard = vendorType === 'BRT'
-          ? (!card || card === '1')
-          : (!card || String(card).toUpperCase() === 'M');
-        if (!isMainCard) return false;
+        if (!isPrimaryCard(record.property_addl_card)) return false;
 
         const propClass = record.property_m4_class?.toUpperCase() || '';
 
@@ -776,7 +793,6 @@ useEffect(() => {
       setGeneratingLists(prev => ({ ...prev, chapter91: true }));
 
       const COMMERCIAL = new Set(['4A', '4B', '4C']);
-      const vendorType = jobData?.vendor_type || jobData?.vendor_source;
       const mailingData = await getAllPropertyRecords(jobData.id);
 
       const matched = [];
@@ -784,11 +800,7 @@ useEffect(() => {
 
       mailingData.forEach(record => {
         // Primary cards only — same rule as the other mailers.
-        const card = record.property_addl_card;
-        const isMainCard = vendorType === 'BRT'
-          ? (!card || card === '1')
-          : (!card || String(card).toUpperCase() === 'M');
-        if (!isMainCard) return;
+        if (!isPrimaryCard(record.property_addl_card)) return;
 
         const m4 = (record.property_m4_class || '').toUpperCase().trim();
         const cama = (record.property_cama_class || '').toUpperCase().trim();
@@ -941,12 +953,7 @@ useEffect(() => {
       // Filter properties for 2nd attempt
       const secondAttemptProperties = propertyData.filter(property => {
         // Skip additional cards — only mail the primary card per parcel.
-        // BRT primary = '1' (or null); Microsystems primary = 'M' (or null).
-        const card = property.property_addl_card;
-        const isMainCard = vendorType === 'BRT'
-          ? (!card || card === '1')
-          : (!card || String(card).toUpperCase() === 'M');
-        if (!isMainCard) return false;
+        if (!isPrimaryCard(property.property_addl_card)) return false;
 
         const propClass = property.property_m4_class?.toUpperCase() || '';
         const inspection = property.property_composite_key ?
@@ -1087,12 +1094,7 @@ useEffect(() => {
       // Filter properties for 3rd attempt (same logic as 2nd for now)
       const thirdAttemptProperties = propertyData.filter(property => {
         // Skip additional cards — only mail the primary card per parcel.
-        // BRT primary = '1' (or null); Microsystems primary = 'M' (or null).
-        const card = property.property_addl_card;
-        const isMainCard = vendorType === 'BRT'
-          ? (!card || card === '1')
-          : (!card || String(card).toUpperCase() === 'M');
-        if (!isMainCard) return false;
+        if (!isPrimaryCard(property.property_addl_card)) return false;
 
         const propClass = property.property_m4_class?.toUpperCase() || '';
         const inspection = property.property_composite_key ?

--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -37,8 +37,11 @@ const ManagementChecklist = ({ jobData, onBackToJobs, activeSubModule = 'checkli
   // disagree about whether a parcel is commercial (4A/4B/4C). Lisa's team needs to
   // hand-audit those edge cases so we don't repeat the Harvey Cedars mistake of
   // mailing 25 "commercial" parcels that were actually residential.
+  // Decisions are persisted to chapter91_audit_decisions so they survive reloads
+  // and the export always respects the saved Include/Ignore state.
   const [chapter91Audit, setChapter91Audit] = useState(null);
-  // Shape: { matched: [...], mismatches: [...], includedMismatchKeys: Set<string> }
+  // Shape: { matched: [...], mismatches: [...], decisions: { [composite_key]: 'include' | 'ignore' } }
+  const [savingDecisionKey, setSavingDecisionKey] = useState(null);
   const [processingApprovals, setProcessingApprovals] = useState({}); // Track which approvals are being processed
 
   // Extract year from end_date - just grab first 4 characters to avoid timezone issues
@@ -836,10 +839,23 @@ useEffect(() => {
         });
       });
 
+      // Hydrate saved Include/Ignore decisions for this job so the user picks
+      // up where they (or a teammate) left off.
+      const { data: savedDecisions, error: decErr } = await supabase
+        .from('chapter91_audit_decisions')
+        .select('property_composite_key, decision')
+        .eq('job_id', jobData.id);
+      if (decErr) console.warn('Could not load saved Chapter 91 decisions:', decErr.message);
+
+      const decisions = {};
+      (savedDecisions || []).forEach(d => {
+        decisions[d.property_composite_key] = d.decision;
+      });
+
       setChapter91Audit({
         matched,
         mismatches,
-        includedMismatchKeys: new Set(), // user opts in per row
+        decisions,
       });
     } catch (error) {
       console.error('Error building Chapter 91 audit:', error);
@@ -849,14 +865,78 @@ useEffect(() => {
     }
   };
 
+  // Persist a single Include/Ignore decision and reflect it locally.
+  const saveChapter91Decision = async (row, decision) => {
+    const key = row.property_composite_key
+      || `${row.property_block}-${row.property_lot}-${row.property_qualifier || ''}`;
+    if (!key) return;
+    setSavingDecisionKey(key);
+    try {
+      const payload = {
+        job_id: jobData.id,
+        property_composite_key: key,
+        decision,
+        property_block: row.property_block,
+        property_lot: row.property_lot,
+        property_qualifier: row.property_qualifier || null,
+        m4_class: row.property_m4_class || null,
+        cama_class: row.property_cama_class || null,
+        decided_by: currentUser?.email || currentUser?.id || null,
+        decided_at: new Date().toISOString(),
+      };
+      const { error } = await supabase
+        .from('chapter91_audit_decisions')
+        .upsert(payload, { onConflict: 'job_id,property_composite_key' });
+      if (error) throw error;
+      setChapter91Audit(prev => prev ? {
+        ...prev,
+        decisions: { ...prev.decisions, [key]: decision }
+      } : prev);
+    } catch (e) {
+      console.error('Failed to save Chapter 91 decision:', e);
+      alert('Failed to save decision. Please try again.');
+    } finally {
+      setSavingDecisionKey(null);
+    }
+  };
+
+  // Reset a row back to undecided (deletes the persisted row).
+  const clearChapter91Decision = async (row) => {
+    const key = row.property_composite_key
+      || `${row.property_block}-${row.property_lot}-${row.property_qualifier || ''}`;
+    if (!key) return;
+    setSavingDecisionKey(key);
+    try {
+      const { error } = await supabase
+        .from('chapter91_audit_decisions')
+        .delete()
+        .eq('job_id', jobData.id)
+        .eq('property_composite_key', key);
+      if (error) throw error;
+      setChapter91Audit(prev => {
+        if (!prev) return prev;
+        const next = { ...prev.decisions };
+        delete next[key];
+        return { ...prev, decisions: next };
+      });
+    } catch (e) {
+      console.error('Failed to clear Chapter 91 decision:', e);
+      alert('Failed to clear decision. Please try again.');
+    } finally {
+      setSavingDecisionKey(null);
+    }
+  };
+
   const exportChapter91Excel = () => {
     if (!chapter91Audit) return;
     try {
-      const { matched, mismatches, includedMismatchKeys } = chapter91Audit;
+      const { matched, mismatches, decisions } = chapter91Audit;
 
-      const acceptedMismatches = mismatches.filter(r =>
-        includedMismatchKeys.has(r.property_composite_key || `${r.property_block}-${r.property_lot}-${r.property_qualifier || ''}`)
-      );
+      // Mismatches only export if explicitly marked Include in the persisted
+      // decisions table. Undecided and Ignored stay off the list.
+      const keyOf = (r) => r.property_composite_key
+        || `${r.property_block}-${r.property_lot}-${r.property_qualifier || ''}`;
+      const acceptedMismatches = mismatches.filter(r => decisions[keyOf(r)] === 'include');
       const rows = [...matched, ...acceptedMismatches];
 
       const excelData = rows.map(record => {
@@ -1896,31 +1976,18 @@ useEffect(() => {
       </div>
 
       {/* Chapter 91 Audit Modal — surfaces m4 vs cama class disagreements
-          so the user can hand-pick which edge cases get included in the export. */}
+          so the user can hand-pick which edge cases get included in the export.
+          Decisions persist in chapter91_audit_decisions so reload + export both
+          honor the saved Include/Ignore state. */}
       {chapter91Audit && (() => {
-        const { matched, mismatches, includedMismatchKeys } = chapter91Audit;
+        const { matched, mismatches, decisions } = chapter91Audit;
         const total = matched.length + mismatches.length;
-        const includedCount = matched.length + includedMismatchKeys.size;
-        const keyOf = (r) => r.property_composite_key || `${r.property_block}-${r.property_lot}-${r.property_qualifier || ''}`;
-
-        const toggleRow = (row) => {
-          const key = keyOf(row);
-          setChapter91Audit(prev => {
-            if (!prev) return prev;
-            const next = new Set(prev.includedMismatchKeys);
-            if (next.has(key)) next.delete(key); else next.add(key);
-            return { ...prev, includedMismatchKeys: next };
-          });
-        };
-
-        const allChecked = mismatches.length > 0 && includedMismatchKeys.size === mismatches.length;
-        const toggleAll = () => {
-          setChapter91Audit(prev => {
-            if (!prev) return prev;
-            const next = allChecked ? new Set() : new Set(prev.mismatches.map(keyOf));
-            return { ...prev, includedMismatchKeys: next };
-          });
-        };
+        const keyOf = (r) => r.property_composite_key
+          || `${r.property_block}-${r.property_lot}-${r.property_qualifier || ''}`;
+        const includedMismatches = mismatches.filter(r => decisions[keyOf(r)] === 'include').length;
+        const ignoredMismatches = mismatches.filter(r => decisions[keyOf(r)] === 'ignore').length;
+        const undecidedMismatches = mismatches.length - includedMismatches - ignoredMismatches;
+        const exportCount = matched.length + includedMismatches;
 
         return (
           <div
@@ -1947,9 +2014,18 @@ useEffect(() => {
                     <p style={{ fontSize: 12, color: '#4b5563', marginTop: 4 }}>
                       <strong>{matched.length} of {total} matched</strong>
                       {mismatches.length > 0 && (
-                        <> · <span style={{ color: '#b45309' }}>{mismatches.length} edge case{mismatches.length === 1 ? '' : 's'} need review</span></>
+                        <>
+                          {' · '}<span style={{ color: '#16a34a' }}>{includedMismatches} included</span>
+                          {' · '}<span style={{ color: '#dc2626' }}>{ignoredMismatches} ignored</span>
+                          {undecidedMismatches > 0 && (
+                            <>{' · '}<span style={{ color: '#b45309', fontWeight: 600 }}>{undecidedMismatches} need review</span></>
+                          )}
+                        </>
                       )}
-                      {' · '}<strong>{includedCount}</strong> will export
+                      {' · '}<strong>{exportCount} will export</strong>
+                    </p>
+                    <p style={{ fontSize: 11, color: '#6b7280', marginTop: 4, fontStyle: 'italic' }}>
+                      Decisions persist per job — Include adds the parcel to every future Chapter 91 export, Ignore keeps it off.
                     </p>
                   </div>
                   <button
@@ -1973,14 +2049,6 @@ useEffect(() => {
                   <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse' }}>
                     <thead style={{ position: 'sticky', top: 0, backgroundColor: '#f9fafb', zIndex: 1 }}>
                       <tr>
-                        <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb', width: 40 }}>
-                          <input
-                            type="checkbox"
-                            checked={allChecked}
-                            onChange={toggleAll}
-                            title={allChecked ? 'Uncheck all' : 'Check all'}
-                          />
-                        </th>
                         <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Block</th>
                         <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Lot</th>
                         <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Qual</th>
@@ -1989,17 +2057,24 @@ useEffect(() => {
                         <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb' }}>M4</th>
                         <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb' }}>CAMA</th>
                         <th style={{ padding: '8px', textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>Conflict</th>
+                        <th style={{ padding: '8px', textAlign: 'center', borderBottom: '1px solid #e5e7eb', width: 220 }}>Decision</th>
                       </tr>
                     </thead>
                     <tbody>
                       {mismatches.map((row, i) => {
                         const k = keyOf(row);
-                        const checked = includedMismatchKeys.has(k);
+                        const decision = decisions[k]; // 'include' | 'ignore' | undefined
+                        const isSaving = savingDecisionKey === k;
+                        const rowBg = decision === 'include' ? '#ECFDF5'
+                          : decision === 'ignore' ? '#FEE2E2'
+                          : 'transparent';
+                        const btnBase = {
+                          padding: '4px 10px', fontSize: 11, borderRadius: 4,
+                          border: '1px solid', cursor: isSaving ? 'wait' : 'pointer',
+                          fontWeight: 600,
+                        };
                         return (
-                          <tr key={k + '-' + i} style={{ backgroundColor: checked ? '#ECFDF5' : 'transparent', borderBottom: '1px solid #f3f4f6' }}>
-                            <td style={{ padding: '6px 8px', textAlign: 'center' }}>
-                              <input type="checkbox" checked={checked} onChange={() => toggleRow(row)} />
-                            </td>
+                          <tr key={k + '-' + i} style={{ backgroundColor: rowBg, borderBottom: '1px solid #f3f4f6' }}>
                             <td style={{ padding: '6px 8px' }}>{row.property_block}</td>
                             <td style={{ padding: '6px 8px' }}>{row.property_lot}</td>
                             <td style={{ padding: '6px 8px' }}>{row.property_qualifier || ''}</td>
@@ -2012,6 +2087,54 @@ useEffect(() => {
                               {row._direction === 'cama→m4' && 'CAMA says commercial, M4 disagrees'}
                               {row._direction === 'subclass' && 'Different commercial subclass'}
                             </td>
+                            <td style={{ padding: '6px 8px', textAlign: 'center' }}>
+                              <div style={{ display: 'inline-flex', gap: 4 }}>
+                                <button
+                                  type="button"
+                                  disabled={isSaving}
+                                  onClick={() => saveChapter91Decision(row, 'include')}
+                                  style={{
+                                    ...btnBase,
+                                    color: decision === 'include' ? '#fff' : '#16a34a',
+                                    backgroundColor: decision === 'include' ? '#16a34a' : '#fff',
+                                    borderColor: '#16a34a',
+                                  }}
+                                  title="Include this parcel in every Chapter 91 export"
+                                >
+                                  Include
+                                </button>
+                                <button
+                                  type="button"
+                                  disabled={isSaving}
+                                  onClick={() => saveChapter91Decision(row, 'ignore')}
+                                  style={{
+                                    ...btnBase,
+                                    color: decision === 'ignore' ? '#fff' : '#dc2626',
+                                    backgroundColor: decision === 'ignore' ? '#dc2626' : '#fff',
+                                    borderColor: '#dc2626',
+                                  }}
+                                  title="Exclude this parcel from every Chapter 91 export"
+                                >
+                                  Ignore
+                                </button>
+                                {decision && (
+                                  <button
+                                    type="button"
+                                    disabled={isSaving}
+                                    onClick={() => clearChapter91Decision(row)}
+                                    style={{
+                                      ...btnBase,
+                                      color: '#6b7280',
+                                      backgroundColor: '#fff',
+                                      borderColor: '#d1d5db',
+                                    }}
+                                    title="Clear this decision"
+                                  >
+                                    Reset
+                                  </button>
+                                )}
+                              </div>
+                            </td>
                           </tr>
                         );
                       })}
@@ -2022,26 +2145,31 @@ useEffect(() => {
 
               <div style={{ padding: '12px 20px', borderTop: '1px solid #e5e7eb', backgroundColor: '#f9fafb', flexShrink: 0, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
                 <div style={{ fontSize: 12, color: '#4b5563' }}>
-                  {matched.length} matched + {includedMismatchKeys.size} edge case{includedMismatchKeys.size === 1 ? '' : 's'} = <strong>{includedCount}</strong> on export
+                  {matched.length} matched + {includedMismatches} included = <strong>{exportCount}</strong> on export
+                  {undecidedMismatches > 0 && (
+                    <span style={{ marginLeft: 8, color: '#b45309' }}>
+                      ⚠ {undecidedMismatches} undecided will be excluded
+                    </span>
+                  )}
                 </div>
                 <div style={{ display: 'flex', gap: 8 }}>
                   <button
                     onClick={() => setChapter91Audit(null)}
                     style={{ padding: '6px 12px', fontSize: 13, backgroundColor: '#fff', border: '1px solid #d1d5db', borderRadius: 4, cursor: 'pointer' }}
                   >
-                    Cancel
+                    Close
                   </button>
                   <button
                     onClick={exportChapter91Excel}
-                    disabled={includedCount === 0}
+                    disabled={exportCount === 0}
                     style={{
                       padding: '6px 12px', fontSize: 13, color: '#fff', borderRadius: 4, border: 'none',
-                      backgroundColor: includedCount === 0 ? '#9ca3af' : '#4f46e5',
-                      cursor: includedCount === 0 ? 'not-allowed' : 'pointer',
+                      backgroundColor: exportCount === 0 ? '#9ca3af' : '#4f46e5',
+                      cursor: exportCount === 0 ? 'not-allowed' : 'pointer',
                       fontWeight: 600
                     }}
                   >
-                    Export {includedCount} to Excel
+                    Export {exportCount} to Excel
                   </button>
                 </div>
               </div>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3448,10 +3448,31 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       </div>
 
       {/* STICKY INSPECTION-UPDATE REMINDER BANNER */}
-      <div className="sticky top-0 z-20 bg-amber-50 border-l-4 border-amber-500 rounded-lg shadow-md p-4 flex items-start gap-3">
-        <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-        <p className="text-sm text-amber-900 leading-relaxed">
-          <span className="font-semibold">If a recent inspection has been completed,</span> please ensure you run a file update to capture any changes from that inspection. Use the <span className="font-semibold">Listed By</span> and <span className="font-semibold">Date</span> to flip to the most recent inspection in the Appeal Log, then click <span className="font-semibold">Evaluate and Update</span> in that appeal's Detailed Valuation to capture any attribute changes.
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 20,
+          backgroundColor: '#FFFBEB',
+          borderLeft: '4px solid #F59E0B',
+          borderRadius: '8px',
+          boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06)',
+          padding: '14px 16px',
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '12px',
+        }}
+      >
+        <AlertCircle
+          style={{ width: 20, height: 20, color: '#D97706', flexShrink: 0, marginTop: 2 }}
+        />
+        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.55, color: '#78350F' }}>
+          <span style={{ fontWeight: 600 }}>If a recent inspection has been completed,</span>{' '}
+          please ensure you run a file update to capture any changes from that inspection. Use the{' '}
+          <span style={{ fontWeight: 600 }}>Listed By</span> and{' '}
+          <span style={{ fontWeight: 600 }}>Date</span> to flip to the most recent inspection in the
+          Appeal Log, then click <span style={{ fontWeight: 600 }}>Evaluate and Update</span> in
+          that appeal's Detailed Valuation to capture any attribute changes.
         </p>
       </div>
 

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3447,6 +3447,14 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         </div>
       </div>
 
+      {/* STICKY INSPECTION-UPDATE REMINDER BANNER */}
+      <div className="sticky top-0 z-20 bg-amber-50 border-l-4 border-amber-500 rounded-lg shadow-md p-4 flex items-start gap-3">
+        <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+        <p className="text-sm text-amber-900 leading-relaxed">
+          <span className="font-semibold">If a recent inspection has been completed,</span> please ensure you run a file update to capture any changes from that inspection. Use the <span className="font-semibold">Listed By</span> and <span className="font-semibold">Date</span> to flip to the most recent inspection in the Appeal Log, then click <span className="font-semibold">Evaluate and Update</span> in that appeal's Detailed Valuation to capture any attribute changes.
+        </p>
+      </div>
+
       {/* FILTER BAR - DROPDOWN WITH CHIPS */}
       <div className="space-y-4">
         {/* Filter Cards Grid */}

--- a/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
@@ -798,6 +798,7 @@ const AppellantEvidencePanel = ({
               <th className="px-2 py-2 text-left font-semibold">Lot</th>
               <th className="px-2 py-2 text-left font-semibold">Qual</th>
               <th className="px-2 py-2 text-left font-semibold">Card</th>
+              <th className="px-2 py-2 text-left font-semibold">Location</th>
               <th className="px-2 py-2 text-left font-semibold">Sale Date</th>
               <th className="px-2 py-2 text-left font-semibold">Sale Price</th>
               <th className="px-2 py-2 text-left font-semibold">NU</th>
@@ -861,6 +862,11 @@ const AppellantEvidencePanel = ({
                   )}
                   <td className={cellCls('card')} title={cellTitle('card')}>
                     <input type="text" value={slot.card} onChange={e => updateSlot(idx, 'card', e.target.value)} placeholder={compProp ? String(compProp.property_addl_card || compProp.property_card || '') : ''} className="w-12 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
+                  </td>
+                  <td className="px-2 py-1 text-gray-700 whitespace-nowrap" title={slot.is_manual ? (slot.manual_address || '') : (compProp?.property_location || '')}>
+                    {slot.is_manual
+                      ? (slot.manual_address || '\u2014')
+                      : (compProp?.property_location || '\u2014')}
                   </td>
                   <td className={cellCls('sale_date')} title={cellTitle('sale_date')}>
                     <input type="date" value={slot.sales_date || (compProp ? fmtCompDate(compProp.sales_date) : '')} onChange={e => updateSlot(idx, 'sales_date', e.target.value)} className="px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -657,8 +657,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   const getGarageDisplayText = (sqft) => {
     if (!sqft || sqft === 0) return 'None';
     const category = getGarageCategory(sqft);
-    const label = getGarageCategoryLabel(category);
-    return `${label} (${sqft.toLocaleString()} SF)`;
+    return getGarageCategoryLabel(category);
   };
 
   // Helper to render comp cells (shows all 5 even if empty)

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -2596,13 +2596,14 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
             const landMethod = marketLandData?.land_method || marketLandData?.valuation_mode || marketLandData?.cascade_rates?.mode || 'ac';
             const farmMode = !!appealRow.farm_mode;
 
-            const evalHeader = [['#', 'Block', 'Lot', 'Qual', 'Card', 'Sale Date', 'Sale Price', 'NU', 'VCS', 'Design', 'T&U', 'Cond', 'YrBuilt', 'SFLA', 'Lot Size']];
+            const evalHeader = [['#', 'Block', 'Lot', 'Qual', 'Card', 'Location', 'Sale Date', 'Sale Price', 'NU', 'VCS', 'Design', 'T&U', 'Cond', 'YrBuilt', 'SFLA', 'Lot Size']];
             const subjRow = [
               'SUBJ',
               subject.property_block || '',
               subject.property_lot || '',
               subject.property_qualifier || '',
               subject.property_addl_card || subject.property_card || '\u2014',
+              subject.property_location || '\u2014',
               subject.sales_date ? new Date(subject.sales_date).toISOString().split('T')[0] : '\u2014',
               subject.sales_price ? `$${Number(subject.sales_price).toLocaleString()}` : '\u2014',
               subject.sales_nu || '\u2014',
@@ -2638,6 +2639,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                   // BLQ collapses into a single "OOT — address" cell across cols 1-3
                   addr, '', '',
                   slot.card || '\u2014',
+                  slot.manual_address ? String(slot.manual_address).toUpperCase() : '\u2014',
                   slot.sales_date || '\u2014',
                   slot.sales_price ? `$${Number(slot.sales_price).toLocaleString()}` : '\u2014',
                   slot.sales_nu || '\u2014',
@@ -2656,6 +2658,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                 slot.lot || (compProp?.property_lot || ''),
                 slot.qualifier || (compProp?.property_qualifier || ''),
                 slot.card || (compProp?.property_addl_card || compProp?.property_card || '\u2014'),
+                compProp?.property_location || '\u2014',
                 slot.sales_date || (compProp?.sales_date ? new Date(compProp.sales_date).toISOString().split('T')[0] : '\u2014'),
                 (slot.sales_price || compProp?.sales_price) ? `$${Number(slot.sales_price || compProp.sales_price).toLocaleString()}` : '\u2014',
                 slot.sales_nu || compProp?.sales_nu || '\u2014',
@@ -2679,16 +2682,17 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
               null,         // 2: Lot
               null,         // 3: Qual
               'card',       // 4: Card
-              'sale_date',  // 5
-              'sale_price', // 6
-              'sale_nu',    // 7
-              'vcs',        // 8
-              'design',     // 9
-              'type_use',   // 10
-              'condition',  // 11
-              'year_built', // 12
-              'sfla',       // 13
-              'lot_size'    // 14
+              null,         // 5: Location (display only, no flag)
+              'sale_date',  // 6
+              'sale_price', // 7
+              'sale_nu',    // 8
+              'vcs',        // 9
+              'design',     // 10
+              'type_use',   // 11
+              'condition',  // 12
+              'year_built', // 13
+              'sfla',       // 14
+              'lot_size'    // 15
             ];
             // Same pastel hexes used in the panel UI (Tailwind {color}-100).
             const COLOR_FILL = {

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5993,23 +5993,57 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
               return (
                 <div
-                  className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center p-4"
+                  style={{
+                    position: 'fixed',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    zIndex: 50,
+                    backgroundColor: 'rgba(0,0,0,0.5)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 16,
+                  }}
                   onClick={() => setCompBrowserOpen(false)}
                 >
                   <div
-                    className="bg-white rounded-lg shadow-2xl w-full max-w-7xl max-h-[90vh] flex flex-col"
+                    style={{
+                      backgroundColor: '#fff',
+                      borderRadius: 8,
+                      boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)',
+                      width: '95vw',
+                      maxWidth: 1280,
+                      height: '85vh',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      overflow: 'hidden',
+                    }}
                     onClick={(e) => e.stopPropagation()}
                   >
                     {/* Header */}
-                    <div className="px-5 py-3 border-b border-gray-200 bg-gray-50 rounded-t-lg flex items-center justify-between gap-4">
+                    <div
+                      className="px-5 py-3 border-b border-gray-200 bg-gray-50"
+                      style={{
+                        flexShrink: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 16,
+                      }}
+                    >
                       <div>
                         <h3 className="text-base font-semibold text-gray-900">Browse Comps from Sales Pool</h3>
                         <p className="text-xs text-gray-600 mt-0.5">
                           {emptySlots} of 5 slots open · {selectedSet.size} selected · {remainingCapacity} more allowed
                         </p>
                       </div>
-                      <div className="flex items-center gap-3">
-                        <label className="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                        <label
+                          className="text-sm text-gray-700 cursor-pointer"
+                          style={{ display: 'flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap' }}
+                        >
                           <input
                             type="checkbox"
                             checked={compBrowserShowAll}
@@ -6038,8 +6072,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     </div>
 
                     {/* Filter strip */}
-                    <div className="px-5 py-3 border-b border-gray-200 bg-white space-y-2">
-                      <div className="flex flex-wrap items-end gap-3">
+                    <div
+                      className="px-5 py-3 border-b border-gray-200 bg-white"
+                      style={{ flexShrink: 0 }}
+                    >
+                      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-end', gap: 12, marginBottom: 8 }}>
                         <div>
                           <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Sale Date From</label>
                           <input
@@ -6079,7 +6116,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                           />
                         </div>
                       </div>
-                      <div className="flex flex-wrap items-center gap-3 text-xs">
+                      <div className="text-xs" style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
                         {poolFilterVCS.length > 0 && (
                           <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 border border-green-300 text-green-800">
                             VCS: {poolFilterVCS.join(', ')}
@@ -6107,8 +6144,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     </div>
 
                     {/* Table */}
-                    <div className="flex-1 overflow-auto">
-                      <table className="min-w-full text-xs">
+                    <div style={{ flex: '1 1 auto', overflow: 'auto', minHeight: 0 }}>
+                      <table className="min-w-full text-xs" style={{ width: '100%' }}>
                         <thead className="bg-gray-50 sticky top-0 z-10">
                           <tr>
                             <th className="px-2 py-2 text-center font-medium text-gray-600 w-10">Pick</th>
@@ -6189,11 +6226,22 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     </div>
 
                     {/* Footer */}
-                    <div className="px-5 py-3 border-t border-gray-200 bg-gray-50 rounded-b-lg flex items-center justify-between gap-3">
+                    <div
+                      className="px-5 py-3 border-t border-gray-200 bg-gray-50"
+                      style={{
+                        flexShrink: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 12,
+                        borderBottomLeftRadius: 8,
+                        borderBottomRightRadius: 8,
+                      }}
+                    >
                       <div className="text-xs text-gray-600">
                         Showing {rows.length} sale{rows.length === 1 ? '' : 's'} · {compBrowserShowAll ? 'all sales' : 'included only'}
                       </div>
-                      <div className="flex items-center gap-2">
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                         <button
                           type="button"
                           onClick={handleClearAllComps}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -183,6 +183,13 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   const [isManualEvaluating, setIsManualEvaluating] = useState(false);
   const [editingResultIndex, setEditingResultIndex] = useState(null); // Track which result row is being edited
 
+  // Comp browser modal (Detailed tab) — lets users hand-pick comps from the
+  // sales pool without leaving Detailed. Shares filter state with Sales Pool.
+  const [compBrowserOpen, setCompBrowserOpen] = useState(false);
+  const [compBrowserSelected, setCompBrowserSelected] = useState([]); // ordered array of _poolKey
+  const [compBrowserShowAll, setCompBrowserShowAll] = useState(false); // false = green (included) only
+  const [compBrowserSearch, setCompBrowserSearch] = useState('');
+
   // Tracks which saved result set (if any) is currently loaded. When set,
   // "Evaluate and update" in Detailed will write back to this row in
   // job_cme_result_sets so the user doesn't have to switch tabs and re-save.
@@ -5681,8 +5688,21 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
             {/* Manual Entry Grid */}
             <div data-cme-manual-entry className="bg-white border-2 border-gray-300 rounded-lg overflow-hidden">
-              <div className="bg-gray-100 px-4 py-3 border-b border-gray-300">
+              <div className="bg-gray-100 px-4 py-3 border-b border-gray-300 flex items-center justify-between gap-3">
                 <h4 className="font-semibold text-gray-900">Property Entry</h4>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCompBrowserSelected([]);
+                    setCompBrowserSearch('');
+                    setCompBrowserOpen(true);
+                  }}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded hover:bg-blue-700"
+                  title="Browse the sales pool and load comps without leaving Detailed"
+                >
+                  <List className="w-3.5 h-3.5" />
+                  Browse Comps from Sales Pool
+                </button>
               </div>
 
               <div className="overflow-x-auto">
@@ -5871,6 +5891,342 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 />
               </div>
             )}
+
+            {/* COMP BROWSER MODAL — pick comps from the sales pool without leaving Detailed.
+                Default view = green (included) sales only. Toggle to see the full pool with
+                the same green/yellow/red coloring used in Sales Pool. Selection cap respects
+                empty slots in manualComps; already-loaded comps are disabled. */}
+            {compBrowserOpen && (() => {
+              const normPart = (v) => String(v == null ? '' : v).trim().toUpperCase();
+              const slotKey = (s) => `${normPart(s.block)}|${normPart(s.lot)}|${normPart(s.qualifier)}`;
+              const propKey = (p) => `${normPart(p.property_block)}|${normPart(p.property_lot)}|${normPart(p.property_qualifier)}`;
+              const loadedKeys = new Set(
+                manualComps.filter(c => c.block && c.lot).map(slotKey)
+              );
+              const emptySlots = manualComps.filter(c => !c.block && !c.lot).length;
+
+              // Source set: green-only by default, full pool when "Show all" is on.
+              const baseRows = compBrowserShowAll
+                ? salesPoolEntries
+                : salesPoolEntries.filter(e => e._included);
+
+              // Apply shared filter chips (same as Sales Pool) plus the local search box.
+              let rows = baseRows;
+              if (poolFilterVCS.length > 0) rows = rows.filter(p => poolFilterVCS.includes(p.property_vcs));
+              if (poolFilterType.length > 0) rows = rows.filter(p => poolFilterType.includes(p.asset_type_use));
+              if (poolFilterStyle.length > 0) rows = rows.filter(p => poolFilterStyle.includes(p.asset_design_style));
+              if (poolFilterView.length > 0) rows = rows.filter(p => poolFilterView.includes(p.asset_view));
+              if (compBrowserSearch.trim()) {
+                const q = compBrowserSearch.trim().toLowerCase();
+                rows = rows.filter(p =>
+                  (p.property_block || '').toLowerCase().includes(q) ||
+                  (p.property_lot || '').toLowerCase().includes(q) ||
+                  (p.property_location || '').toLowerCase().includes(q)
+                );
+              }
+              // Newest sales first
+              rows = [...rows].sort((a, b) => String(b.sales_date || '').localeCompare(String(a.sales_date || '')));
+
+              const selectedSet = new Set(compBrowserSelected);
+              const remainingCapacity = Math.max(0, emptySlots - selectedSet.size);
+
+              const toggleSelect = (key, alreadyLoaded) => {
+                if (alreadyLoaded) return;
+                setCompBrowserSelected(prev => {
+                  if (prev.includes(key)) return prev.filter(k => k !== key);
+                  if (prev.length >= emptySlots) return prev; // cap enforced
+                  return [...prev, key];
+                });
+              };
+
+              const handleResetFilters = () => {
+                setCompFilters(prev => ({
+                  ...prev,
+                  salesDateStart: cspDateRange.start,
+                  salesDateEnd: cspDateRange.end,
+                  salesCodes: []
+                }));
+                setStagedDateStart(cspDateRange.start);
+                setStagedDateEnd(cspDateRange.end);
+                setStagedSearch('');
+                setSalesPoolSearch('');
+                setPoolFilterVCS([]);
+                setPoolFilterType([]);
+                setPoolFilterStyle([]);
+                setPoolFilterView([]);
+                setCompBrowserSearch('');
+              };
+
+              const handleClearAllComps = () => {
+                if (manualComps.every(c => !c.block && !c.lot)) return;
+                if (!window.confirm('Clear all 5 comp slots and start fresh? Subject is preserved.')) return;
+                setManualComps([
+                  { block: '', lot: '', qualifier: '' },
+                  { block: '', lot: '', qualifier: '' },
+                  { block: '', lot: '', qualifier: '' },
+                  { block: '', lot: '', qualifier: '' },
+                  { block: '', lot: '', qualifier: '' }
+                ]);
+                setCompBrowserSelected([]);
+              };
+
+              const handleAddSelected = () => {
+                if (compBrowserSelected.length === 0) return;
+                const next = [...manualComps];
+                const emptyIdxs = next
+                  .map((c, i) => (!c.block && !c.lot) ? i : -1)
+                  .filter(i => i >= 0);
+                compBrowserSelected.forEach((key, i) => {
+                  if (i >= emptyIdxs.length) return;
+                  const sale = salesPoolEntries.find(e => e._poolKey === key);
+                  if (!sale) return;
+                  next[emptyIdxs[i]] = {
+                    block: String(sale.property_block || '').trim(),
+                    lot: String(sale.property_lot || '').trim(),
+                    qualifier: String(sale.property_qualifier || '').trim()
+                  };
+                });
+                setManualComps(next);
+                setCompBrowserSelected([]);
+                setCompBrowserOpen(false);
+              };
+
+              return (
+                <div
+                  className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center p-4"
+                  onClick={() => setCompBrowserOpen(false)}
+                >
+                  <div
+                    className="bg-white rounded-lg shadow-2xl w-full max-w-7xl max-h-[90vh] flex flex-col"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {/* Header */}
+                    <div className="px-5 py-3 border-b border-gray-200 bg-gray-50 rounded-t-lg flex items-center justify-between gap-4">
+                      <div>
+                        <h3 className="text-base font-semibold text-gray-900">Browse Comps from Sales Pool</h3>
+                        <p className="text-xs text-gray-600 mt-0.5">
+                          {emptySlots} of 5 slots open · {selectedSet.size} selected · {remainingCapacity} more allowed
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <label className="flex items-center gap-1.5 text-sm text-gray-700 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={compBrowserShowAll}
+                            onChange={(e) => setCompBrowserShowAll(e.target.checked)}
+                            className="rounded"
+                          />
+                          Show all sales (not just included)
+                        </label>
+                        <button
+                          type="button"
+                          onClick={handleResetFilters}
+                          className="px-2.5 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded hover:bg-gray-100"
+                          title="Clear all filters (date range, codes, VCS, Type/Use, Style, View, search). These filters are shared with Sales Pool."
+                        >
+                          Reset Filters
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setCompBrowserOpen(false)}
+                          className="p-1 text-gray-500 hover:text-gray-800 hover:bg-gray-200 rounded"
+                          title="Close"
+                        >
+                          <X className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Filter strip */}
+                    <div className="px-5 py-3 border-b border-gray-200 bg-white space-y-2">
+                      <div className="flex flex-wrap items-end gap-3">
+                        <div>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Sale Date From</label>
+                          <input
+                            type="date"
+                            value={stagedDateStart}
+                            onChange={(e) => setStagedDateStart(e.target.value)}
+                            className="px-2 py-1 text-sm border border-gray-300 rounded"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Sale Date To</label>
+                          <input
+                            type="date"
+                            value={stagedDateEnd}
+                            onChange={(e) => setStagedDateEnd(e.target.value)}
+                            className="px-2 py-1 text-sm border border-gray-300 rounded"
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setCompFilters(prev => ({ ...prev, salesDateStart: stagedDateStart, salesDateEnd: stagedDateEnd }));
+                            setSalesPoolSearch(stagedSearch);
+                          }}
+                          className="px-2.5 py-1 text-xs font-medium text-white bg-blue-600 rounded hover:bg-blue-700"
+                        >
+                          Apply Dates
+                        </button>
+                        <div className="flex-1 min-w-[180px]">
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Search Block / Lot / Address</label>
+                          <input
+                            type="text"
+                            value={compBrowserSearch}
+                            onChange={(e) => setCompBrowserSearch(e.target.value)}
+                            placeholder="Quick search…"
+                            className="w-full px-2 py-1 text-sm border border-gray-300 rounded"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-3 text-xs">
+                        {poolFilterVCS.length > 0 && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 border border-green-300 text-green-800">
+                            VCS: {poolFilterVCS.join(', ')}
+                          </span>
+                        )}
+                        {poolFilterType.length > 0 && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-100 border border-blue-300 text-blue-800">
+                            Type/Use: {poolFilterType.join(', ')}
+                          </span>
+                        )}
+                        {poolFilterStyle.length > 0 && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-violet-100 border border-violet-300 text-violet-800">
+                            Style: {poolFilterStyle.join(', ')}
+                          </span>
+                        )}
+                        {poolFilterView.length > 0 && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 border border-amber-300 text-amber-800">
+                            View: {poolFilterView.join(', ')}
+                          </span>
+                        )}
+                        {(poolFilterVCS.length + poolFilterType.length + poolFilterStyle.length + poolFilterView.length) === 0 && (
+                          <span className="text-gray-500">No VCS / Type / Style / View filters active. Manage these from the Sales Pool tab.</span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Table */}
+                    <div className="flex-1 overflow-auto">
+                      <table className="min-w-full text-xs">
+                        <thead className="bg-gray-50 sticky top-0 z-10">
+                          <tr>
+                            <th className="px-2 py-2 text-center font-medium text-gray-600 w-10">Pick</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">VCS</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Block</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Lot</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Qual</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Class</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Location</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Style</th>
+                            <th className="px-2 py-2 text-right font-medium text-gray-600">Sales Price</th>
+                            <th className="px-2 py-2 text-right font-medium text-gray-600">SFLA</th>
+                            <th className="px-2 py-2 text-right font-medium text-gray-600">PPSF</th>
+                            <th className="px-2 py-2 text-center font-medium text-gray-600">NU</th>
+                            <th className="px-2 py-2 text-left font-medium text-gray-600">Sale Date</th>
+                            <th className="px-2 py-2 text-right font-medium text-gray-600">Yr Built</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-100">
+                          {rows.length === 0 && (
+                            <tr>
+                              <td colSpan={14} className="px-4 py-8 text-center text-gray-500">
+                                No sales match the current filters. Try Reset Filters or toggle "Show all sales".
+                              </td>
+                            </tr>
+                          )}
+                          {rows.map((p, idx) => {
+                            const key = p._poolKey;
+                            const alreadyLoaded = loadedKeys.has(propKey(p));
+                            const isSelected = selectedSet.has(key);
+                            const ppsf = p.sales_price && p.asset_sfla > 0 ? p.sales_price / p.asset_sfla : 0;
+                            const rowBg = alreadyLoaded
+                              ? 'bg-gray-100 text-gray-400'
+                              : (p._included ? 'bg-green-50' : '');
+                            return (
+                              <tr
+                                key={key + '-' + idx}
+                                className={`${rowBg} ${alreadyLoaded ? '' : 'hover:bg-blue-50'} transition-colors`}
+                              >
+                                <td className="px-2 py-1.5 text-center">
+                                  {alreadyLoaded ? (
+                                    <span title="Already loaded in comp grid" className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-300 text-white">
+                                      <CheckCircle className="w-4 h-4" />
+                                    </span>
+                                  ) : (
+                                    <input
+                                      type="checkbox"
+                                      checked={isSelected}
+                                      disabled={!isSelected && remainingCapacity === 0}
+                                      onChange={() => toggleSelect(key, alreadyLoaded)}
+                                      className="rounded cursor-pointer"
+                                      title={!isSelected && remainingCapacity === 0 ? 'Slot cap reached — uncheck a row or clear comps' : ''}
+                                    />
+                                  )}
+                                </td>
+                                <td className="px-2 py-1.5 whitespace-nowrap">
+                                  {p.property_vcs || ''}
+                                  {p._isFarm && <span className="ml-1 px-1 py-0.5 text-[10px] font-medium bg-amber-100 text-amber-800 rounded">FARM</span>}
+                                  {p._isPackage && !p._isFarm && <span className="ml-1 px-1 py-0.5 text-[10px] font-medium bg-violet-100 text-violet-800 rounded">PKG</span>}
+                                </td>
+                                <td className="px-2 py-1.5">{p.property_block}</td>
+                                <td className="px-2 py-1.5">{p.property_lot}</td>
+                                <td className="px-2 py-1.5">{p.property_qualifier || ''}</td>
+                                <td className="px-2 py-1.5">{p.property_m4_class || ''}</td>
+                                <td className="px-2 py-1.5 truncate max-w-[180px]" title={p.property_location || ''}>{p.property_location || ''}</td>
+                                <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_design_style ? getCodeLabel('style', p.asset_design_style) : ''}</td>
+                                <td className="px-2 py-1.5 text-right font-mono">{p.sales_price ? `$${Number(p.sales_price).toLocaleString()}` : '-'}</td>
+                                <td className="px-2 py-1.5 text-right">{p.asset_sfla ? Number(p.asset_sfla).toLocaleString() : '-'}</td>
+                                <td className="px-2 py-1.5 text-right font-mono">{ppsf > 0 ? `$${ppsf.toFixed(0)}` : '-'}</td>
+                                <td className="px-2 py-1.5 text-center">{p.sales_nu || '00'}</td>
+                                <td className="px-2 py-1.5">{p.sales_date || ''}</td>
+                                <td className="px-2 py-1.5 text-right">{p.asset_year_built || ''}</td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {/* Footer */}
+                    <div className="px-5 py-3 border-t border-gray-200 bg-gray-50 rounded-b-lg flex items-center justify-between gap-3">
+                      <div className="text-xs text-gray-600">
+                        Showing {rows.length} sale{rows.length === 1 ? '' : 's'} · {compBrowserShowAll ? 'all sales' : 'included only'}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={handleClearAllComps}
+                          className="px-3 py-1.5 text-xs font-medium text-red-700 bg-white border border-red-300 rounded hover:bg-red-50"
+                          title="Empty all 5 comp slots so you can pick a fresh set (subject is preserved)"
+                        >
+                          Clear All Comps
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setCompBrowserOpen(false)}
+                          className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded hover:bg-gray-100"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleAddSelected}
+                          disabled={compBrowserSelected.length === 0}
+                          className={`px-3 py-1.5 text-xs font-medium rounded ${
+                            compBrowserSelected.length === 0
+                              ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                              : 'bg-blue-600 text-white hover:bg-blue-700'
+                          }`}
+                        >
+                          Add Selected ({compBrowserSelected.length})
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })()}
 
           </div>
         )}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5982,6 +5982,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 location: (p) => p.property_location || '',
                 sales_date: (p) => p.sales_date || '',
                 sales_price: (p) => Number(p.sales_price) || 0,
+                nu: (p) => p.sales_nu || '',
                 type_use: (p) => (p.asset_type_use ? (getCodeLabel('typeUse', p.asset_type_use) || p.asset_type_use) : ''),
                 style: (p) => (p.asset_design_style ? (getCodeLabel('style', p.asset_design_style) || p.asset_design_style) : ''),
                 year_built: (p) => Number(p.asset_year_built) || 0,
@@ -6470,6 +6471,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                               { key: 'location', label: 'Location', align: 'left' },
                               { key: 'sales_date', label: 'Sale Date', align: 'left' },
                               { key: 'sales_price', label: 'Sale Price', align: 'right' },
+                              { key: 'nu', label: 'NU', align: 'center' },
                               { key: 'type_use', label: 'Type/Use', align: 'left' },
                               { key: 'style', label: 'Style', align: 'left' },
                               { key: 'year_built', label: 'Yr Built', align: 'right' },
@@ -6505,7 +6507,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         <tbody className="divide-y divide-gray-100">
                           {rows.length === 0 && (
                             <tr>
-                              <td colSpan={15} className="px-4 py-8 text-center text-gray-500">
+                              <td colSpan={16} className="px-4 py-8 text-center text-gray-500">
                                 No sales match the current filters. Try Reset Filters or toggle "Show all sales".
                               </td>
                             </tr>
@@ -6558,6 +6560,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                                 <td className="px-2 py-1.5 truncate max-w-[180px]" title={p.property_location || ''}>{p.property_location || ''}</td>
                                 <td className="px-2 py-1.5">{p.sales_date || ''}</td>
                                 <td className="px-2 py-1.5 text-right font-mono">{p.sales_price ? `$${Number(p.sales_price).toLocaleString()}` : '-'}</td>
+                                <td className="px-2 py-1.5 text-center">{p.sales_nu || '00'}</td>
                                 <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_type_use ? getCodeLabel('typeUse', p.asset_type_use) : ''}</td>
                                 <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_design_style ? getCodeLabel('style', p.asset_design_style) : ''}</td>
                                 <td className="px-2 py-1.5 text-right">{p.asset_year_built || ''}</td>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1592,6 +1592,23 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         return;
       }
 
+      // Mirror the bulk Evaluate readiness gate: confirm Adjustments Configuration,
+      // Adjustments Grid defaults, AND Attribute Condition Config are all saved.
+      // Without condition config, interior/exterior condition ranks silently return 0.
+      try {
+        const ackKey = `cme_eval_ack_${jobData?.id}`;
+        const alreadyAcked = sessionStorage.getItem(ackKey) === '1';
+        if (!alreadyAcked) {
+          const { configMissing, adjustmentsMissing, conditionConfigMissing } = await checkAdjustmentReadiness();
+          if (configMissing || adjustmentsMissing || conditionConfigMissing) {
+            setPreEvalCheck({ configMissing, adjustmentsMissing, conditionConfigMissing });
+            setIsManualEvaluating(false);
+            return;
+          }
+          sessionStorage.setItem(ackKey, '1');
+        }
+      } catch (_) { /* non-critical */ }
+
       // Find subject by block, lot, qualifier (normalize for comparison)
       const subjectRaw = properties.find(p => {
         const blockMatch = (p.property_block || '').trim().toUpperCase() === manualSubject.block.trim().toUpperCase();
@@ -1778,7 +1795,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   // Verifies the user has saved the Adjustments Configuration AND the Adjustments grid
   // before letting an Evaluate run go through. Only blocks the FIRST evaluate per session per job.
   const checkAdjustmentReadiness = async () => {
-    if (!jobData?.id) return { configMissing: false, adjustmentsMissing: false };
+    if (!jobData?.id) return { configMissing: false, adjustmentsMissing: false, conditionConfigMissing: false };
     try {
       const [{ data: settingsRows }, { data: gridRows }] = await Promise.all([
         supabase
@@ -1794,10 +1811,13 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       const configMissing = !settingsRows || settingsRows.length === 0;
       const hasDefaults = (gridRows || []).some(r => r.is_default === true);
       const adjustmentsMissing = !hasDefaults;
-      return { configMissing, adjustmentsMissing };
+      const condCfg = jobData?.attribute_condition_config;
+      const conditionConfigMissing = !condCfg ||
+        (typeof condCfg === 'object' && !condCfg.interior && !condCfg.exterior);
+      return { configMissing, adjustmentsMissing, conditionConfigMissing };
     } catch (e) {
       console.warn('Pre-evaluate readiness check failed (allowing evaluate):', e?.message);
-      return { configMissing: false, adjustmentsMissing: false };
+      return { configMissing: false, adjustmentsMissing: false, conditionConfigMissing: false };
     }
   };
 
@@ -1815,9 +1835,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       const ackKey = `cme_eval_ack_${jobData?.id}`;
       const alreadyAcked = sessionStorage.getItem(ackKey) === '1';
       if (!alreadyAcked) {
-        const { configMissing, adjustmentsMissing } = await checkAdjustmentReadiness();
-        if (configMissing || adjustmentsMissing) {
-          setPreEvalCheck({ configMissing, adjustmentsMissing });
+        const { configMissing, adjustmentsMissing, conditionConfigMissing } = await checkAdjustmentReadiness();
+        if (configMissing || adjustmentsMissing || conditionConfigMissing) {
+          setPreEvalCheck({ configMissing, adjustmentsMissing, conditionConfigMissing });
           return; // Block evaluate until user resolves
         }
         sessionStorage.setItem(ackKey, '1');
@@ -7393,7 +7413,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
               <div>
                 <h3 className="text-lg font-semibold text-gray-900">Setup required before evaluating</h3>
                 <p className="text-sm text-gray-600 mt-1">
-                  Two quick clicks before you run the first evaluation on this job:
+                  A few quick clicks before you run the first evaluation on this job:
                 </p>
               </div>
             </div>
@@ -7415,6 +7435,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 <span className="text-gray-800">
                   <strong>Save Adjustments Grid</strong> — open <em>Adjustments → Adjustment Grid</em> and click <strong>Save Adjustments</strong>.
                   This locks in bracket values used during evaluation.
+                </span>
+              </li>
+              <li className="flex items-start gap-2 text-sm">
+                <span className={preEvalCheck.conditionConfigMissing ? 'text-red-500' : 'text-green-600'}>
+                  {preEvalCheck.conditionConfigMissing ? '✗' : '✓'}
+                </span>
+                <span className="text-gray-800">
+                  <strong>Save Attribute Condition Config</strong> — open <em>Market Analysis → Attribute Cards</em> and save the interior/exterior condition baseline, better, and worse codes.
+                  Without this, condition adjustments silently fall back to baseline (0) during evaluation.
                 </span>
               </li>
             </ul>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -6133,12 +6133,20 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                           const subjType = subjectForBrowser.asset_type_use
                             ? (getCodeLabel('typeUse', subjectForBrowser.asset_type_use) || subjectForBrowser.asset_type_use)
                             : null;
+                          const subjIntCondCode = subjectForBrowser.asset_int_cond || '';
+                          const subjIntCondName = subjIntCondCode && codeDefinitions
+                            ? (interpretCodes.getInteriorConditionName(subjectForBrowser, codeDefinitions, vendorType) || '')
+                            : '';
+                          const subjIntCond = subjIntCondCode
+                            ? (subjIntCondName ? `${subjIntCondCode} (${subjIntCondName})` : subjIntCondCode)
+                            : null;
                           const chips = [
                             { label: 'VCS', value: subjectForBrowser.property_vcs },
                             { label: 'Type/Use', value: subjType },
                             { label: 'Style', value: subjStyle },
                             { label: 'SFLA', value: subjectForBrowser.asset_sfla ? `${Number(subjectForBrowser.asset_sfla).toLocaleString()} sf` : null },
                             { label: 'Yr Built', value: subjectForBrowser.asset_year_built },
+                            { label: 'Int. Cond.', value: subjIntCond },
                           ].filter(c => c.value != null && c.value !== '');
                           if (chips.length === 0) return null;
                           return (

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -6116,30 +6116,178 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                           />
                         </div>
                       </div>
-                      <div className="text-xs" style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
-                        {poolFilterVCS.length > 0 && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 border border-green-300 text-green-800">
-                            VCS: {poolFilterVCS.join(', ')}
-                          </span>
-                        )}
-                        {poolFilterType.length > 0 && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-100 border border-blue-300 text-blue-800">
-                            Type/Use: {poolFilterType.join(', ')}
-                          </span>
-                        )}
-                        {poolFilterStyle.length > 0 && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-violet-100 border border-violet-300 text-violet-800">
-                            Style: {poolFilterStyle.join(', ')}
-                          </span>
-                        )}
-                        {poolFilterView.length > 0 && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 border border-amber-300 text-amber-800">
-                            View: {poolFilterView.join(', ')}
-                          </span>
-                        )}
-                        {(poolFilterVCS.length + poolFilterType.length + poolFilterStyle.length + poolFilterView.length) === 0 && (
-                          <span className="text-gray-500">No VCS / Type / Style / View filters active. Manage these from the Sales Pool tab.</span>
-                        )}
+                      <div
+                        className="text-xs"
+                        style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 16 }}
+                      >
+                        {/* Sales Codes */}
+                        <div style={{ minWidth: 180 }}>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Sales Code</label>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
+                            {compFilters.salesCodes.map(code => (
+                              <span
+                                key={code}
+                                className="px-2 py-0.5 rounded-full bg-blue-100 border border-blue-300 text-blue-800"
+                                style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                              >
+                                {code || '00'}
+                                <button
+                                  type="button"
+                                  onClick={() => toggleCompFilterChip('salesCodes')(code)}
+                                  className="hover:text-blue-900"
+                                >
+                                  <X className="w-3 h-3" />
+                                </button>
+                              </span>
+                            ))}
+                            <select
+                              value=""
+                              onChange={(e) => {
+                                if (e.target.value && !compFilters.salesCodes.includes(e.target.value)) {
+                                  toggleCompFilterChip('salesCodes')(e.target.value);
+                                }
+                              }}
+                              className="px-1 py-0.5 border border-gray-300 rounded"
+                            >
+                              <option value="">+ Code</option>
+                              {uniqueSalesCodes.filter(c => !compFilters.salesCodes.includes(c)).map(code => (
+                                <option key={code} value={code}>{code || '00'}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+
+                        {/* VCS */}
+                        <div style={{ minWidth: 180 }}>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">VCS</label>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
+                            {poolFilterVCS.map(v => (
+                              <span
+                                key={v}
+                                className="px-2 py-0.5 rounded-full bg-green-100 border border-green-300 text-green-800"
+                                style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                              >
+                                {v}
+                                <button
+                                  type="button"
+                                  onClick={() => setPoolFilterVCS(prev => prev.filter(x => x !== v))}
+                                  className="hover:text-green-900"
+                                >
+                                  <X className="w-3 h-3" />
+                                </button>
+                              </span>
+                            ))}
+                            <select
+                              value=""
+                              onChange={(e) => { if (e.target.value) setPoolFilterVCS(prev => [...prev, e.target.value]); }}
+                              className="px-1 py-0.5 border border-gray-300 rounded"
+                            >
+                              <option value="">+ VCS</option>
+                              {poolUniqueVCS.filter(v => !poolFilterVCS.includes(v)).map(v => (
+                                <option key={v} value={v}>{v}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+
+                        {/* Type/Use */}
+                        <div style={{ minWidth: 180 }}>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Type/Use</label>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
+                            {poolFilterType.map(t => (
+                              <span
+                                key={t}
+                                className="px-2 py-0.5 rounded-full bg-blue-100 border border-blue-300 text-blue-800"
+                                style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                              >
+                                {getCodeLabel('typeUse', t) || t}
+                                <button
+                                  type="button"
+                                  onClick={() => setPoolFilterType(prev => prev.filter(x => x !== t))}
+                                  className="hover:text-blue-900"
+                                >
+                                  <X className="w-3 h-3" />
+                                </button>
+                              </span>
+                            ))}
+                            <select
+                              value=""
+                              onChange={(e) => { if (e.target.value) setPoolFilterType(prev => [...prev, e.target.value]); }}
+                              className="px-1 py-0.5 border border-gray-300 rounded"
+                            >
+                              <option value="">+ Type</option>
+                              {poolUniqueTypes.filter(t => !poolFilterType.includes(t)).map(t => (
+                                <option key={t} value={t}>{getCodeLabel('typeUse', t) || t}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+
+                        {/* Style */}
+                        <div style={{ minWidth: 180 }}>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Style</label>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
+                            {poolFilterStyle.map(s => (
+                              <span
+                                key={s}
+                                className="px-2 py-0.5 rounded-full bg-violet-100 border border-violet-300 text-violet-800"
+                                style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                              >
+                                {getCodeLabel('style', s) || s}
+                                <button
+                                  type="button"
+                                  onClick={() => setPoolFilterStyle(prev => prev.filter(x => x !== s))}
+                                  className="hover:text-violet-900"
+                                >
+                                  <X className="w-3 h-3" />
+                                </button>
+                              </span>
+                            ))}
+                            <select
+                              value=""
+                              onChange={(e) => { if (e.target.value) setPoolFilterStyle(prev => [...prev, e.target.value]); }}
+                              className="px-1 py-0.5 border border-gray-300 rounded"
+                            >
+                              <option value="">+ Style</option>
+                              {poolUniqueStyles.filter(s => !poolFilterStyle.includes(s)).map(s => (
+                                <option key={s} value={s}>{getCodeLabel('style', s) || s}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+
+                        {/* View */}
+                        <div style={{ minWidth: 180 }}>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">View</label>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
+                            {poolFilterView.map(v => (
+                              <span
+                                key={v}
+                                className="px-2 py-0.5 rounded-full bg-amber-100 border border-amber-300 text-amber-800"
+                                style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                              >
+                                {getCodeLabel('view', v) || v}
+                                <button
+                                  type="button"
+                                  onClick={() => setPoolFilterView(prev => prev.filter(x => x !== v))}
+                                  className="hover:text-amber-900"
+                                >
+                                  <X className="w-3 h-3" />
+                                </button>
+                              </span>
+                            ))}
+                            <select
+                              value=""
+                              onChange={(e) => { if (e.target.value) setPoolFilterView(prev => [...prev, e.target.value]); }}
+                              className="px-1 py-0.5 border border-gray-300 rounded"
+                            >
+                              <option value="">+ View</option>
+                              {poolUniqueViews.filter(v => !poolFilterView.includes(v)).map(v => (
+                                <option key={v} value={v}>{getCodeLabel('view', v) || v}</option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
                       </div>
                     </div>
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5980,13 +5980,14 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 qual: (p) => p.property_qualifier || '',
                 class: (p) => p.property_m4_class || '',
                 location: (p) => p.property_location || '',
-                style: (p) => (p.asset_design_style ? (getCodeLabel('style', p.asset_design_style) || p.asset_design_style) : ''),
+                sales_date: (p) => p.sales_date || '',
                 sales_price: (p) => Number(p.sales_price) || 0,
+                type_use: (p) => (p.asset_type_use ? (getCodeLabel('typeUse', p.asset_type_use) || p.asset_type_use) : ''),
+                style: (p) => (p.asset_design_style ? (getCodeLabel('style', p.asset_design_style) || p.asset_design_style) : ''),
+                year_built: (p) => Number(p.asset_year_built) || 0,
                 sfla: (p) => Number(p.asset_sfla) || 0,
                 ppsf: (p) => (p.sales_price && p.asset_sfla > 0 ? p.sales_price / p.asset_sfla : 0),
-                nu: (p) => p.sales_nu || '',
-                sales_date: (p) => p.sales_date || '',
-                year_built: (p) => Number(p.asset_year_built) || 0,
+                int_cond: (p) => p.asset_int_cond || '',
               };
               const numericKeys = new Set(['sales_price', 'sfla', 'ppsf', 'year_built']);
               const sortKey = compBrowserSort.key;
@@ -6467,13 +6468,14 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                               { key: 'qual', label: 'Qual', align: 'left' },
                               { key: 'class', label: 'Class', align: 'left' },
                               { key: 'location', label: 'Location', align: 'left' },
-                              { key: 'style', label: 'Style', align: 'left' },
-                              { key: 'sales_price', label: 'Sales Price', align: 'right' },
-                              { key: 'sfla', label: 'SFLA', align: 'right' },
-                              { key: 'ppsf', label: 'PPSF', align: 'right' },
-                              { key: 'nu', label: 'NU', align: 'center' },
                               { key: 'sales_date', label: 'Sale Date', align: 'left' },
+                              { key: 'sales_price', label: 'Sale Price', align: 'right' },
+                              { key: 'type_use', label: 'Type/Use', align: 'left' },
+                              { key: 'style', label: 'Style', align: 'left' },
                               { key: 'year_built', label: 'Yr Built', align: 'right' },
+                              { key: 'sfla', label: 'Size', align: 'right' },
+                              { key: 'ppsf', label: 'PPSF', align: 'right' },
+                              { key: 'int_cond', label: 'Int. Cond.', align: 'left' },
                             ].map(col => (
                               <th
                                 key={col.key}
@@ -6503,7 +6505,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         <tbody className="divide-y divide-gray-100">
                           {rows.length === 0 && (
                             <tr>
-                              <td colSpan={14} className="px-4 py-8 text-center text-gray-500">
+                              <td colSpan={15} className="px-4 py-8 text-center text-gray-500">
                                 No sales match the current filters. Try Reset Filters or toggle "Show all sales".
                               </td>
                             </tr>
@@ -6516,6 +6518,13 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                             const rowBg = alreadyLoaded
                               ? 'bg-gray-100 text-gray-400'
                               : (p._included ? 'bg-green-50' : '');
+                            const intCondCode = p.asset_int_cond || '';
+                            const intCondName = intCondCode && codeDefinitions
+                              ? (interpretCodes.getInteriorConditionName(p, codeDefinitions, vendorType) || '')
+                              : '';
+                            const intCondDisplay = intCondCode
+                              ? (intCondName ? `${intCondCode} (${intCondName})` : intCondCode)
+                              : '';
                             return (
                               <tr
                                 key={key + '-' + idx}
@@ -6547,13 +6556,14 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                                 <td className="px-2 py-1.5">{p.property_qualifier || ''}</td>
                                 <td className="px-2 py-1.5">{p.property_m4_class || ''}</td>
                                 <td className="px-2 py-1.5 truncate max-w-[180px]" title={p.property_location || ''}>{p.property_location || ''}</td>
-                                <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_design_style ? getCodeLabel('style', p.asset_design_style) : ''}</td>
+                                <td className="px-2 py-1.5">{p.sales_date || ''}</td>
                                 <td className="px-2 py-1.5 text-right font-mono">{p.sales_price ? `$${Number(p.sales_price).toLocaleString()}` : '-'}</td>
+                                <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_type_use ? getCodeLabel('typeUse', p.asset_type_use) : ''}</td>
+                                <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_design_style ? getCodeLabel('style', p.asset_design_style) : ''}</td>
+                                <td className="px-2 py-1.5 text-right">{p.asset_year_built || ''}</td>
                                 <td className="px-2 py-1.5 text-right">{p.asset_sfla ? Number(p.asset_sfla).toLocaleString() : '-'}</td>
                                 <td className="px-2 py-1.5 text-right font-mono">{ppsf > 0 ? `$${ppsf.toFixed(0)}` : '-'}</td>
-                                <td className="px-2 py-1.5 text-center">{p.sales_nu || '00'}</td>
-                                <td className="px-2 py-1.5">{p.sales_date || ''}</td>
-                                <td className="px-2 py-1.5 text-right">{p.asset_year_built || ''}</td>
+                                <td className="px-2 py-1.5 whitespace-nowrap" title={intCondName || ''}>{intCondDisplay || '-'}</td>
                               </tr>
                             );
                           })}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -189,6 +189,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   const [compBrowserSelected, setCompBrowserSelected] = useState([]); // ordered array of _poolKey
   const [compBrowserShowAll, setCompBrowserShowAll] = useState(false); // false = green (included) only
   const [compBrowserSearch, setCompBrowserSearch] = useState('');
+  const [compBrowserRadius, setCompBrowserRadius] = useState(''); // miles; '' = no radius filter
 
   // Tracks which saved result set (if any) is currently loaded. When set,
   // "Evaluate and update" in Detailed will write back to this row in
@@ -5924,6 +5925,31 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                   (p.property_location || '').toLowerCase().includes(q)
                 );
               }
+
+              // Radius filter — only applies if subject is geocoded AND user entered a radius.
+              const subjectForBrowser = manualEvaluationResult?.subject;
+              const subjLat = parseFloat(subjectForBrowser?.property_latitude);
+              const subjLng = parseFloat(subjectForBrowser?.property_longitude);
+              const subjectGeocoded = Number.isFinite(subjLat) && Number.isFinite(subjLng);
+              const radiusMiles = parseFloat(compBrowserRadius);
+              const radiusActive = subjectGeocoded && Number.isFinite(radiusMiles) && radiusMiles > 0;
+
+              // Decorate each row with its distance (when computable) so we can
+              // both filter and surface it in the table for context.
+              rows = rows.map(p => {
+                const cLat = parseFloat(p.property_latitude);
+                const cLng = parseFloat(p.property_longitude);
+                const compGeocoded = Number.isFinite(cLat) && Number.isFinite(cLng);
+                const _distance = subjectGeocoded && compGeocoded
+                  ? distanceMiles([subjLat, subjLng], [cLat, cLng])
+                  : null;
+                return { ...p, _distance };
+              });
+
+              if (radiusActive) {
+                rows = rows.filter(p => p._distance != null && p._distance <= radiusMiles);
+              }
+
               // Newest sales first
               rows = [...rows].sort((a, b) => String(b.sales_date || '').localeCompare(String(a.sales_date || '')));
 
@@ -5955,6 +5981,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 setPoolFilterStyle([]);
                 setPoolFilterView([]);
                 setCompBrowserSearch('');
+                setCompBrowserRadius('');
               };
 
               const handleClearAllComps = () => {
@@ -6105,29 +6132,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         >
                           Apply Dates
                         </button>
-                        <div className="flex-1 min-w-[180px]">
-                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Search Block / Lot / Address</label>
-                          <input
-                            type="text"
-                            value={compBrowserSearch}
-                            onChange={(e) => setCompBrowserSearch(e.target.value)}
-                            placeholder="Quick search…"
-                            className="w-full px-2 py-1 text-sm border border-gray-300 rounded"
-                          />
-                        </div>
-                      </div>
-                      <div
-                        className="text-xs"
-                        style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 16 }}
-                      >
-                        {/* Sales Codes */}
+
+                        {/* Sales Codes (moved up so VCS/Type/Style/View row stays a clean 4-across) */}
                         <div style={{ minWidth: 180 }}>
                           <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Sales Code</label>
                           <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
                             {compFilters.salesCodes.map(code => (
                               <span
                                 key={code}
-                                className="px-2 py-0.5 rounded-full bg-blue-100 border border-blue-300 text-blue-800"
+                                className="text-xs px-2 py-0.5 rounded-full bg-blue-100 border border-blue-300 text-blue-800"
                                 style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
                               >
                                 {code || '00'}
@@ -6147,7 +6160,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                                   toggleCompFilterChip('salesCodes')(e.target.value);
                                 }
                               }}
-                              className="px-1 py-0.5 border border-gray-300 rounded"
+                              className="text-xs px-1 py-1 border border-gray-300 rounded"
                             >
                               <option value="">+ Code</option>
                               {uniqueSalesCodes.filter(c => !compFilters.salesCodes.includes(c)).map(code => (
@@ -6157,8 +6170,49 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                           </div>
                         </div>
 
+                        {/* Radius (gated on subject geocoding) */}
+                        <div title={!subjectGeocoded ? 'Subject is not geocoded — radius filter unavailable' : 'Filter sales by miles from subject'}>
+                          <label
+                            className="block text-[11px] font-medium mb-0.5"
+                            style={{ color: subjectGeocoded ? '#4b5563' : '#9ca3af' }}
+                          >
+                            Within (miles){subjectGeocoded ? '' : ' — subject not geocoded'}
+                          </label>
+                          <input
+                            type="number"
+                            min="0"
+                            step="0.25"
+                            value={compBrowserRadius}
+                            onChange={(e) => setCompBrowserRadius(e.target.value)}
+                            disabled={!subjectGeocoded}
+                            placeholder="e.g. 1.5"
+                            className="px-2 py-1 text-sm border border-gray-300 rounded"
+                            style={{ width: 90, backgroundColor: subjectGeocoded ? '#fff' : '#f3f4f6' }}
+                          />
+                        </div>
+
+                        <div className="flex-1 min-w-[180px]" style={{ flex: '1 1 180px', minWidth: 180 }}>
+                          <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Search Block / Lot / Address</label>
+                          <input
+                            type="text"
+                            value={compBrowserSearch}
+                            onChange={(e) => setCompBrowserSearch(e.target.value)}
+                            placeholder="Quick search…"
+                            className="w-full px-2 py-1 text-sm border border-gray-300 rounded"
+                            style={{ width: '100%' }}
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="text-xs"
+                        style={{
+                          display: 'grid',
+                          gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+                          gap: 16,
+                        }}
+                      >
                         {/* VCS */}
-                        <div style={{ minWidth: 180 }}>
+                        <div style={{ minWidth: 0 }}>
                           <label className="block text-[11px] font-medium text-gray-600 mb-0.5">VCS</label>
                           <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
                             {poolFilterVCS.map(v => (
@@ -6191,7 +6245,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         </div>
 
                         {/* Type/Use */}
-                        <div style={{ minWidth: 180 }}>
+                        <div style={{ minWidth: 0 }}>
                           <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Type/Use</label>
                           <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
                             {poolFilterType.map(t => (
@@ -6224,7 +6278,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         </div>
 
                         {/* Style */}
-                        <div style={{ minWidth: 180 }}>
+                        <div style={{ minWidth: 0 }}>
                           <label className="block text-[11px] font-medium text-gray-600 mb-0.5">Style</label>
                           <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
                             {poolFilterStyle.map(s => (
@@ -6257,7 +6311,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         </div>
 
                         {/* View */}
-                        <div style={{ minWidth: 180 }}>
+                        <div style={{ minWidth: 0 }}>
                           <label className="block text-[11px] font-medium text-gray-600 mb-0.5">View</label>
                           <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4 }}>
                             {poolFilterView.map(v => (

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -190,6 +190,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   const [compBrowserShowAll, setCompBrowserShowAll] = useState(false); // false = green (included) only
   const [compBrowserSearch, setCompBrowserSearch] = useState('');
   const [compBrowserRadius, setCompBrowserRadius] = useState(''); // miles; '' = no radius filter
+  const [compBrowserSort, setCompBrowserSort] = useState({ key: 'sales_date', dir: 'desc' });
 
   // Tracks which saved result set (if any) is currently loaded. When set,
   // "Evaluate and update" in Detailed will write back to this row in
@@ -5970,8 +5971,46 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 rows = rows.filter(p => p._distance != null && p._distance <= radiusMiles);
               }
 
-              // Newest sales first
-              rows = [...rows].sort((a, b) => String(b.sales_date || '').localeCompare(String(a.sales_date || '')));
+              // Sortable columns. Each entry maps a column key to the value extractor
+              // used for comparison; missing values sort last regardless of direction.
+              const sortAccessors = {
+                vcs: (p) => p.property_vcs || '',
+                block: (p) => p.property_block || '',
+                lot: (p) => p.property_lot || '',
+                qual: (p) => p.property_qualifier || '',
+                class: (p) => p.property_m4_class || '',
+                location: (p) => p.property_location || '',
+                style: (p) => (p.asset_design_style ? (getCodeLabel('style', p.asset_design_style) || p.asset_design_style) : ''),
+                sales_price: (p) => Number(p.sales_price) || 0,
+                sfla: (p) => Number(p.asset_sfla) || 0,
+                ppsf: (p) => (p.sales_price && p.asset_sfla > 0 ? p.sales_price / p.asset_sfla : 0),
+                nu: (p) => p.sales_nu || '',
+                sales_date: (p) => p.sales_date || '',
+                year_built: (p) => Number(p.asset_year_built) || 0,
+              };
+              const numericKeys = new Set(['sales_price', 'sfla', 'ppsf', 'year_built']);
+              const sortKey = compBrowserSort.key;
+              const sortDir = compBrowserSort.dir === 'asc' ? 1 : -1;
+              const accessor = sortAccessors[sortKey] || sortAccessors.sales_date;
+              rows = [...rows].sort((a, b) => {
+                const av = accessor(a);
+                const bv = accessor(b);
+                const aMissing = av === '' || av === 0 || av == null;
+                const bMissing = bv === '' || bv === 0 || bv == null;
+                if (aMissing && !bMissing) return 1;
+                if (!aMissing && bMissing) return -1;
+                if (numericKeys.has(sortKey)) return (av - bv) * sortDir;
+                return String(av).localeCompare(String(bv)) * sortDir;
+              });
+
+              const toggleSort = (key) => {
+                setCompBrowserSort(prev => prev.key === key
+                  ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+                  : { key, dir: numericKeys.has(key) || key === 'sales_date' ? 'desc' : 'asc' });
+              };
+              const sortIndicator = (key) => compBrowserSort.key === key
+                ? (compBrowserSort.dir === 'asc' ? ' ▲' : ' ▼')
+                : '';
 
               const selectedSet = new Set(compBrowserSelected);
               const remainingCapacity = Math.max(0, emptySlots - selectedSet.size);
@@ -6080,11 +6119,61 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         gap: 16,
                       }}
                     >
-                      <div>
+                      <div style={{ minWidth: 0, flex: '1 1 auto' }}>
                         <h3 className="text-base font-semibold text-gray-900">Browse Comps from Sales Pool</h3>
                         <p className="text-xs text-gray-600 mt-0.5">
                           {emptySlots} of 5 slots open · {selectedSet.size} selected · {remainingCapacity} more allowed
                         </p>
+                        {subjectForBrowser && (() => {
+                          const subjStyle = subjectForBrowser.asset_design_style
+                            ? (getCodeLabel('style', subjectForBrowser.asset_design_style) || subjectForBrowser.asset_design_style)
+                            : null;
+                          const subjType = subjectForBrowser.asset_type_use
+                            ? (getCodeLabel('typeUse', subjectForBrowser.asset_type_use) || subjectForBrowser.asset_type_use)
+                            : null;
+                          const chips = [
+                            { label: 'VCS', value: subjectForBrowser.property_vcs },
+                            { label: 'Type/Use', value: subjType },
+                            { label: 'Style', value: subjStyle },
+                            { label: 'SFLA', value: subjectForBrowser.asset_sfla ? `${Number(subjectForBrowser.asset_sfla).toLocaleString()} sf` : null },
+                            { label: 'Yr Built', value: subjectForBrowser.asset_year_built },
+                          ].filter(c => c.value != null && c.value !== '');
+                          if (chips.length === 0) return null;
+                          return (
+                            <div
+                              style={{
+                                marginTop: 6,
+                                display: 'flex',
+                                flexWrap: 'wrap',
+                                alignItems: 'center',
+                                gap: 6,
+                                fontSize: 11,
+                              }}
+                              title="Subject snapshot — for quick reference while picking comps"
+                            >
+                              <span style={{ fontWeight: 600, color: '#374151' }}>Subject:</span>
+                              {chips.map(c => (
+                                <span
+                                  key={c.label}
+                                  style={{
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: 4,
+                                    padding: '2px 8px',
+                                    backgroundColor: '#FEF3C7',
+                                    border: '1px solid #FDE68A',
+                                    borderRadius: 9999,
+                                    color: '#92400E',
+                                    whiteSpace: 'nowrap',
+                                  }}
+                                >
+                                  <span style={{ fontWeight: 600 }}>{c.label}:</span>
+                                  <span>{c.value}</span>
+                                </span>
+                              ))}
+                            </div>
+                          );
+                        })()}
                       </div>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                         <label
@@ -6371,19 +6460,44 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         <thead className="bg-gray-50 sticky top-0 z-10">
                           <tr>
                             <th className="px-2 py-2 text-center font-medium text-gray-600 w-10">Pick</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">VCS</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Block</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Lot</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Qual</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Class</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Location</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Style</th>
-                            <th className="px-2 py-2 text-right font-medium text-gray-600">Sales Price</th>
-                            <th className="px-2 py-2 text-right font-medium text-gray-600">SFLA</th>
-                            <th className="px-2 py-2 text-right font-medium text-gray-600">PPSF</th>
-                            <th className="px-2 py-2 text-center font-medium text-gray-600">NU</th>
-                            <th className="px-2 py-2 text-left font-medium text-gray-600">Sale Date</th>
-                            <th className="px-2 py-2 text-right font-medium text-gray-600">Yr Built</th>
+                            {[
+                              { key: 'vcs', label: 'VCS', align: 'left' },
+                              { key: 'block', label: 'Block', align: 'left' },
+                              { key: 'lot', label: 'Lot', align: 'left' },
+                              { key: 'qual', label: 'Qual', align: 'left' },
+                              { key: 'class', label: 'Class', align: 'left' },
+                              { key: 'location', label: 'Location', align: 'left' },
+                              { key: 'style', label: 'Style', align: 'left' },
+                              { key: 'sales_price', label: 'Sales Price', align: 'right' },
+                              { key: 'sfla', label: 'SFLA', align: 'right' },
+                              { key: 'ppsf', label: 'PPSF', align: 'right' },
+                              { key: 'nu', label: 'NU', align: 'center' },
+                              { key: 'sales_date', label: 'Sale Date', align: 'left' },
+                              { key: 'year_built', label: 'Yr Built', align: 'right' },
+                            ].map(col => (
+                              <th
+                                key={col.key}
+                                className={`px-2 py-2 font-medium text-gray-600 text-${col.align}`}
+                              >
+                                <button
+                                  type="button"
+                                  onClick={() => toggleSort(col.key)}
+                                  className="font-medium text-gray-600 hover:text-gray-900"
+                                  style={{
+                                    background: 'none',
+                                    border: 'none',
+                                    padding: 0,
+                                    cursor: 'pointer',
+                                    textAlign: col.align,
+                                    width: '100%',
+                                    color: compBrowserSort.key === col.key ? '#1d4ed8' : undefined,
+                                  }}
+                                  title={`Sort by ${col.label}`}
+                                >
+                                  {col.label}{sortIndicator(col.key)}
+                                </button>
+                              </th>
+                            ))}
                           </tr>
                         </thead>
                         <tbody className="divide-y divide-gray-100">


### PR DESCRIPTION
### Summary
Adds a Chapter 91 commercial mailing audit workflow to the Management Checklist to prevent misclassified commercial mailings (like the Harvey Cedars incident), and enhances the Browse Comps modal in the Sales Comparison tab with richer columns, sortable headers, and interior condition display.

### Problem
The original mailing list generation had no safeguard against class mismatches between `property_m4_class` and `property_cama_class` for commercial properties (4A/4B/4C). This led to situations like 25 residential parcels being mailed as commercial — causing client complaints and rework. Additionally, additional (non-primary) cards were being included in mailing lists, generating duplicate notices, and the pre-evaluation gate only warned on a single missing config rather than checking both adjustment and condition configs.

### Solution
A new Chapter 91 audit flow cross-checks `property_m4_class` against `property_cama_class` for all commercial-class parcels, surfaces mismatches for manual review, and persists Include/Ignore decisions to a `chapter91_audit_decisions` table so the export always respects the audited state. A vendor-aware `isPrimaryCard()` helper is centralized and applied consistently across all mailers. The Browse Comps modal columns and the pre-eval checklist were also improved.

### Key Changes
- **Chapter 91 audit modal**: Builds matched vs. mismatch lists by comparing `property_m4_class` ↔ `property_cama_class` for 4A/4B/4C parcels; surfaces edge cases for Include/Ignore decisions
- **Persistent audit decisions**: Saves/loads Include/Ignore state to `chapter91_audit_decisions` (upsert on `job_id + property_composite_key`); export always respects saved decisions
- **Vendor-aware `isPrimaryCard()` helper**: Centralizes primary-card detection for BRT (numeric `1` or blank) and Microsystems (`M`/`MAIN`/`1`/blank); applied to Initial, Chapter 91, 2nd, and 3rd attempt mailers to eliminate duplicate additional-card notices
- **Mailing data fields expanded**: `property_addl_card` and `property_cama_class` now included in `getAllPropertyRecords` mapping so primary-card guards and cross-checks work correctly
- **Chapter 91 Excel export**: Exports matched + audited-include mismatches with Lisa's requested fields; zip in its own column for mail-merge compatibility
- **Browse Comps modal columns**: Added Interior Condition code + definition column; columns now include VCS, Block, Lot, Qual, Class, Location, Sale Date, Sale Price, NU, Type, Style, Year Built, Size, PPSF, and Interior Condition
- **Pre-eval checklist updated**: Added a third checklist item for missing Attribute Condition Config (interior/exterior condition baseline codes), with AND logic so both adjustment config and condition config must be present before evaluating


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/frosted-slice-ngjppvt2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-frosted-slice-ngjppvt2_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 200`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>frosted-slice-ngjppvt2</branchName>-->