### PR TITLE
Add living basement config, SFLA badge, and payroll banner fix

### DIFF
--- a/SUPABASE_RESOURCE_FIX.md
+++ b/SUPABASE_RESOURCE_FIX.md
@@ -84,6 +84,63 @@ Don't tackle this until you're ready for production. You'll need to:
 
 This is a larger refactor but necessary for security in production.
 
+### What RLS Actually Is (Plain-English Refresher)
+
+Row-Level Security is a Postgres feature that lets the **database** decide which
+rows a connection can see or modify, instead of relying on app-side `WHERE`
+clauses. With RLS off, anyone holding the anon/authenticated key can technically
+read or write every row of every exposed table — the only thing keeping that
+from happening is the filters our React code remembers to add. With RLS on,
+every query is automatically rewritten with a scoping clause based on the
+current session (typical patterns: `auth.uid() = user_id`,
+`organization_id = ...`, or a join into `job_access_grants`).
+
+In Supabase's role model:
+- **anon** and **authenticated** keys go through PostgREST as low-privilege roles
+  and are subject to RLS.
+- **service_role** bypasses RLS entirely. It must only ever be used server-side.
+- That's why the security advisor keeps flagging us — the keys we ship to the
+  browser today aren't being constrained by the database.
+
+### Why It's Off Today
+
+Early development. Writing policies before the data model stabilized would have
+been thrown-away work, and we had no production users to protect.
+
+### Will Turning It Back On Require Code Changes?
+
+Mostly no — RLS lives in the database, not in supabase-js calls. The work is:
+
+1. **Audit any `service_role` usage in client code.** That key bypasses RLS, so
+   if it ever leaked into the browser bundle we have to move that call to a
+   server route / edge function before enabling RLS, otherwise it's the only
+   real refactor risk.
+2. **Confirm every existing query already has a scoping filter.** Once RLS is
+   on, a query like `supabase.from('jobs').select('*')` will silently return
+   only the rows the current user is allowed to see. Usually that's what we
+   want — but any UI that assumed "I'm getting everything" needs to either
+   become an `internal`-org-only view or get an explicit filter.
+3. **Make sure `auth.uid()` is populated** anywhere the anon/authenticated key
+   writes rows on a user's behalf (i.e., the user is signed in).
+4. **Write the policies.** One pass per table, mirroring the
+   `organization_id` / `job_id` / `job_access_grants` logic the app already
+   enforces in `WHERE` clauses today. The `internal` org gets a "see all" check
+   so admins keep working as they do now.
+
+### Recommended Sequencing
+
+1. Inventory every `service_role` usage and confirm none of it ships to the
+   browser.
+2. Roll out the pattern on one low-risk table first (e.g., `profiles`) — enable
+   RLS, write policies, smoke test.
+3. Apply the same pattern table by table, starting with the most sensitive
+   (`property_records`, `appeal_log`, `employees`, `jobs`) and ending with the
+   read-mostly lookup tables.
+4. Advisor warnings (and the monthly vulnerability email) drop off as each
+   table is enabled.
+
+---
+
 **Current state (audited):** 41 of 44 `public.*` tables have RLS **disabled**. The
 only three with RLS enabled are the newer CME-related tables:
 - `job_cme_bracket_mappings`

--- a/SUPABASE_RESOURCE_FIX.md
+++ b/SUPABASE_RESOURCE_FIX.md
@@ -84,6 +84,59 @@ Don't tackle this until you're ready for production. You'll need to:
 
 This is a larger refactor but necessary for security in production.
 
+**Current state (audited):** 41 of 44 `public.*` tables have RLS **disabled**. The
+only three with RLS enabled are the newer CME-related tables:
+- `job_cme_bracket_mappings`
+- `job_cme_result_sets`
+- `job_sales_pool_overrides`
+
+When the production push happens, every other table needs an RLS policy pass —
+most queries are scoped by `organization_id` / `job_id` / `job_access_grants`,
+so the policies should mirror that logic rather than invent new rules.
+
+---
+
+## Supabase Data API Default-Grant Change (May 30 / Oct 30, 2026)
+
+Supabase is changing the default so that **new** tables in `public` are no longer
+exposed to the Data API (supabase-js, PostgREST, GraphQL) unless an explicit
+`GRANT` is added.
+
+- **May 30, 2026:** default for newly-created Supabase projects.
+- **Oct 30, 2026:** enforced on **all existing projects**, including ours.
+
+**What stays safe:** every table that already exists keeps its current grants —
+nothing breaks on the cutover.
+
+**What changes for us:** any new `public.*` table created on or after Oct 30,
+2026 must include explicit grants in its migration, or supabase-js will return a
+`42501` error from the client.
+
+### Required boilerplate for new-table migrations going forward
+
+```sql
+-- Whatever your CREATE TABLE statement is...
+create table public.your_new_table ( ... );
+
+-- Required: expose it to the Data API roles the app uses.
+-- (anon is only needed if the table should be readable without auth.)
+grant select, insert, update, delete on public.your_new_table to authenticated;
+grant select, insert, update, delete on public.your_new_table to service_role;
+
+-- Strongly recommended: enable RLS at create time so the table is never
+-- briefly world-writable while we figure out policies later.
+alter table public.your_new_table enable row level security;
+
+-- Add at least one policy (example — replace with real scope):
+create policy "tenant scoped read"
+  on public.your_new_table
+  for select to authenticated
+  using ( /* org/job scoping check */ );
+```
+
+If a grant is missing in production, PostgREST returns `42501` with the exact
+GRANT statement to fix it — don't paper over that error, run the grant.
+
 ---
 
 ## Priority Order

--- a/src/components/PayrollManagement.jsx
+++ b/src/components/PayrollManagement.jsx
@@ -258,7 +258,10 @@ const PayrollManagement = ({
 
 const loadInitialData = async () => {
     try {
-      // Just check localStorage for last processed info
+      // Source the banner from the DB so it stays sticky across navigation,
+      // re-imports, and browsers/sessions where localStorage may be missing
+      // or out of sync. localStorage is only used to enrich startDate, which
+      // isn't persisted on inspection_data.
       const { data: lastInspection, error } = await supabase
         .from('inspection_data')
         .select('payroll_period_end, payroll_processed_date')
@@ -266,16 +269,33 @@ const loadInitialData = async () => {
         .order('payroll_period_end', { ascending: false })
         .limit(1)
         .single();
-      
-      if (!error && lastInspection) {
-        const storedInfo = localStorage.getItem('lastPayrollProcessed');
-        if (storedInfo) {
+
+      if (error || !lastInspection) return;
+
+      const { count } = await supabase
+        .from('inspection_data')
+        .select('id', { count: 'exact', head: true })
+        .eq('payroll_period_end', lastInspection.payroll_period_end);
+
+      let startDate = null;
+      const storedInfo = localStorage.getItem('lastPayrollProcessed');
+      if (storedInfo) {
+        try {
           const parsed = JSON.parse(storedInfo);
           if (parsed.endDate === lastInspection.payroll_period_end) {
-            setLastProcessedInfo(parsed);
+            startDate = parsed.startDate;
           }
+        } catch (_) {
+          // ignore malformed cache
         }
       }
+
+      setLastProcessedInfo({
+        startDate,
+        endDate: lastInspection.payroll_period_end,
+        processedDate: lastInspection.payroll_processed_date,
+        inspectionCount: count ?? 0,
+      });
     } catch (error) {
       console.error('Error loading last processed info:', error);
       // Don't set error for this, it's not critical
@@ -764,7 +784,8 @@ const loadInitialData = async () => {
         inspectionCount: allInspectionIds.length
       };
       localStorage.setItem('lastPayrollProcessed', JSON.stringify(processInfo));
-      
+      setLastProcessedInfo(processInfo);
+
       setSuccessMessage(`Successfully marked ${allInspectionIds.length} inspections as processed for period ending ${payrollPeriod.endDate}`);
 
       const nextPeriod = getNextPayrollPeriod(payrollPeriod.endDate);
@@ -924,7 +945,9 @@ const loadInitialData = async () => {
             <div>
               <span className="text-blue-700">Period:</span>
               <span className="ml-2 font-medium text-blue-900">
-                {formatDateForDisplay(lastProcessedInfo.startDate)} - {formatDateForDisplay(lastProcessedInfo.endDate)}
+                {lastProcessedInfo.startDate
+                  ? `${formatDateForDisplay(lastProcessedInfo.startDate)} - ${formatDateForDisplay(lastProcessedInfo.endDate)}`
+                  : `Ending ${formatDateForDisplay(lastProcessedInfo.endDate)}`}
               </span>
             </div>
             <div>
@@ -1391,7 +1414,7 @@ const loadInitialData = async () => {
                 </div>
                 <div className="flex items-center">
                   <span className="inline-block w-3 h-3 mr-2 bg-red-500 rounded-full"></span>
-                  <span className="text-gray-600">Stale (>30 days)</span>
+                  <span className="text-gray-600">Stale (&gt;30 days)</span>
                 </div>
                 <div className="flex items-center">
                   <span className="inline-block w-3 h-3 mr-2 bg-gray-400 rounded-full"></span>

--- a/src/components/job-modules/FileUploadButton.jsx
+++ b/src/components/job-modules/FileUploadButton.jsx
@@ -332,7 +332,7 @@ const FileUploadButton = ({
 
 // FIXED: Handle code file update with proper Unicode sanitization and BRT support
 const handleCodeFileUpdate = async () => {
-  if (!codeFile || !codeFileContent) {
+  if (!codeFile) {
     addNotification('Please select a code file first', 'error');
     return;
   }
@@ -343,13 +343,30 @@ const handleCodeFileUpdate = async () => {
     setProcessing(true);
     setProcessingStatus('Processing code file...');
 
+    // Fall back to re-reading the File if state content is missing/empty.
+    // The upload handler sets codeFile synchronously but codeFileContent
+    // only after an await; a stale render or a failed read can leave
+    // content null while the Update Codes button is still visible.
+    let contentToProcess = codeFileContent;
+    if (!contentToProcess || !contentToProcess.length) {
+      try {
+        contentToProcess = await codeFile.text();
+        if (contentToProcess) setCodeFileContent(contentToProcess);
+      } catch (readErr) {
+        throw new Error(`Could not read code file: ${readErr.message}`);
+      }
+    }
+    if (!contentToProcess || !contentToProcess.length) {
+      throw new Error('Selected code file is empty');
+    }
+
     // Call the actual processor to handle the code file properly
     if (job.vendor_type === 'BRT') {
       const { brtProcessor } = await import('../../lib/data-pipeline/brt-processor.js');
-      await brtProcessor.processCodeFile(codeFileContent, job.id);
+      await brtProcessor.processCodeFile(contentToProcess, job.id);
     } else if (job.vendor_type === 'Microsystems') {
       const { microsystemsProcessor } = await import('../../lib/data-pipeline/microsystems-processor.js');
-      await microsystemsProcessor.processCodeFile(codeFileContent, job.id);
+      await microsystemsProcessor.processCodeFile(contentToProcess, job.id);
     } else {
       throw new Error('Unsupported vendor type');
     }

--- a/src/components/job-modules/FileUploadButton.jsx
+++ b/src/components/job-modules/FileUploadButton.jsx
@@ -332,7 +332,7 @@ const FileUploadButton = ({
 
 // FIXED: Handle code file update with proper Unicode sanitization and BRT support
 const handleCodeFileUpdate = async () => {
-  if (!codeFile) {
+  if (!codeFile || !codeFileContent) {
     addNotification('Please select a code file first', 'error');
     return;
   }
@@ -343,30 +343,13 @@ const handleCodeFileUpdate = async () => {
     setProcessing(true);
     setProcessingStatus('Processing code file...');
 
-    // Fall back to re-reading the File if state content is missing/empty.
-    // The upload handler sets codeFile synchronously but codeFileContent
-    // only after an await; a stale render or a failed read can leave
-    // content null while the Update Codes button is still visible.
-    let contentToProcess = codeFileContent;
-    if (!contentToProcess || !contentToProcess.length) {
-      try {
-        contentToProcess = await codeFile.text();
-        if (contentToProcess) setCodeFileContent(contentToProcess);
-      } catch (readErr) {
-        throw new Error(`Could not read code file: ${readErr.message}`);
-      }
-    }
-    if (!contentToProcess || !contentToProcess.length) {
-      throw new Error('Selected code file is empty');
-    }
-
     // Call the actual processor to handle the code file properly
     if (job.vendor_type === 'BRT') {
       const { brtProcessor } = await import('../../lib/data-pipeline/brt-processor.js');
-      await brtProcessor.processCodeFile(contentToProcess, job.id);
+      await brtProcessor.processCodeFile(codeFileContent, job.id);
     } else if (job.vendor_type === 'Microsystems') {
       const { microsystemsProcessor } = await import('../../lib/data-pipeline/microsystems-processor.js');
-      await microsystemsProcessor.processCodeFile(contentToProcess, job.id);
+      await microsystemsProcessor.processCodeFile(codeFileContent, job.id);
     } else {
       throw new Error('Unsupported vendor type');
     }

--- a/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
@@ -224,6 +224,31 @@ const AppellantEvidencePanel = ({
   ), [marketLandData]);
 
   const vendorType = jobData?.vendor_type || jobData?.vendor_detection?.vendor || 'BRT';
+
+  // Mirror DetailedAppraisalGrid / SalesComparisonTab so SFLA stays consistent
+  // across surfaces. Honors market_land_valuation.basement_type_config.
+  const basementTypeConfig = marketLandData?.basement_type_config || null;
+  const getAdjustedSFLA = useCallback((prop) => {
+    if (!prop || !prop.asset_sfla) return prop?.asset_sfla || 0;
+    let sfla = Number(prop.asset_sfla) || 0;
+    const codeMode = (code) => {
+      if (!code) return null;
+      return basementTypeConfig?.codes?.[code.toString().trim().toUpperCase()]?.mode || null;
+    };
+    if (vendorType === 'BRT') {
+      if (codeMode(prop.fin_basement_code_1) === 'subtract') {
+        sfla -= Number(prop.fin_basement_area_1) || 0;
+      }
+      if (codeMode(prop.fin_basement_code_2) === 'subtract') {
+        sfla -= Number(prop.fin_basement_area_2) || 0;
+      }
+    } else if (vendorType === 'Microsystems') {
+      if (basementTypeConfig?.microsystemsMode === 'subtract' && prop.living_basement_area) {
+        sfla -= Number(prop.living_basement_area) || 0;
+      }
+    }
+    return Math.max(0, sfla);
+  }, [vendorType, basementTypeConfig]);
   const codeDefinitions = jobData?.parsed_code_definitions || null;
 
   // ----- Lookup helpers -----
@@ -774,7 +799,7 @@ const AppellantEvidencePanel = ({
             <div><div className="text-[9px] uppercase tracking-wide text-gray-500">T&amp;U</div><div className="font-semibold">{codeWithName(subject, 'asset_type_use')}</div></div>
             <div><div className="text-[9px] uppercase tracking-wide text-gray-500">Cond</div><div className="font-semibold">{codeWithName(subject, 'asset_int_cond')}</div></div>
             <div><div className="text-[9px] uppercase tracking-wide text-gray-500">Year Built</div><div className="font-semibold">{fmtSubjectVal(subject.asset_year_built)}</div></div>
-            <div><div className="text-[9px] uppercase tracking-wide text-gray-500">SFLA</div><div className="font-semibold">{fmtSubjectVal(subject.asset_sfla)}</div></div>
+            <div><div className="text-[9px] uppercase tracking-wide text-gray-500">SFLA</div><div className="font-semibold">{fmtSubjectVal(getAdjustedSFLA(subject) || subject.asset_sfla)}</div></div>
             <div><div className="text-[9px] uppercase tracking-wide text-gray-500">Lot Size</div><div className="font-semibold">{compLotDisplay(subject)}</div></div>
             <div><div className="text-[9px] uppercase tracking-wide text-gray-500">Sale Date</div><div className="font-semibold">{fmtSubjectVal(fmtCompDate(subject.sales_date))}</div></div>
             <div><div className="text-[9px] uppercase tracking-wide text-gray-500">Sale Price</div><div className="font-semibold">{subject.sales_price ? `$${Number(subject.sales_price).toLocaleString()}` : '\u2014'}</div></div>
@@ -914,7 +939,7 @@ const AppellantEvidencePanel = ({
                   <td className={cellCls('sfla')} title={cellTitle('sfla')}>
                     {slot.is_manual
                       ? <input type="number" value={slot.manual_sfla || ''} onChange={e => updateSlot(idx, 'manual_sfla', e.target.value)} placeholder="sf" className="w-20 px-1 py-0.5 border border-gray-300 rounded text-xs bg-white" />
-                      : (compProp?.asset_sfla || '\u2014')}
+                      : ((compProp ? getAdjustedSFLA(compProp) : null) || compProp?.asset_sfla || '\u2014')}
                   </td>
                   <td className={cellCls('lot_size')} title={cellTitle('lot_size')}>
                     {slot.is_manual

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -784,31 +784,113 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     return null;
   };
 
-  // Franklin Township: Exclude finished basement with heat (code "02") from SFLA
+  // ==================== BASEMENT-IN-SFLA HANDLING ====================
+  // Driven by market_land_valuation.basement_type_config (set in
+  // AttributeCardsTab → Basement Type Config). For BRT, codes flagged with
+  // `subtract: true` get their fin_basement_area_N stripped out of SFLA. For
+  // Microsystems, `microsystemsSubtract: true` strips living_basement_area.
+  // Franklin's pre-config hardcode is left as a fallback so behavior doesn't
+  // change for them mid-appeal — their config can be wired up after appeals
+  // close to retire the hardcode entirely.
+  const basementTypeConfig = marketLandData?.basement_type_config || null;
+
+  const getBasementSubtractAmount = (prop) => {
+    if (!prop) return 0;
+    let subtract = 0;
+    if (vendorType === 'BRT') {
+      const cfgCodes = basementTypeConfig?.codes || {};
+      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
+      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
+      if (code1 && cfgCodes[code1]?.subtract && prop.fin_basement_area_1) {
+        subtract += Number(prop.fin_basement_area_1) || 0;
+      }
+      if (code2 && cfgCodes[code2]?.subtract && prop.fin_basement_area_2) {
+        subtract += Number(prop.fin_basement_area_2) || 0;
+      }
+    } else if (vendorType === 'Microsystems') {
+      if (basementTypeConfig?.microsystemsSubtract && prop.living_basement_area) {
+        subtract += Number(prop.living_basement_area) || 0;
+      }
+    }
+    return subtract;
+  };
+
+  // True when the property's SFLA either includes a living-basement area
+  // (BRT code flagged isLiving, or Microsystems living_basement_area > 0)
+  // *and* the user hasn't elected to subtract it. Drives the "*" badge.
+  const sflaIncludesLivingBasement = (prop) => {
+    if (!prop) return false;
+    if (vendorType === 'BRT') {
+      const cfgCodes = basementTypeConfig?.codes || {};
+      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
+      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
+      const flagged = (code) => {
+        if (!code) return false;
+        const cfg = cfgCodes[code];
+        return cfg?.isLiving && !cfg?.subtract;
+      };
+      return flagged(code1) || flagged(code2);
+    }
+    if (vendorType === 'Microsystems') {
+      const livingArea = Number(prop.living_basement_area) || 0;
+      return livingArea > 0 && !basementTypeConfig?.microsystemsSubtract;
+    }
+    return false;
+  };
+
+  const getLivingBasementBadgeArea = (prop) => {
+    if (!prop) return 0;
+    if (vendorType === 'BRT') {
+      const cfgCodes = basementTypeConfig?.codes || {};
+      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
+      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
+      let area = 0;
+      if (code1 && cfgCodes[code1]?.isLiving && !cfgCodes[code1]?.subtract) {
+        area += Number(prop.fin_basement_area_1) || 0;
+      }
+      if (code2 && cfgCodes[code2]?.isLiving && !cfgCodes[code2]?.subtract) {
+        area += Number(prop.fin_basement_area_2) || 0;
+      }
+      return area;
+    }
+    if (vendorType === 'Microsystems') {
+      return Number(prop.living_basement_area) || 0;
+    }
+    return 0;
+  };
+
   const getAdjustedSFLA = (prop) => {
     if (!prop || !prop.asset_sfla) return prop?.asset_sfla || null;
 
+    let sfla = Number(prop.asset_sfla) || 0;
+
+    // Config-driven subtraction (preferred path)
+    const configSubtract = getBasementSubtractAmount(prop);
+    if (configSubtract > 0) {
+      return Math.max(0, sfla - configSubtract);
+    }
+
+    // Legacy Franklin fallback — only when no config has been set for this job.
+    // Once Franklin's config is populated post-appeals, this branch becomes a
+    // no-op and can be removed.
+    const hasConfig = basementTypeConfig && (
+      Object.keys(basementTypeConfig.codes || {}).length > 0 ||
+      basementTypeConfig.microsystemsSubtract
+    );
     const isFranklinJob = jobData?.municipality?.toLowerCase().includes('franklin');
-    if (!isFranklinJob) {
-      return prop.asset_sfla; // No adjustment for other townships
+    if (!hasConfig && isFranklinJob) {
+      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
+      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
+      if ((code1.includes('02') || code1.includes('FIN B W/HEAT')) && prop.fin_basement_area_1) {
+        sfla -= prop.fin_basement_area_1;
+      }
+      if ((code2.includes('02') || code2.includes('FIN B W/HEAT')) && prop.fin_basement_area_2) {
+        sfla -= prop.fin_basement_area_2;
+      }
+      return Math.max(0, sfla);
     }
 
-    // For Franklin: exclude fin_basement_area if code is "02 FIN B W/HEAT" or similar
-    let sfla = prop.asset_sfla;
-    const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
-    const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
-
-    // If finish code 1 is "02", subtract the corresponding area (fin_basement_area_1)
-    if ((code1.includes('02') || code1.includes('FIN B W/HEAT')) && prop.fin_basement_area_1) {
-      sfla -= prop.fin_basement_area_1;
-    }
-
-    // If finish code 2 is "02", subtract the corresponding area (fin_basement_area_2)
-    if ((code2.includes('02') || code2.includes('FIN B W/HEAT')) && prop.fin_basement_area_2) {
-      sfla -= prop.fin_basement_area_2;
-    }
-
-    return Math.max(0, sfla); // Ensure SFLA doesn't go negative
+    return sfla;
   };
 
   // Define attribute order as specified by user
@@ -967,7 +1049,23 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       label: 'Liveable Area',
       render: (prop) => {
         const adjustedSFLA = getAdjustedSFLA(prop);
-        return adjustedSFLA ? adjustedSFLA.toLocaleString() : 'N/A';
+        if (!adjustedSFLA) return 'N/A';
+        const includesLiving = sflaIncludesLivingBasement(prop);
+        if (!includesLiving) return adjustedSFLA.toLocaleString();
+        const livingArea = getLivingBasementBadgeArea(prop);
+        const tip = livingArea > 0
+          ? `SFLA includes ${Math.round(livingArea).toLocaleString()} SF of living/heated basement`
+          : 'SFLA includes living/heated basement';
+        return (
+          <span className="inline-flex items-center gap-1">
+            <span>{adjustedSFLA.toLocaleString()}</span>
+            <span
+              title={tip}
+              className="text-amber-600 font-bold cursor-help"
+              aria-label={tip}
+            >*</span>
+          </span>
+        );
       },
       adjustmentName: 'Living Area (Sq Ft)',
       bold: true

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -786,54 +786,52 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
   // ==================== BASEMENT-IN-SFLA HANDLING ====================
   // Driven by market_land_valuation.basement_type_config (set in
-  // AttributeCardsTab → Basement Type Config). For BRT, codes flagged with
-  // `subtract: true` get their fin_basement_area_N stripped out of SFLA. For
-  // Microsystems, `microsystemsSubtract: true` strips living_basement_area.
+  // AttributeCardsTab → Basement Type Config). Per-code mode is mutually
+  // exclusive:
+  //   'living'   — SFLA already includes the basement; render the * badge,
+  //                suppress the Finished Basement = Yes CME adjustment.
+  //   'subtract' — strip basement SF out of SFLA; let the Finished Basement
+  //                adjustment fire normally.
   // Franklin's pre-config hardcode is left as a fallback so behavior doesn't
   // change for them mid-appeal — their config can be wired up after appeals
   // close to retire the hardcode entirely.
   const basementTypeConfig = marketLandData?.basement_type_config || null;
 
+  const getBasementCodeMode = (code) => {
+    if (!code) return null;
+    const cfg = basementTypeConfig?.codes?.[code.toUpperCase()];
+    return cfg?.mode || null;
+  };
+
   const getBasementSubtractAmount = (prop) => {
     if (!prop) return 0;
     let subtract = 0;
     if (vendorType === 'BRT') {
-      const cfgCodes = basementTypeConfig?.codes || {};
-      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
-      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
-      if (code1 && cfgCodes[code1]?.subtract && prop.fin_basement_area_1) {
+      if (getBasementCodeMode(prop.fin_basement_code_1) === 'subtract') {
         subtract += Number(prop.fin_basement_area_1) || 0;
       }
-      if (code2 && cfgCodes[code2]?.subtract && prop.fin_basement_area_2) {
+      if (getBasementCodeMode(prop.fin_basement_code_2) === 'subtract') {
         subtract += Number(prop.fin_basement_area_2) || 0;
       }
     } else if (vendorType === 'Microsystems') {
-      if (basementTypeConfig?.microsystemsSubtract && prop.living_basement_area) {
+      if (basementTypeConfig?.microsystemsMode === 'subtract' && prop.living_basement_area) {
         subtract += Number(prop.living_basement_area) || 0;
       }
     }
     return subtract;
   };
 
-  // True when the property's SFLA either includes a living-basement area
-  // (BRT code flagged isLiving, or Microsystems living_basement_area > 0)
-  // *and* the user hasn't elected to subtract it. Drives the "*" badge.
+  // True when the property's SFLA includes a living-basement area
+  // (BRT code mode === 'living', or Microsystems mode === 'living' or default).
   const sflaIncludesLivingBasement = (prop) => {
     if (!prop) return false;
     if (vendorType === 'BRT') {
-      const cfgCodes = basementTypeConfig?.codes || {};
-      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
-      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
-      const flagged = (code) => {
-        if (!code) return false;
-        const cfg = cfgCodes[code];
-        return cfg?.isLiving && !cfg?.subtract;
-      };
-      return flagged(code1) || flagged(code2);
+      return getBasementCodeMode(prop.fin_basement_code_1) === 'living'
+        || getBasementCodeMode(prop.fin_basement_code_2) === 'living';
     }
     if (vendorType === 'Microsystems') {
       const livingArea = Number(prop.living_basement_area) || 0;
-      return livingArea > 0 && !basementTypeConfig?.microsystemsSubtract;
+      return livingArea > 0 && basementTypeConfig?.microsystemsMode === 'living';
     }
     return false;
   };
@@ -841,14 +839,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   const getLivingBasementBadgeArea = (prop) => {
     if (!prop) return 0;
     if (vendorType === 'BRT') {
-      const cfgCodes = basementTypeConfig?.codes || {};
-      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
-      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
       let area = 0;
-      if (code1 && cfgCodes[code1]?.isLiving && !cfgCodes[code1]?.subtract) {
+      if (getBasementCodeMode(prop.fin_basement_code_1) === 'living') {
         area += Number(prop.fin_basement_area_1) || 0;
       }
-      if (code2 && cfgCodes[code2]?.isLiving && !cfgCodes[code2]?.subtract) {
+      if (getBasementCodeMode(prop.fin_basement_code_2) === 'living') {
         area += Number(prop.fin_basement_area_2) || 0;
       }
       return area;
@@ -875,7 +870,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     // no-op and can be removed.
     const hasConfig = basementTypeConfig && (
       Object.keys(basementTypeConfig.codes || {}).length > 0 ||
-      basementTypeConfig.microsystemsSubtract
+      basementTypeConfig.microsystemsMode
     );
     const isFranklinJob = jobData?.municipality?.toLowerCase().includes('franklin');
     if (!hasConfig && isFranklinJob) {
@@ -3642,7 +3637,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                         case 'enclosed_porch_area': rawPropertyValue = aggregatedSubject.enclosed_porch_area; break;
                         case 'pool_area': rawPropertyValue = aggregatedSubject.pool_area; break;
                         case 'basement_area': rawPropertyValue = aggregatedSubject.basement_area; break;
-                        case 'fin_bsmt_area': rawPropertyValue = aggregatedSubject.fin_basement_area; break;
+                        case 'fin_bsmt_area':
+                          // Suppress when subject's basement is treated as
+                          // living-in-SFLA (already counted via SFLA).
+                          rawPropertyValue = sflaIncludesLivingBasement(aggregatedSubject) ? 0 : aggregatedSubject.fin_basement_area;
+                          break;
                         case 'ac_area': rawPropertyValue = aggregatedSubject.ac_area; break;
                         default: break;
                       }
@@ -3700,7 +3699,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                         rawPropertyValue = comp.basement_area;
                         break;
                       case 'fin_bsmt_area':
-                        rawPropertyValue = comp.fin_basement_area;
+                        // Suppress when this comp's basement is treated as
+                        // living-in-SFLA — counting it again here would double
+                        // up against the SFLA-driven adjustment.
+                        rawPropertyValue = sflaIncludesLivingBasement(comp) ? 0 : comp.fin_basement_area;
                         break;
                       case 'ac_area':
                         rawPropertyValue = comp.ac_area;

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -2730,7 +2730,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
               codeWithName(subject, 'asset_type_use'),
               codeWithName(subject, 'asset_int_cond'),
               subject.asset_year_built || '\u2014',
-              subject.asset_sfla || '\u2014',
+              getAdjustedSFLA(subject) || subject.asset_sfla || '\u2014',
               lotDisplay(subject)
             ];
             const evaluations = appellantComps.map(slot => {
@@ -2785,7 +2785,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                 compProp ? codeWithName(compProp, 'asset_type_use') : '\u2014',
                 compProp ? codeWithName(compProp, 'asset_int_cond') : '\u2014',
                 compProp?.asset_year_built || '\u2014',
-                compProp?.asset_sfla || '\u2014',
+                (compProp ? getAdjustedSFLA(compProp) : null) || compProp?.asset_sfla || '\u2014',
                 lotDisplay(compProp)
               ];
             });

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -822,7 +822,8 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   };
 
   // True when the property's SFLA includes a living-basement area
-  // (BRT code mode === 'living', or Microsystems mode === 'living' or default).
+  // (BRT code mode === 'living', or Microsystems mode === 'living').
+  // Drives the CME suppression logic — only 'living' mode suppresses.
   const sflaIncludesLivingBasement = (prop) => {
     if (!prop) return false;
     if (vendorType === 'BRT') {
@@ -836,14 +837,37 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     return false;
   };
 
+  // True when the property has a configured living basement under EITHER
+  // treatment ('living' or 'subtract'). Drives the SFLA "*" badge — we want
+  // the user to see "this parcel has living basement" regardless of which
+  // treatment is selected; the tooltip explains the math.
+  const hasConfiguredLivingBasement = (prop) => {
+    if (!prop) return false;
+    if (vendorType === 'BRT') {
+      const m1 = getBasementCodeMode(prop.fin_basement_code_1);
+      const m2 = getBasementCodeMode(prop.fin_basement_code_2);
+      return m1 === 'living' || m1 === 'subtract' || m2 === 'living' || m2 === 'subtract';
+    }
+    if (vendorType === 'Microsystems') {
+      const livingArea = Number(prop.living_basement_area) || 0;
+      const mode = basementTypeConfig?.microsystemsMode;
+      return livingArea > 0 && (mode === 'living' || mode === 'subtract');
+    }
+    return false;
+  };
+
+  // Total SF of basement currently treated under the active mode for this
+  // property — used both for the badge tooltip and to size the badge text.
   const getLivingBasementBadgeArea = (prop) => {
     if (!prop) return 0;
     if (vendorType === 'BRT') {
       let area = 0;
-      if (getBasementCodeMode(prop.fin_basement_code_1) === 'living') {
+      const m1 = getBasementCodeMode(prop.fin_basement_code_1);
+      const m2 = getBasementCodeMode(prop.fin_basement_code_2);
+      if (m1 === 'living' || m1 === 'subtract') {
         area += Number(prop.fin_basement_area_1) || 0;
       }
-      if (getBasementCodeMode(prop.fin_basement_code_2) === 'living') {
+      if (m2 === 'living' || m2 === 'subtract') {
         area += Number(prop.fin_basement_area_2) || 0;
       }
       return area;
@@ -1045,12 +1069,13 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       render: (prop) => {
         const adjustedSFLA = getAdjustedSFLA(prop);
         if (!adjustedSFLA) return 'N/A';
+        if (!hasConfiguredLivingBasement(prop)) return adjustedSFLA.toLocaleString();
         const includesLiving = sflaIncludesLivingBasement(prop);
-        if (!includesLiving) return adjustedSFLA.toLocaleString();
-        const livingArea = getLivingBasementBadgeArea(prop);
-        const tip = livingArea > 0
-          ? `SFLA includes ${Math.round(livingArea).toLocaleString()} SF of living/heated basement`
-          : 'SFLA includes living/heated basement';
+        const area = getLivingBasementBadgeArea(prop);
+        const areaStr = area > 0 ? `${Math.round(area).toLocaleString()} SF of ` : '';
+        const tip = includesLiving
+          ? `SFLA includes ${areaStr}living/heated basement (Finished Basement adjustment suppressed)`
+          : `SFLA has ${areaStr}living/heated basement subtracted (Finished Basement adjustment applies)`;
         return (
           <span className="inline-flex items-center gap-1">
             <span>{adjustedSFLA.toLocaleString()}</span>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -823,6 +823,22 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       // Without restoring manualProperties / subjectVCS / subjectTypeUse, a
       // re-run of Evaluate after a reload silently widened to the whole town.
       const savedCriteria = data.search_criteria || null;
+      // Fallback: legacy rows saved before subject_selection was bundled
+      // don't have chips. Reconstruct manualProperties from the saved
+      // result subjects so re-running Evaluate stays scoped to the same
+      // properties instead of silently widening to the whole town.
+      const reconstructedManual = Array.from(new Set(
+        (data.results || [])
+          .map(r => {
+            const s = r?.subject || {};
+            const block = String(s.property_block || '').trim();
+            const lot = String(s.property_lot || '').trim();
+            const qual = String(s.property_qualifier || '').trim();
+            if (!block || !lot) return null;
+            return qual ? `${block}-${lot}-${qual}` : `${block}-${lot}-`;
+          })
+          .filter(Boolean)
+      ));
       if (savedCriteria && typeof savedCriteria === 'object') {
         const { subject_selection, ...savedCompFilters } = savedCriteria;
         setCompFilters(prev => ({
@@ -833,23 +849,26 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           autoAdjustment:
             (data.adjustment_bracket ?? savedCompFilters.adjustmentBracket) === 'auto',
         }));
-        if (subject_selection && typeof subject_selection === 'object') {
-          if (Array.isArray(subject_selection.manualProperties)) {
-            setManualProperties(subject_selection.manualProperties);
-          }
-          if (Array.isArray(subject_selection.subjectVCS)) {
-            setSubjectVCS(subject_selection.subjectVCS);
-          }
-          if (Array.isArray(subject_selection.subjectTypeUse)) {
-            setSubjectTypeUse(subject_selection.subjectTypeUse);
-          }
+        const sel = (subject_selection && typeof subject_selection === 'object') ? subject_selection : {};
+        const savedManual = Array.isArray(sel.manualProperties) ? sel.manualProperties : [];
+        setManualProperties(savedManual.length > 0 ? savedManual : reconstructedManual);
+        if (Array.isArray(sel.subjectVCS)) {
+          setSubjectVCS(sel.subjectVCS);
         }
-      } else if (data.adjustment_bracket) {
-        setCompFilters(prev => ({
-          ...prev,
-          adjustmentBracket: data.adjustment_bracket,
-          autoAdjustment: data.adjustment_bracket === 'auto',
-        }));
+        if (Array.isArray(sel.subjectTypeUse)) {
+          setSubjectTypeUse(sel.subjectTypeUse);
+        }
+      } else {
+        if (data.adjustment_bracket) {
+          setCompFilters(prev => ({
+            ...prev,
+            adjustmentBracket: data.adjustment_bracket,
+            autoAdjustment: data.adjustment_bracket === 'auto',
+          }));
+        }
+        if (reconstructedManual.length > 0) {
+          setManualProperties(reconstructedManual);
+        }
       }
 
       // Scroll to results

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5537,7 +5537,6 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                         <th className="border border-gray-300 px-2 py-2 text-center font-semibold">Address</th>
                         <th className="border border-gray-300 px-2 py-2 text-center font-semibold"># Comps</th>
                         <th className="border border-gray-300 px-2 py-2 text-center font-semibold bg-green-50">Projected Assessment</th>
-                        <th className="border border-gray-300 px-2 py-2 text-center font-semibold">Confidence</th>
                         <th className="border border-gray-300 px-2 py-2 text-center font-semibold">Saved At</th>
                         <th className="border border-gray-300 px-2 py-2 text-center font-semibold">Actions</th>
                       </tr>
@@ -5556,11 +5555,6 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                           </td>
                           <td className="border border-gray-300 px-2 py-1.5 text-center font-semibold text-green-700 bg-green-50">
                             ${(Math.round((evaluation.projected_assessment || 0) / 100) * 100).toLocaleString()}
-                          </td>
-                          <td className="border border-gray-300 px-2 py-1.5 text-center">
-                            {evaluation.confidence_score != null
-                              ? `${(evaluation.confidence_score * 100).toFixed(0)}%`
-                              : '-'}
                           </td>
                           <td className="border border-gray-300 px-2 py-1.5 text-center text-gray-500">
                             {evaluation.created_at

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -396,32 +396,74 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     return 4; // MULTI CAR
   }, [garageThresholds]);
 
-  // Helper: Get adjusted SFLA for Franklin Township (exclude finished basement code "02")
+  // Basement type config (set in AttributeCardsTab → Basement Type Config).
+  // Mirrors the helper set in DetailedAppraisalGrid — see notes there.
+  const basementTypeConfig = marketLandData?.basement_type_config || null;
+
+  const getBasementCodeMode = useCallback((code) => {
+    if (!code) return null;
+    const cfg = basementTypeConfig?.codes?.[code.toString().trim().toUpperCase()];
+    return cfg?.mode || null;
+  }, [basementTypeConfig]);
+
+  // True when SFLA already includes a living/heated basement and the
+  // Finished Basement = Yes CME adjustment should therefore be suppressed.
+  const treatedAsLivingInSFLA = useCallback((prop) => {
+    if (!prop) return false;
+    if (vendorType === 'BRT') {
+      return getBasementCodeMode(prop.fin_basement_code_1) === 'living'
+        || getBasementCodeMode(prop.fin_basement_code_2) === 'living';
+    }
+    if (vendorType === 'Microsystems') {
+      const livingArea = Number(prop.living_basement_area) || 0;
+      return livingArea > 0 && basementTypeConfig?.microsystemsMode === 'living';
+    }
+    return false;
+  }, [vendorType, basementTypeConfig, getBasementCodeMode]);
+
+  // Helper: Get adjusted SFLA. Honors basement_type_config first; falls back
+  // to the legacy Franklin hardcode only when no config is set.
   const getAdjustedSFLA = useCallback((prop) => {
     if (!prop || !prop.asset_sfla) return prop?.asset_sfla || 0;
 
+    let sfla = Number(prop.asset_sfla) || 0;
+
+    // Config-driven subtraction
+    if (vendorType === 'BRT') {
+      if (getBasementCodeMode(prop.fin_basement_code_1) === 'subtract') {
+        sfla -= Number(prop.fin_basement_area_1) || 0;
+      }
+      if (getBasementCodeMode(prop.fin_basement_code_2) === 'subtract') {
+        sfla -= Number(prop.fin_basement_area_2) || 0;
+      }
+    } else if (vendorType === 'Microsystems') {
+      if (basementTypeConfig?.microsystemsMode === 'subtract' && prop.living_basement_area) {
+        sfla -= Number(prop.living_basement_area) || 0;
+      }
+    }
+
+    if (sfla !== Number(prop.asset_sfla)) return Math.max(0, sfla);
+
+    // Legacy Franklin fallback — only when no config has been set
+    const hasConfig = basementTypeConfig && (
+      Object.keys(basementTypeConfig.codes || {}).length > 0 ||
+      basementTypeConfig.microsystemsMode
+    );
     const isFranklinJob = jobData?.municipality?.toLowerCase().includes('franklin');
-    if (!isFranklinJob) {
-      return prop.asset_sfla; // No adjustment for other townships
+    if (!hasConfig && isFranklinJob) {
+      const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
+      const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
+      if ((code1.includes('02') || code1.includes('FIN B W/HEAT')) && prop.fin_basement_area_1) {
+        sfla -= prop.fin_basement_area_1;
+      }
+      if ((code2.includes('02') || code2.includes('FIN B W/HEAT')) && prop.fin_basement_area_2) {
+        sfla -= prop.fin_basement_area_2;
+      }
+      return Math.max(0, sfla);
     }
 
-    // For Franklin: exclude fin_basement_area if code is "02"
-    let sfla = prop.asset_sfla;
-    const code1 = (prop.fin_basement_code_1 || '').toString().trim().toUpperCase();
-    const code2 = (prop.fin_basement_code_2 || '').toString().trim().toUpperCase();
-
-    // If finish code 1 is "02", subtract the corresponding area (fin_basement_area_1)
-    if ((code1.includes('02') || code1.includes('FIN B W/HEAT')) && prop.fin_basement_area_1) {
-      sfla -= prop.fin_basement_area_1;
-    }
-
-    // If finish code 2 is "02", subtract the corresponding area (fin_basement_area_2)
-    if ((code2.includes('02') || code2.includes('FIN B W/HEAT')) && prop.fin_basement_area_2) {
-      sfla -= prop.fin_basement_area_2;
-    }
-
-    return Math.max(0, sfla); // Ensure SFLA doesn't go negative
-  }, [jobData?.municipality]);
+    return sfla;
+  }, [jobData?.municipality, vendorType, basementTypeConfig, getBasementCodeMode]);
 
   // Load garage thresholds and detached condition multipliers on mount
   useEffect(() => {
@@ -2799,9 +2841,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         break;
 
       case 'finished_basement':
-        // Use fin_basement_area column
-        subjectValue = subject.fin_basement_area > 0 ? 1 : 0;
-        compValue = comp.fin_basement_area > 0 ? 1 : 0;
+        // Use fin_basement_area column. Suppress when basement is configured
+        // as 'living' (i.e., already inside SFLA) — counting it again here
+        // double-dips the size-normalized math.
+        subjectValue = (!treatedAsLivingInSFLA(subject) && subject.fin_basement_area > 0) ? 1 : 0;
+        compValue = (!treatedAsLivingInSFLA(comp) && comp.fin_basement_area > 0) ? 1 : 0;
         break;
 
       case 'deck':

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -688,6 +688,18 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         hasSubjectSale: r.hasSubjectSale,
       }));
 
+      // Bundle subject-selection chips into search_criteria so a reload
+      // restores "Which properties do you want to evaluate?" — without these,
+      // re-running Evaluate after a reload silently falls back to whole-town.
+      const searchCriteriaPayload = {
+        ...compFilters,
+        subject_selection: {
+          manualProperties,
+          subjectVCS,
+          subjectTypeUse,
+        },
+      };
+
       let error;
       let savedId = existingId;
       if (shouldOverwrite && existingId) {
@@ -696,7 +708,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           .from('job_cme_result_sets')
           .update({
             adjustment_bracket: compFilters.adjustmentBracket,
-            search_criteria: compFilters,
+            search_criteria: searchCriteriaPayload,
             results: serializedResults,
             updated_at: new Date().toISOString(),
           })
@@ -710,7 +722,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
             job_id: jobData.id,
             name: name.trim(),
             adjustment_bracket: compFilters.adjustmentBracket,
-            search_criteria: compFilters,
+            search_criteria: searchCriteriaPayload,
             results: serializedResults,
           })
           .select('id')
@@ -765,8 +777,32 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       );
       setSelectedForSetAside(allIds);
 
-      // Restore adjustment bracket
-      if (data.adjustment_bracket) {
+      // Restore search criteria (filters) and the subject-selection chips.
+      // Without restoring manualProperties / subjectVCS / subjectTypeUse, a
+      // re-run of Evaluate after a reload silently widened to the whole town.
+      const savedCriteria = data.search_criteria || null;
+      if (savedCriteria && typeof savedCriteria === 'object') {
+        const { subject_selection, ...savedCompFilters } = savedCriteria;
+        setCompFilters(prev => ({
+          ...prev,
+          ...savedCompFilters,
+          adjustmentBracket:
+            data.adjustment_bracket ?? savedCompFilters.adjustmentBracket ?? prev.adjustmentBracket,
+          autoAdjustment:
+            (data.adjustment_bracket ?? savedCompFilters.adjustmentBracket) === 'auto',
+        }));
+        if (subject_selection && typeof subject_selection === 'object') {
+          if (Array.isArray(subject_selection.manualProperties)) {
+            setManualProperties(subject_selection.manualProperties);
+          }
+          if (Array.isArray(subject_selection.subjectVCS)) {
+            setSubjectVCS(subject_selection.subjectVCS);
+          }
+          if (Array.isArray(subject_selection.subjectTypeUse)) {
+            setSubjectTypeUse(subject_selection.subjectTypeUse);
+          }
+        }
+      } else if (data.adjustment_bracket) {
         setCompFilters(prev => ({
           ...prev,
           adjustmentBracket: data.adjustment_bracket,

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1252,7 +1252,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       if (!groups[vcs]) groups[vcs] = { count: 0, totalPrice: 0, sflaSum: 0, yearBuiltSum: 0, yearBuiltCount: 0 };
       groups[vcs].count++;
       if (p.sales_price) { groups[vcs].totalPrice += p.sales_price; totals.totalPrice += p.sales_price; }
-      if (p.asset_sfla) { groups[vcs].sflaSum += p.asset_sfla; totals.sflaSum += p.asset_sfla; }
+      const adjSflaVcs = getAdjustedSFLA(p) || 0;
+      if (adjSflaVcs) { groups[vcs].sflaSum += adjSflaVcs; totals.sflaSum += adjSflaVcs; }
       if (p.asset_year_built) { groups[vcs].yearBuiltSum += p.asset_year_built; groups[vcs].yearBuiltCount++; totals.yearBuiltSum += p.asset_year_built; totals.yearBuiltCount++; }
       totals.count++;
     });
@@ -1283,7 +1284,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       if (!groups[style]) groups[style] = { count: 0, totalPrice: 0, sflaSum: 0 };
       groups[style].count++;
       if (p.sales_price) { groups[style].totalPrice += p.sales_price; totals.totalPrice += p.sales_price; }
-      if (p.asset_sfla) { groups[style].sflaSum += p.asset_sfla; totals.sflaSum += p.asset_sfla; }
+      const adjSflaStyle = getAdjustedSFLA(p) || 0;
+      if (adjSflaStyle) { groups[style].sflaSum += adjSflaStyle; totals.sflaSum += adjSflaStyle; }
       totals.count++;
     });
     const parsedCodes = jobData?.parsed_code_definitions;
@@ -1306,7 +1308,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       if (!groups[type]) groups[type] = { count: 0, totalPrice: 0, sflaSum: 0 };
       groups[type].count++;
       if (p.sales_price) { groups[type].totalPrice += p.sales_price; totals.totalPrice += p.sales_price; }
-      if (p.asset_sfla) { groups[type].sflaSum += p.asset_sfla; totals.sflaSum += p.asset_sfla; }
+      const adjSflaType = getAdjustedSFLA(p) || 0;
+      if (adjSflaType) { groups[type].sflaSum += adjSflaType; totals.sflaSum += adjSflaType; }
       totals.count++;
     });
     const parsedCodes = jobData?.parsed_code_definitions;
@@ -1329,7 +1332,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       if (!groups[view]) groups[view] = { count: 0, totalPrice: 0, sflaSum: 0 };
       groups[view].count++;
       if (p.sales_price) { groups[view].totalPrice += p.sales_price; totals.totalPrice += p.sales_price; }
-      if (p.asset_sfla) { groups[view].sflaSum += p.asset_sfla; totals.sflaSum += p.asset_sfla; }
+      const adjSflaView = getAdjustedSFLA(p) || 0;
+      if (adjSflaView) { groups[view].sflaSum += adjSflaView; totals.sflaSum += adjSflaView; }
       totals.count++;
     });
     const parsedCodes = jobData?.parsed_code_definitions;
@@ -2245,25 +2249,28 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
             }
           }
 
-          // Size filter
+          // Size filter — uses adjusted SFLA on both sides so the math lines
+          // up with what the Detailed grid and sales pool table display.
+          const compAdjSfla = getAdjustedSFLA(comp) || 0;
+          const subjectAdjSfla = getAdjustedSFLA(subject) || 0;
           if (compFilters.useSizeRange) {
-            if (compFilters.sizeMin && comp.asset_sfla < parseInt(compFilters.sizeMin)) {
+            if (compFilters.sizeMin && compAdjSfla < parseInt(compFilters.sizeMin)) {
               if (isFirstProperty) debugFilters.size++;
-              logExclusion('SFLA min', `comp=${comp.asset_sfla} < min=${compFilters.sizeMin}`);
+              logExclusion('SFLA min', `comp=${compAdjSfla} < min=${compFilters.sizeMin}`);
               return false;
             }
-            if (compFilters.sizeMax && comp.asset_sfla > parseInt(compFilters.sizeMax)) {
+            if (compFilters.sizeMax && compAdjSfla > parseInt(compFilters.sizeMax)) {
               if (isFirstProperty) debugFilters.size++;
-              logExclusion('SFLA max', `comp=${comp.asset_sfla} > max=${compFilters.sizeMax}`);
+              logExclusion('SFLA max', `comp=${compAdjSfla} > max=${compFilters.sizeMax}`);
               return false;
             }
           } else if (compFilters.sizeWithinSqft > 0) {
             // Only apply tolerance filter if it's set to > 0
             // When cleared (0), no size restriction applies
-            const sizeDiff = Math.abs((comp.asset_sfla || 0) - (subject.asset_sfla || 0));
+            const sizeDiff = Math.abs(compAdjSfla - subjectAdjSfla);
             if (sizeDiff > compFilters.sizeWithinSqft) {
               if (isFirstProperty) debugFilters.size++;
-              logExclusion('SFLA', `diff=${sizeDiff} > limit=${compFilters.sizeWithinSqft} (comp=${comp.asset_sfla}, subject=${subject.asset_sfla})`);
+              logExclusion('SFLA', `diff=${sizeDiff} > limit=${compFilters.sizeWithinSqft} (comp=${compAdjSfla}, subject=${subjectAdjSfla})`);
               return false;
             }
           }
@@ -3492,7 +3499,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         'Building Class': subject.asset_building_class || '',
         'Style': subject.asset_design_style || '',
         'Year Built': subject.asset_year_built || '',
-        'SFLA': subject.asset_sfla || 0,
+        'SFLA': getAdjustedSFLA(subject) || 0,
         'Lot Size (SF)': subject.market_manual_lot_sf || subject.asset_lot_sf || 0,
         'Current Land': currentLand,
         'Current Impr': currentImpr,
@@ -4027,25 +4034,33 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       if (poolFilterStyle.length > 0) displayed = displayed.filter(p => poolFilterStyle.includes(p.asset_design_style));
                       if (poolFilterView.length > 0) displayed = displayed.filter(p => poolFilterView.includes(p.asset_view));
 
-                      // Compute derived fields for sorting and display
-                      displayed = displayed.map(p => ({
-                        ...p,
-                        _currentAsmt: p.values_mod_total || p.values_cama_total || 0,
-                        _ppsf: p.sales_price && p.asset_sfla > 0 ? p.sales_price / p.asset_sfla : 0,
-                        // Sales Ratio = Current Assessment / Sale Price (calculate on ALL sales)
-                        _salesRatio: (p.values_mod_total || p.values_cama_total) && p.sales_price > 0
-                          ? ((p.values_mod_total || p.values_cama_total) / p.sales_price) * 100
-                          : 0,
-                      }));
+                      // Compute derived fields for sorting and display.
+                      // SFLA + PPSF use the adjusted SFLA so the table lines
+                      // up with the size filter and the Detailed comp grid.
+                      displayed = displayed.map(p => {
+                        const adjSfla = getAdjustedSFLA(p) || 0;
+                        return {
+                          ...p,
+                          _adjustedSfla: adjSfla,
+                          _currentAsmt: p.values_mod_total || p.values_cama_total || 0,
+                          _ppsf: p.sales_price && adjSfla > 0 ? p.sales_price / adjSfla : 0,
+                          // Sales Ratio = Current Assessment / Sale Price (calculate on ALL sales)
+                          _salesRatio: (p.values_mod_total || p.values_cama_total) && p.sales_price > 0
+                            ? ((p.values_mod_total || p.values_cama_total) / p.sales_price) * 100
+                            : 0,
+                        };
+                      });
 
                       // Sort
                       displayed.sort((a, b) => {
                         const dir = salesPoolSort.dir === 'asc' ? 1 : -1;
                         const field = salesPoolSort.field;
-                        const aVal = a[field];
-                        const bVal = b[field];
+                        // Re-route asset_sfla sort to the adjusted derived field
+                        const effectiveField = field === 'asset_sfla' ? '_adjustedSfla' : field;
+                        const aVal = a[effectiveField];
+                        const bVal = b[effectiveField];
                         // Numeric fields
-                        if (['sales_price', 'asset_sfla', 'asset_year_built', 'asset_lot_acre', 'asset_lot_sf', 'asset_lot_frontage', '_ppsf', '_salesRatio', '_currentAsmt', 'asset_building_class'].includes(field)) {
+                        if (['sales_price', 'asset_sfla', '_adjustedSfla', 'asset_year_built', 'asset_lot_acre', 'asset_lot_sf', 'asset_lot_frontage', '_ppsf', '_salesRatio', '_currentAsmt', 'asset_building_class'].includes(field)) {
                           return ((parseFloat(aVal) || 0) - (parseFloat(bVal) || 0)) * dir;
                         }
                         return String(aVal || '').localeCompare(String(bVal || '')) * dir;
@@ -4125,7 +4140,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                             </td>
                             <td className="px-2 py-1.5 text-right whitespace-nowrap">{lotSizeDisplay}</td>
                             <td className="px-2 py-1.5 text-right">{p.asset_lot_frontage || '-'}</td>
-                            <td className="px-2 py-1.5 text-right">{p.asset_sfla ? Number(p.asset_sfla).toLocaleString() : '-'}</td>
+                            <td className="px-2 py-1.5 text-right">{p._adjustedSfla > 0 ? Number(p._adjustedSfla).toLocaleString() : '-'}</td>
                             <td className="px-2 py-1.5 text-right font-mono">
                               {p._ppsf > 0 ? `$${p._ppsf.toFixed(0)}` : '-'}
                             </td>
@@ -6063,8 +6078,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 type_use: (p) => (p.asset_type_use ? (getCodeLabel('typeUse', p.asset_type_use) || p.asset_type_use) : ''),
                 style: (p) => (p.asset_design_style ? (getCodeLabel('style', p.asset_design_style) || p.asset_design_style) : ''),
                 year_built: (p) => Number(p.asset_year_built) || 0,
-                sfla: (p) => Number(p.asset_sfla) || 0,
-                ppsf: (p) => (p.sales_price && p.asset_sfla > 0 ? p.sales_price / p.asset_sfla : 0),
+                sfla: (p) => Number(getAdjustedSFLA(p)) || 0,
+                ppsf: (p) => {
+                  const adj = Number(getAdjustedSFLA(p)) || 0;
+                  return p.sales_price && adj > 0 ? p.sales_price / adj : 0;
+                },
                 int_cond: (p) => p.asset_int_cond || '',
               };
               const numericKeys = new Set(['sales_price', 'sfla', 'ppsf', 'year_built']);
@@ -6221,7 +6239,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                             { label: 'VCS', value: subjectForBrowser.property_vcs },
                             { label: 'Type/Use', value: subjType },
                             { label: 'Style', value: subjStyle },
-                            { label: 'SFLA', value: subjectForBrowser.asset_sfla ? `${Number(subjectForBrowser.asset_sfla).toLocaleString()} sf` : null },
+                            { label: 'SFLA', value: (() => {
+                              const adj = Number(getAdjustedSFLA(subjectForBrowser)) || 0;
+                              return adj > 0 ? `${adj.toLocaleString()} sf` : null;
+                            })() },
                             { label: 'Yr Built', value: subjectForBrowser.asset_year_built },
                             { label: 'Int. Cond.', value: subjIntCond },
                           ].filter(c => c.value != null && c.value !== '');
@@ -6601,7 +6622,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                             const key = p._poolKey;
                             const alreadyLoaded = loadedKeys.has(propKey(p));
                             const isSelected = selectedSet.has(key);
-                            const ppsf = p.sales_price && p.asset_sfla > 0 ? p.sales_price / p.asset_sfla : 0;
+                            const adjSfla = Number(getAdjustedSFLA(p)) || 0;
+                            const ppsf = p.sales_price && adjSfla > 0 ? p.sales_price / adjSfla : 0;
                             const rowBg = alreadyLoaded
                               ? 'bg-gray-100 text-gray-400'
                               : (p._included ? 'bg-green-50' : '');
@@ -6649,7 +6671,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                                 <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_type_use ? getCodeLabel('typeUse', p.asset_type_use) : ''}</td>
                                 <td className="px-2 py-1.5 whitespace-nowrap">{p.asset_design_style ? getCodeLabel('style', p.asset_design_style) : ''}</td>
                                 <td className="px-2 py-1.5 text-right">{p.asset_year_built || ''}</td>
-                                <td className="px-2 py-1.5 text-right">{p.asset_sfla ? Number(p.asset_sfla).toLocaleString() : '-'}</td>
+                                <td className="px-2 py-1.5 text-right">{adjSfla > 0 ? Number(adjSfla).toLocaleString() : '-'}</td>
                                 <td className="px-2 py-1.5 text-right font-mono">{ppsf > 0 ? `$${ppsf.toFixed(0)}` : '-'}</td>
                                 <td className="px-2 py-1.5 whitespace-nowrap" title={intCondName || ''}>{intCondDisplay || '-'}</td>
                               </tr>

--- a/src/components/job-modules/market-tabs/AttributeCardsTab.jsx
+++ b/src/components/job-modules/market-tabs/AttributeCardsTab.jsx
@@ -110,15 +110,42 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
   const [propertyMarketData, setPropertyMarketData] = useState([]);
 
   // ============ BASEMENT TYPE CONFIG STATE ============
-  const [basementConfig, setBasementConfig] = useState(() => {
-    const seed = marketLandData?.basement_type_config || {};
-    return {
-      codes: seed.codes && typeof seed.codes === 'object' ? seed.codes : {},
-      microsystemsSubtract: !!seed.microsystemsSubtract,
-    };
-  });
+  // Shape: {
+  //   codes: { "<BRT_CODE>": { mode: 'living' | 'subtract' } },  // absence = Off
+  //   microsystemsMode: 'living' | 'subtract' | undefined,        // Microsystems global
+  // }
+  // 'living' = SFLA already includes the basement (badge fires, finished-basement
+  // CME adjustment is suppressed). 'subtract' = strip basement SF out of SFLA
+  // and let the finished-basement CME adjustment fire normally.
+  const normalizeBasementConfig = (raw) => {
+    const out = { codes: {}, microsystemsMode: undefined };
+    if (!raw || typeof raw !== 'object') return out;
+    if (raw.codes && typeof raw.codes === 'object') {
+      Object.entries(raw.codes).forEach(([code, cfg]) => {
+        if (!cfg) return;
+        // Backwards-compat: collapse the old { isLiving, subtract } shape
+        let mode = cfg.mode;
+        if (!mode) {
+          if (cfg.subtract) mode = 'subtract';
+          else if (cfg.isLiving) mode = 'living';
+        }
+        if (mode === 'living' || mode === 'subtract') {
+          out.codes[code.toUpperCase()] = { mode };
+        }
+      });
+    }
+    if (raw.microsystemsMode === 'living' || raw.microsystemsMode === 'subtract') {
+      out.microsystemsMode = raw.microsystemsMode;
+    } else if (raw.microsystemsSubtract) {
+      out.microsystemsMode = 'subtract';
+    }
+    return out;
+  };
+
+  const [basementConfig, setBasementConfig] = useState(() => normalizeBasementConfig(marketLandData?.basement_type_config));
   const [basementSaving, setBasementSaving] = useState(false);
   const [basementSaved, setBasementSaved] = useState(false);
+  const [basementSeedApplied, setBasementSeedApplied] = useState(false);
 
   // Get Type/Use options - CORRECTED based on actual codebase patterns
   const getTypeUseOptions = () => [
@@ -4518,14 +4545,47 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
         setAdditionalResults(marketLandData.additional_cards_rollup);
       }
       if (marketLandData.basement_type_config) {
-        const seed = marketLandData.basement_type_config;
-        setBasementConfig({
-          codes: seed.codes && typeof seed.codes === 'object' ? seed.codes : {},
-          microsystemsSubtract: !!seed.microsystemsSubtract,
-        });
+        setBasementConfig(normalizeBasementConfig(marketLandData.basement_type_config));
       }
     }
   }, [marketLandData]);
+
+  // ============ BASEMENT TYPE CONFIG: BRT description lookup ============
+  // Walk parsed_code_definitions.sections.Residential to find the basement
+  // section (KEY === '30') and build a code -> description map. The shared
+  // interpretCodes.getBRTValue helper hardcodes only a few sections and does
+  // not include basement, so we do the walk locally.
+  const brtBasementCodeDescriptions = useMemo(() => {
+    if (vendorType !== 'BRT') return {};
+    const out = {};
+    const residential = parsedCodeDefinitions?.sections?.Residential;
+    if (!residential) return out;
+    let basementSection = null;
+    for (const sectionData of Object.values(residential)) {
+      if (sectionData?.KEY === '30') {
+        basementSection = sectionData;
+        break;
+      }
+    }
+    if (!basementSection?.MAP) return out;
+    Object.values(basementSection.MAP).forEach(mapItem => {
+      const code = (mapItem?.KEY || mapItem?.DATA?.KEY || '').toString().trim().toUpperCase();
+      const desc = mapItem?.DATA?.VALUE || mapItem?.VALUE;
+      if (code && desc) out[code] = desc;
+    });
+    return out;
+  }, [parsedCodeDefinitions, vendorType]);
+
+  // Pattern for codes/descriptions that should default to 'living' on first load.
+  const isLivingBasementLabel = (code, description) => {
+    const haystack = `${code || ''} ${description || ''}`.toUpperCase();
+    if (/\bLIVING\b/.test(haystack)) return true;
+    if (/\bLIVABLE\b/.test(haystack)) return true;
+    if (/\bHEATED\b/.test(haystack)) return true;
+    if (/W\/HEAT/.test(haystack)) return true;
+    if (/\bWITH\s+HEAT\b/.test(haystack)) return true;
+    return false;
+  };
 
   // ============ BASEMENT TYPE CONFIG: aggregate distinct codes from properties ============
   const basementCodeRows = useMemo(() => {
@@ -4540,7 +4600,8 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
         if (!raw) return;
         const key = raw.toUpperCase();
         if (!map.has(key)) {
-          map.set(key, { code: key, raw, count: 0, totalArea: 0 });
+          const description = brtBasementCodeDescriptions[key] || null;
+          map.set(key, { code: key, raw, count: 0, totalArea: 0, description });
         }
         const row = map.get(key);
         row.count += 1;
@@ -4548,29 +4609,49 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
       });
     });
     return Array.from(map.values()).sort((a, b) => a.code.localeCompare(b.code));
-  }, [properties, vendorType]);
+  }, [properties, vendorType, brtBasementCodeDescriptions]);
 
-  const updateBasementCodeFlag = (code, field, value) => {
+  // Auto-seed defaults the first time we render the tab with codes available.
+  // Only seeds rows that don't already have a saved mode — never overwrites
+  // user choices. Doesn't write to DB; user still has to hit Save.
+  useEffect(() => {
+    if (basementSeedApplied) return;
+    if (vendorType !== 'BRT') return;
+    if (basementCodeRows.length === 0) return;
+    const additions = {};
+    basementCodeRows.forEach(row => {
+      if (basementConfig.codes?.[row.code]) return; // user-set or pre-saved
+      if (isLivingBasementLabel(row.code, row.description)) {
+        additions[row.code] = { mode: 'living' };
+      }
+    });
+    if (Object.keys(additions).length > 0) {
+      setBasementConfig(prev => ({
+        ...prev,
+        codes: { ...(prev.codes || {}), ...additions },
+      }));
+    }
+    setBasementSeedApplied(true);
+  }, [basementCodeRows, basementSeedApplied, vendorType, basementConfig.codes]);
+
+  const setBasementCodeMode = (code, mode) => {
     setBasementConfig(prev => {
       const codes = { ...(prev.codes || {}) };
-      const existing = codes[code] || { isLiving: false, subtract: false };
-      const next = { ...existing, [field]: !!value };
-      // If subtract turns on, isLiving is implied — keep them coherent
-      if (field === 'subtract' && value) next.isLiving = true;
-      // If isLiving turns off, subtract must turn off too
-      if (field === 'isLiving' && !value) next.subtract = false;
-      if (!next.isLiving && !next.subtract) {
-        delete codes[code];
+      if (mode === 'living' || mode === 'subtract') {
+        codes[code] = { mode };
       } else {
-        codes[code] = next;
+        delete codes[code];
       }
       return { ...prev, codes };
     });
     setBasementSaved(false);
   };
 
-  const updateBasementMicroSubtract = (value) => {
-    setBasementConfig(prev => ({ ...prev, microsystemsSubtract: !!value }));
+  const setMicrosystemsBasementMode = (mode) => {
+    setBasementConfig(prev => ({
+      ...prev,
+      microsystemsMode: mode === 'living' || mode === 'subtract' ? mode : undefined,
+    }));
     setBasementSaved(false);
   };
 
@@ -4600,14 +4681,32 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
   const renderBasementTypeConfig = () => {
     return (
       <div className="space-y-4">
-        <div className="bg-blue-50 border border-blue-200 rounded p-4 text-sm text-gray-700">
-          <p className="font-medium text-blue-900 mb-1">Basement Type Configuration</p>
+        <div className="bg-blue-50 border border-blue-200 rounded p-4 text-sm text-gray-700 space-y-2">
+          <p className="font-medium text-blue-900">Basement Type Configuration</p>
           <p>
-            Tell the system which basement types count as <strong>living area</strong> (heated /
-            finished living space) so the SFLA cell can flag it in CME and Detailed. Optionally mark
-            a code as <strong>Subtract from SFLA</strong> if your municipality reports living
-            basement <em>inside</em> the SFLA total — turning that on strips the basement SF out of
-            the displayed/used SFLA the same way Franklin currently does for code <code>02</code>.
+            Pick a treatment per basement code so SFLA and the CME{' '}
+            <em>Finished Basement = Yes</em> adjustment stay consistent.
+          </p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              <strong>In SFLA (Living)</strong> — the SFLA total already includes this basement (heated /
+              living). The Liveable Area cell shows a <span className="text-amber-600 font-bold">*</span>
+              badge, and the <em>Finished Basement = Yes</em> CME adjustment is suppressed so the
+              property isn't counted twice.
+            </li>
+            <li>
+              <strong>Subtract from SFLA</strong> — strip the basement SF out of the displayed/used SFLA
+              (Franklin's behavior for code <code>02</code>). The <em>Finished Basement = Yes</em>
+              adjustment fires normally, treating the basement as its own amenity.
+            </li>
+            <li>
+              <strong>Off</strong> — leave the code alone. SFLA and finished-basement adjustment behave
+              as they always have.
+            </li>
+          </ul>
+          <p className="text-xs text-gray-600">
+            Codes whose description matches <em>Living</em>, <em>Heated</em>, or <em>W/Heat</em> are
+            pre-set to <strong>In SFLA (Living)</strong> on first load. You still have to hit Save.
           </p>
         </div>
 
@@ -4626,45 +4725,31 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
                     <th className="border border-gray-300 px-3 py-2 text-left font-semibold">Description</th>
                     <th className="border border-gray-300 px-3 py-2 text-right font-semibold"># Properties</th>
                     <th className="border border-gray-300 px-3 py-2 text-right font-semibold">Total SF</th>
-                    <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Counts as Living Area</th>
-                    <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Subtract from SFLA</th>
+                    <th className="border border-gray-300 px-3 py-2 text-left font-semibold">Treatment</th>
                   </tr>
                 </thead>
                 <tbody>
                   {basementCodeRows.map(row => {
-                    const cfg = basementConfig.codes?.[row.code] || { isLiving: false, subtract: false };
-                    const description = (() => {
-                      try {
-                        return interpretCodes.getBRTValue(
-                          { fin_basement_code_1: row.raw },
-                          parsedCodeDefinitions,
-                          'fin_basement_code_1'
-                        );
-                      } catch {
-                        return null;
-                      }
-                    })();
+                    const cfg = basementConfig.codes?.[row.code];
+                    const mode = cfg?.mode || '';
                     return (
                       <tr key={row.code} className="border-t border-gray-200">
                         <td className="border border-gray-300 px-3 py-2 font-mono">{row.code}</td>
                         <td className="border border-gray-300 px-3 py-2 text-gray-700">
-                          {description && description !== row.raw ? description : <span className="text-gray-400">—</span>}
+                          {row.description ? row.description : <span className="text-gray-400">— (no description in code file)</span>}
                         </td>
                         <td className="border border-gray-300 px-3 py-2 text-right">{row.count.toLocaleString()}</td>
                         <td className="border border-gray-300 px-3 py-2 text-right">{Math.round(row.totalArea).toLocaleString()}</td>
-                        <td className="border border-gray-300 px-3 py-2 text-center">
-                          <input
-                            type="checkbox"
-                            checked={!!cfg.isLiving}
-                            onChange={e => updateBasementCodeFlag(row.code, 'isLiving', e.target.checked)}
-                          />
-                        </td>
-                        <td className="border border-gray-300 px-3 py-2 text-center">
-                          <input
-                            type="checkbox"
-                            checked={!!cfg.subtract}
-                            onChange={e => updateBasementCodeFlag(row.code, 'subtract', e.target.checked)}
-                          />
+                        <td className="border border-gray-300 px-3 py-2">
+                          <select
+                            value={mode}
+                            onChange={e => setBasementCodeMode(row.code, e.target.value)}
+                            className="px-2 py-1 border border-gray-300 rounded text-sm w-56"
+                          >
+                            <option value="">Off</option>
+                            <option value="living">In SFLA (Living)</option>
+                            <option value="subtract">Subtract from SFLA</option>
+                          </select>
                         </td>
                       </tr>
                     );
@@ -4677,18 +4762,19 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
           <div className="bg-white border border-gray-300 rounded p-4">
             <p className="text-sm text-gray-700 mb-3">
               Microsystems exposes living/heated basement directly via the <code>Bsmt Living Sf</code>
-              field (stored as <code>living_basement_area</code>). Any property with a non-zero value
-              will display the SFLA badge automatically. Use the toggle below if your municipality
-              <em> also</em> rolls that area into <code>Livable Area</code> and you want it stripped
-              back out.
+              field (stored as <code>living_basement_area</code>). Pick how it should be treated:
             </p>
             <label className="inline-flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={!!basementConfig.microsystemsSubtract}
-                onChange={e => updateBasementMicroSubtract(e.target.checked)}
-              />
-              <span>Subtract <code>living_basement_area</code> from displayed SFLA</span>
+              <span>Treatment:</span>
+              <select
+                value={basementConfig.microsystemsMode || ''}
+                onChange={e => setMicrosystemsBasementMode(e.target.value)}
+                className="px-2 py-1 border border-gray-300 rounded text-sm w-56"
+              >
+                <option value="">Off</option>
+                <option value="living">In SFLA (Living)</option>
+                <option value="subtract">Subtract from SFLA</option>
+              </select>
             </label>
           </div>
         )}

--- a/src/components/job-modules/market-tabs/AttributeCardsTab.jsx
+++ b/src/components/job-modules/market-tabs/AttributeCardsTab.jsx
@@ -4577,13 +4577,18 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
   }, [parsedCodeDefinitions, vendorType]);
 
   // Pattern for codes/descriptions that should default to 'living' on first load.
+  // Includes the BRT-truncated forms (LIV / HEAT) since BRT label cells are narrow
+  // and code files routinely abbreviate (e.g. Cedar Grove: "LIV BSMT", or
+  // Franklin: "FIN B W/HEAT").
   const isLivingBasementLabel = (code, description) => {
     const haystack = `${code || ''} ${description || ''}`.toUpperCase();
     if (/\bLIVING\b/.test(haystack)) return true;
     if (/\bLIVABLE\b/.test(haystack)) return true;
+    if (/\bLIV\b/.test(haystack)) return true;            // BRT truncation: "LIV BSMT"
     if (/\bHEATED\b/.test(haystack)) return true;
     if (/W\/HEAT/.test(haystack)) return true;
     if (/\bWITH\s+HEAT\b/.test(haystack)) return true;
+    if (/\bHEAT\b/.test(haystack)) return true;
     return false;
   };
 

--- a/src/components/job-modules/market-tabs/AttributeCardsTab.jsx
+++ b/src/components/job-modules/market-tabs/AttributeCardsTab.jsx
@@ -109,6 +109,17 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
   // ============ PROPERTY MARKET DATA STATE ============
   const [propertyMarketData, setPropertyMarketData] = useState([]);
 
+  // ============ BASEMENT TYPE CONFIG STATE ============
+  const [basementConfig, setBasementConfig] = useState(() => {
+    const seed = marketLandData?.basement_type_config || {};
+    return {
+      codes: seed.codes && typeof seed.codes === 'object' ? seed.codes : {},
+      microsystemsSubtract: !!seed.microsystemsSubtract,
+    };
+  });
+  const [basementSaving, setBasementSaving] = useState(false);
+  const [basementSaved, setBasementSaved] = useState(false);
+
   // Get Type/Use options - CORRECTED based on actual codebase patterns
   const getTypeUseOptions = () => [
     { code: 'all', description: 'All Properties' },
@@ -4506,8 +4517,197 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
       if (marketLandData.additional_cards_rollup) {
         setAdditionalResults(marketLandData.additional_cards_rollup);
       }
+      if (marketLandData.basement_type_config) {
+        const seed = marketLandData.basement_type_config;
+        setBasementConfig({
+          codes: seed.codes && typeof seed.codes === 'object' ? seed.codes : {},
+          microsystemsSubtract: !!seed.microsystemsSubtract,
+        });
+      }
     }
   }, [marketLandData]);
+
+  // ============ BASEMENT TYPE CONFIG: aggregate distinct codes from properties ============
+  const basementCodeRows = useMemo(() => {
+    if (vendorType !== 'BRT') return [];
+    const map = new Map();
+    (properties || []).forEach(p => {
+      [
+        { code: p.fin_basement_code_1, area: p.fin_basement_area_1 },
+        { code: p.fin_basement_code_2, area: p.fin_basement_area_2 },
+      ].forEach(({ code, area }) => {
+        const raw = (code || '').toString().trim();
+        if (!raw) return;
+        const key = raw.toUpperCase();
+        if (!map.has(key)) {
+          map.set(key, { code: key, raw, count: 0, totalArea: 0 });
+        }
+        const row = map.get(key);
+        row.count += 1;
+        row.totalArea += Number(area) || 0;
+      });
+    });
+    return Array.from(map.values()).sort((a, b) => a.code.localeCompare(b.code));
+  }, [properties, vendorType]);
+
+  const updateBasementCodeFlag = (code, field, value) => {
+    setBasementConfig(prev => {
+      const codes = { ...(prev.codes || {}) };
+      const existing = codes[code] || { isLiving: false, subtract: false };
+      const next = { ...existing, [field]: !!value };
+      // If subtract turns on, isLiving is implied — keep them coherent
+      if (field === 'subtract' && value) next.isLiving = true;
+      // If isLiving turns off, subtract must turn off too
+      if (field === 'isLiving' && !value) next.subtract = false;
+      if (!next.isLiving && !next.subtract) {
+        delete codes[code];
+      } else {
+        codes[code] = next;
+      }
+      return { ...prev, codes };
+    });
+    setBasementSaved(false);
+  };
+
+  const updateBasementMicroSubtract = (value) => {
+    setBasementConfig(prev => ({ ...prev, microsystemsSubtract: !!value }));
+    setBasementSaved(false);
+  };
+
+  const saveBasementConfig = async () => {
+    if (!jobData?.id) return;
+    setBasementSaving(true);
+    setBasementSaved(false);
+    try {
+      const { error } = await supabase
+        .from('market_land_valuation')
+        .upsert({
+          job_id: jobData.id,
+          basement_type_config: basementConfig,
+          updated_at: new Date().toISOString(),
+        }, { onConflict: 'job_id' });
+      if (error) throw error;
+      setBasementSaved(true);
+      if (onUpdateJobCache) onUpdateJobCache();
+    } catch (err) {
+      console.error('Error saving basement config:', err);
+      alert(`Failed to save basement config: ${err.message}`);
+    } finally {
+      setBasementSaving(false);
+    }
+  };
+
+  const renderBasementTypeConfig = () => {
+    return (
+      <div className="space-y-4">
+        <div className="bg-blue-50 border border-blue-200 rounded p-4 text-sm text-gray-700">
+          <p className="font-medium text-blue-900 mb-1">Basement Type Configuration</p>
+          <p>
+            Tell the system which basement types count as <strong>living area</strong> (heated /
+            finished living space) so the SFLA cell can flag it in CME and Detailed. Optionally mark
+            a code as <strong>Subtract from SFLA</strong> if your municipality reports living
+            basement <em>inside</em> the SFLA total — turning that on strips the basement SF out of
+            the displayed/used SFLA the same way Franklin currently does for code <code>02</code>.
+          </p>
+        </div>
+
+        {vendorType === 'BRT' ? (
+          basementCodeRows.length === 0 ? (
+            <div className="bg-gray-50 border border-gray-200 rounded p-4 text-sm text-gray-600">
+              No <code>fin_basement_code_*</code> values found on this job's properties yet. Once
+              the source file is loaded with finished/living basement codes, they'll appear here.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full border-collapse text-sm">
+                <thead className="bg-gray-100">
+                  <tr>
+                    <th className="border border-gray-300 px-3 py-2 text-left font-semibold">Code</th>
+                    <th className="border border-gray-300 px-3 py-2 text-left font-semibold">Description</th>
+                    <th className="border border-gray-300 px-3 py-2 text-right font-semibold"># Properties</th>
+                    <th className="border border-gray-300 px-3 py-2 text-right font-semibold">Total SF</th>
+                    <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Counts as Living Area</th>
+                    <th className="border border-gray-300 px-3 py-2 text-center font-semibold">Subtract from SFLA</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {basementCodeRows.map(row => {
+                    const cfg = basementConfig.codes?.[row.code] || { isLiving: false, subtract: false };
+                    const description = (() => {
+                      try {
+                        return interpretCodes.getBRTValue(
+                          { fin_basement_code_1: row.raw },
+                          parsedCodeDefinitions,
+                          'fin_basement_code_1'
+                        );
+                      } catch {
+                        return null;
+                      }
+                    })();
+                    return (
+                      <tr key={row.code} className="border-t border-gray-200">
+                        <td className="border border-gray-300 px-3 py-2 font-mono">{row.code}</td>
+                        <td className="border border-gray-300 px-3 py-2 text-gray-700">
+                          {description && description !== row.raw ? description : <span className="text-gray-400">—</span>}
+                        </td>
+                        <td className="border border-gray-300 px-3 py-2 text-right">{row.count.toLocaleString()}</td>
+                        <td className="border border-gray-300 px-3 py-2 text-right">{Math.round(row.totalArea).toLocaleString()}</td>
+                        <td className="border border-gray-300 px-3 py-2 text-center">
+                          <input
+                            type="checkbox"
+                            checked={!!cfg.isLiving}
+                            onChange={e => updateBasementCodeFlag(row.code, 'isLiving', e.target.checked)}
+                          />
+                        </td>
+                        <td className="border border-gray-300 px-3 py-2 text-center">
+                          <input
+                            type="checkbox"
+                            checked={!!cfg.subtract}
+                            onChange={e => updateBasementCodeFlag(row.code, 'subtract', e.target.checked)}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )
+        ) : (
+          <div className="bg-white border border-gray-300 rounded p-4">
+            <p className="text-sm text-gray-700 mb-3">
+              Microsystems exposes living/heated basement directly via the <code>Bsmt Living Sf</code>
+              field (stored as <code>living_basement_area</code>). Any property with a non-zero value
+              will display the SFLA badge automatically. Use the toggle below if your municipality
+              <em> also</em> rolls that area into <code>Livable Area</code> and you want it stripped
+              back out.
+            </p>
+            <label className="inline-flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={!!basementConfig.microsystemsSubtract}
+                onChange={e => updateBasementMicroSubtract(e.target.checked)}
+              />
+              <span>Subtract <code>living_basement_area</code> from displayed SFLA</span>
+            </label>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={saveBasementConfig}
+            disabled={basementSaving}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 text-sm font-medium"
+          >
+            {basementSaving ? 'Saving…' : 'Save Basement Config'}
+          </button>
+          {basementSaved && (
+            <span className="text-sm text-green-700">✓ Saved</span>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   // Persist state changes to localStorage
   useEffect(() => {
@@ -4586,14 +4786,23 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
         >
           Custom Attribute Analysis
         </button>
-        <button 
-          onClick={() => setActive('additional')} 
+        <button
+          onClick={() => setActive('additional')}
           className={`mls-subtab-btn ${active === 'additional' ? 'mls-subtab-btn--active' : ''}`}
           role="tab"
           aria-selected={active === 'additional'}
           aria-controls="additional-panel"
         >
           Additional Card Analysis
+        </button>
+        <button
+          onClick={() => setActive('basement')}
+          className={`mls-subtab-btn ${active === 'basement' ? 'mls-subtab-btn--active' : ''}`}
+          role="tab"
+          aria-selected={active === 'basement'}
+          aria-controls="basement-panel"
+        >
+          Basement Type Config
         </button>
       </div>
 
@@ -4614,6 +4823,12 @@ const AttributeCardsTab = ({ jobData = {}, properties = [], marketLandData = {},
         {active === 'additional' && (
           <section role="tabpanel" id="additional-panel" aria-labelledby="additional-tab">
             {renderAdditionalCardsAnalysis()}
+          </section>
+        )}
+
+        {active === 'basement' && (
+          <section role="tabpanel" id="basement-panel" aria-labelledby="basement-tab">
+            {renderBasementTypeConfig()}
           </section>
         )}
       </div>

--- a/src/lib/data-pipeline/microsystems-processor.js
+++ b/src/lib/data-pipeline/microsystems-processor.js
@@ -481,6 +481,7 @@ export class MicrosystemsProcessor {
       fireplace_count: this.extractFireplaceCount(rawRecord),
       basement_area: this.extractBasementArea(rawRecord),
       fin_basement_area: this.extractFinBasementArea(rawRecord),
+      living_basement_area: this.extractLivingBasementArea(rawRecord),
       garage_area: this.extractGarageArea(rawRecord),
       deck_area: this.extractDeckArea(rawRecord),
       patio_area: this.extractPatioArea(rawRecord),
@@ -964,6 +965,28 @@ export class MicrosystemsProcessor {
     }
 
     return null;
+  }
+
+  /**
+   * Extract living/heated basement area from Bsmt Living Sf
+   * Same shape as Bsmt Finish Sq Ft — value can be a % of total Basement or raw SF.
+   */
+  extractLivingBasementArea(rawRecord) {
+    const basementArea = this.parseNumeric(rawRecord['Basement']) || 0;
+    const livingValue = rawRecord['Bsmt Living Sf'];
+
+    if (!livingValue || livingValue.toString().trim() === '') return null;
+
+    const str = livingValue.toString();
+    if (str.includes('%')) {
+      const percentage = parseFloat(str.replace('%', '').trim());
+      if (!isNaN(percentage) && basementArea > 0) {
+        return Math.round(basementArea * (percentage / 100));
+      }
+      return null;
+    }
+
+    return this.parseNumeric(str);
   }
 
   /**

--- a/src/lib/data-pipeline/microsystems-updater.js
+++ b/src/lib/data-pipeline/microsystems-updater.js
@@ -605,6 +605,7 @@ export class MicrosystemsUpdater {
       fireplace_count: this.extractFireplaceCount(rawRecord),
       basement_area: this.extractBasementArea(rawRecord),
       fin_basement_area: this.extractFinBasementArea(rawRecord),
+      living_basement_area: this.extractLivingBasementArea(rawRecord),
       garage_area: this.extractGarageArea(rawRecord),
       deck_area: this.extractDeckArea(rawRecord),
       patio_area: this.extractPatioArea(rawRecord),
@@ -1198,6 +1199,28 @@ export class MicrosystemsUpdater {
     }
 
     return null;
+  }
+
+  /**
+   * Extract living/heated basement area from Bsmt Living Sf
+   * Mirrors extractFinBasementArea — value may be % of Basement or raw SF.
+   */
+  extractLivingBasementArea(rawRecord) {
+    const basementArea = this.parseNumeric(rawRecord['Basement']) || 0;
+    const livingValue = rawRecord['Bsmt Living Sf'];
+
+    if (!livingValue || livingValue.toString().trim() === '') return null;
+
+    const str = livingValue.toString();
+    if (str.includes('%')) {
+      const percentage = parseFloat(str.replace('%', '').trim());
+      if (!isNaN(percentage) && basementArea > 0) {
+        return Math.round(basementArea * (percentage / 100));
+      }
+      return null;
+    }
+
+    return this.parseNumeric(str);
   }
 
   /**


### PR DESCRIPTION
### Summary
Introduces a configurable living/heated basement treatment system that controls how basement square footage is counted toward SFLA, adds a visual asterisk badge in the detailed view, and fixes the payroll "last processed" banner to persist correctly across navigation and re-imports.

### Problem
Living and heated basements were always folded into SFLA with no way to configure the behavior per job. Users had no visual indicator when a property's SFLA included living basement area, and the finished-basement adjustment could fire incorrectly depending on how the basement was counted. Additionally, the payroll "last processed" banner would disappear after navigating away or re-importing, because it relied solely on `localStorage`.

### Solution
- Added a **Basement Type Config** sub-tab under Attribute & Card Analytics where users can set per-code treatment (BRT) or a global mode (Microsystems): **In SFLA (Living)**, **Subtract from SFLA**, or **Off**.
- The config drives SFLA calculation and finished-basement adjustment logic consistently across the detailed view, sales comparison, and appellant evidence surfaces.
- An asterisk badge renders in the detailed component whenever a property has living basement area included in SFLA.
- Payroll banner now sources its state from the database on load, making it sticky across sessions, navigation, and re-imports.

### Key Changes
- **`AppellantEvidencePanel.jsx`** — mirrors `DetailedAppraisalGrid` / `SalesComparisonTab` basement config logic; adds `renderBasementTypeConfig()` UI with BRT code-level table and Microsystems single-mode selector; new **Basement Type Config** sub-tab wired into the tab panel.
- **`microsystems-processor.js`** — added `extractLivingBasementArea()` to parse `Bsmt Living Sf` (raw SF or % of total basement) and map it to `living_basement_area`.
- **`microsystems-updater.js`** — same `extractLivingBasementArea()` extraction added to the updater path so incremental updates also capture the field.
- **`PayrollManagement.jsx`** — `loadInitialData` now queries `inspection_data` directly for the last processed period and count, falling back to `localStorage` only for `startDate` enrichment; banner renders gracefully when `startDate` is unavailable; `setLastProcessedInfo` called immediately on process completion so the banner appears without a reload; fixed JSX escape for `>` in legend label.
- **`SUPABASE_RESOURCE_FIX.md`** — added plain-English RLS explainer, current audit status (41 of 44 tables have RLS disabled), recommended sequencing for enabling RLS, and required boilerplate for new-table migrations ahead of the May 30 / Oct 30, 2026 Supabase Data API grant-change deadline.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/frosted-fountain-wgjc3ugd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-frosted-fountain-wgjc3ugd_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 208`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>frosted-fountain-wgjc3ugd</branchName>-->