### PR TITLE
Add persistent billed checkbox to Appeals Summary

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1671,6 +1671,7 @@ const App = () => {
             <AppealsSummary
               jobs={[...filteredPpaJobs, ...specialJobs]}
               onJobSelect={handleJobSelect}
+              currentUser={user}
             />
           );
         })()}

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -615,19 +615,19 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                 <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700">Job Name</th>
                 <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Personal tracker — click the checkbox once you've billed this job">Billed</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Total</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Residential</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Commercial</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Vacant Land</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Defend</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Stipulated</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Heard</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Withdrawn</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Assessor</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Affirmed</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Has CME</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Pro Se</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Attorney</th>
-                <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Hearing</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Residential">Resi</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Commercial">Comm</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Vacant Land">Vcnt Lnd</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700">Defend</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Stipulated">Stip</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700">Heard</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Withdrawn">Wdrn</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Assessor">Asssr</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Affirmed">Affm</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Has CME">CME</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700">Pro Se</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Attorney">Atty</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700">Hearing</th>
               </tr>
             </thead>
             <tbody>
@@ -655,21 +655,21 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                       className="w-4 h-4 accent-green-600 cursor-pointer"
                     />
                   </td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700 font-semibold">{row.totalAppeals}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.vacant !== null ? row.vacant : '—'}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.defend}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.stipulated}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.heard}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.withdrawn}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.assessor}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.affirmed}</td>
-                  <td className={`px-4 py-3 text-sm text-center ${cmeMatchesTotal && !row.isCompleted ? 'text-green-800 font-semibold' : 'text-gray-700'}`}>{row.statusBreakdown.hasCME}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.proSeCount}</td>
-                  <td className="px-4 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700 font-semibold">{row.totalAppeals}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.vacant !== null ? row.vacant : '—'}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.defend}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.stipulated}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.heard}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.withdrawn}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.assessor}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.statusBreakdown.affirmed}</td>
+                  <td className={`px-2 py-3 text-sm text-center ${cmeMatchesTotal && !row.isCompleted ? 'text-green-800 font-semibold' : 'text-gray-700'}`}>{row.statusBreakdown.hasCME}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.proSeCount}</td>
+                  <td className="px-2 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
                   <td
-                    className={`px-4 py-3 text-sm text-center ${
+                    className={`px-2 py-3 text-sm text-center whitespace-nowrap ${
                       row.isCompleted ? 'text-blue-800 font-semibold' : 'text-gray-700'
                     }`}
                   >
@@ -684,20 +684,20 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
               <tr className="bg-blue-50 border-t-2 border-blue-200 font-bold">
                 <td className="px-4 py-3 text-sm text-gray-900">TOTALS</td>
                 <td className="px-2 py-3 text-sm text-center text-gray-900">{billedJobIds.size}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.totalAppeals}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.vacant}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.defend}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.stipulated}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.heard}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.withdrawn}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.assessor}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.affirmed}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.hasCME}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.proSe}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.attorney}</td>
-                <td className="px-4 py-3 text-sm text-center text-gray-900">—</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.totalAppeals}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.vacant}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.defend}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.stipulated}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.heard}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.withdrawn}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.assessor}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.affirmed}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.hasCME}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.proSe}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{totals.attorney}</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">—</td>
               </tr>
             </tbody>
           </table>

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -2,28 +2,63 @@ import React, { useState, useEffect } from 'react';
 import { supabase, formatDateLocalYMD } from '../lib/supabaseClient';
 import { AlertCircle, Calendar, FileText, TrendingUp, FileDown } from 'lucide-react';
 
-const BILLED_JOBS_STORAGE_KEY = 'appealsSummaryBilledJobs';
-
 const AppealsSummary = ({ jobs = [], onJobSelect }) => {
   const [jobAppealsSummary, setJobAppealsSummary] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [availableYears, setAvailableYears] = useState([]);
-  // Click-to-mark-billed state \u2014 persisted per-user via localStorage.
-  // Toggle is forward/reverse: Completed -> Billed -> Completed.
-  const [billedJobIds, setBilledJobIds] = useState(() => {
-    try {
-      const raw = localStorage.getItem(BILLED_JOBS_STORAGE_KEY);
-      return new Set(raw ? JSON.parse(raw) : []);
-    } catch { return new Set(); }
-  });
-  const toggleBilled = (jobId) => {
+  // Personal "I already billed this job" tracker \u2014 per-user row in user_billed_jobs,
+  // keyed by (user_id, job_id, appeal_year). Independent of the BillingManagement module.
+  const [billedJobIds, setBilledJobIds] = useState(new Set());
+  const [currentUserId, setCurrentUserId] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (cancelled) return;
+      setCurrentUserId(user?.id || null);
+      if (!user?.id) { setBilledJobIds(new Set()); return; }
+      const { data, error } = await supabase
+        .from('user_billed_jobs')
+        .select('job_id')
+        .eq('user_id', user.id)
+        .eq('appeal_year', selectedYear);
+      if (cancelled) return;
+      if (error) { console.error('Error loading billed jobs:', error); return; }
+      setBilledJobIds(new Set((data || []).map(r => r.job_id)));
+    })();
+    return () => { cancelled = true; };
+  }, [selectedYear]);
+
+  const toggleBilled = async (jobId) => {
+    if (!currentUserId) return;
+    const wasBilled = billedJobIds.has(jobId);
     setBilledJobIds(prev => {
       const next = new Set(prev);
-      if (next.has(jobId)) next.delete(jobId); else next.add(jobId);
-      try { localStorage.setItem(BILLED_JOBS_STORAGE_KEY, JSON.stringify([...next])); } catch {}
+      if (wasBilled) next.delete(jobId); else next.add(jobId);
       return next;
     });
+    if (wasBilled) {
+      const { error } = await supabase
+        .from('user_billed_jobs')
+        .delete()
+        .eq('user_id', currentUserId)
+        .eq('job_id', jobId)
+        .eq('appeal_year', selectedYear);
+      if (error) {
+        console.error('Error clearing billed flag:', error);
+        setBilledJobIds(prev => { const n = new Set(prev); n.add(jobId); return n; });
+      }
+    } else {
+      const { error } = await supabase
+        .from('user_billed_jobs')
+        .insert({ user_id: currentUserId, job_id: jobId, appeal_year: selectedYear });
+      if (error) {
+        console.error('Error setting billed flag:', error);
+        setBilledJobIds(prev => { const n = new Set(prev); n.delete(jobId); return n; });
+      }
+    }
   };
 
   useEffect(() => {
@@ -341,13 +376,14 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
 
     // Build rows. Track which rows are "all-CME" so we can tint them green to match the UI.
     const head = [[
-      'Job Name', 'Total', 'Residential', 'Commercial', 'Vacant Land',
+      'Job Name', 'Billed', 'Total', 'Residential', 'Commercial', 'Vacant Land',
       'Defend', 'Stipulated', 'Heard', 'Withdrawn', 'Assessor', 'Affirmed',
       'Has CME', 'Pro Se', 'Attorney', 'Hearing'
     ]];
 
     const body = jobAppealsSummary.map((row) => ([
       row.jobName,
+      billedJobIds.has(row.jobId) ? '\u2713' : '',
       row.totalAppeals,
       row.residential !== null ? row.residential : '—',
       row.commercial !== null ? row.commercial : '—',
@@ -362,13 +398,14 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       row.proSeCount,
       row.attorneyCount,
       row.isCompleted
-        ? (billedJobIds.has(row.jobId) ? 'Billed' : 'Completed')
+        ? 'Completed'
         : (row.hearingDate ? `${row.hearingDate}${row.hasMultipleHearings ? '*' : ''}` : '—')
     ]));
 
     // Totals row
     body.push([
       'TOTALS',
+      '',
       totals.totalAppeals,
       totals.residential, totals.commercial, totals.vacant,
       totals.defend, totals.stipulated, totals.heard, totals.withdrawn,
@@ -396,12 +433,13 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
       },
       columnStyles: {
         0: { halign: 'left', fontStyle: 'bold', cellWidth: 110 },
-        1: { halign: 'center', fontStyle: 'bold' },
-        2: { halign: 'center' }, 3: { halign: 'center' }, 4: { halign: 'center' },
-        5: { halign: 'center' }, 6: { halign: 'center' }, 7: { halign: 'center' },
-        8: { halign: 'center' }, 9: { halign: 'center' }, 10: { halign: 'center' },
-        11: { halign: 'center' }, 12: { halign: 'center' }, 13: { halign: 'center' },
-        14: { halign: 'center', cellWidth: 60 }
+        1: { halign: 'center', fontStyle: 'bold', cellWidth: 30 },
+        2: { halign: 'center', fontStyle: 'bold' },
+        3: { halign: 'center' }, 4: { halign: 'center' }, 5: { halign: 'center' },
+        6: { halign: 'center' }, 7: { halign: 'center' }, 8: { halign: 'center' },
+        9: { halign: 'center' }, 10: { halign: 'center' }, 11: { halign: 'center' },
+        12: { halign: 'center' }, 13: { halign: 'center' }, 14: { halign: 'center' },
+        15: { halign: 'center', cellWidth: 60 }
       },
       didParseCell: (data) => {
         // Only apply body-row tinting to body cells. Without this guard,
@@ -422,24 +460,37 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
         }
 
         const summaryRow = jobAppealsSummary[rowIndex];
+        if (!summaryRow) return;
 
-        // Completed (final hearing past) — blue lock; Billed — emerald lock (takes precedence over CME green)
-        if (summaryRow && summaryRow.isCompleted) {
-          const isBilledRow = billedJobIds.has(summaryRow.jobId);
-          data.cell.styles.fillColor = isBilledRow ? [236, 253, 245] : [219, 234, 254]; // emerald-50 vs blue-50
-          if (data.column.index === 14) {
-            data.cell.styles.textColor = isBilledRow ? [4, 120, 87] : [30, 64, 175]; // emerald-700 vs blue-800
+        const isBilledRow = billedJobIds.has(summaryRow.jobId);
+        const cmeMatchesTotal = summaryRow.totalAppeals > 0
+          && summaryRow.statusBreakdown.hasCME === summaryRow.totalAppeals;
+
+        // Billed wins, then Completed (blue), then CME-matches-total (yellow)
+        if (isBilledRow) {
+          data.cell.styles.fillColor = [220, 252, 231]; // bg-green-100
+          if (data.column.index === 1) {
+            data.cell.styles.textColor = [22, 101, 52]; // text-green-800
+            data.cell.styles.fontStyle = 'bold';
+          }
+          if (data.column.index === 15) {
+            data.cell.styles.textColor = [30, 64, 175];
             data.cell.styles.fontStyle = 'bold';
           }
           return;
         }
-
-        // Per-row green tint when Has CME equals Total Appeals (matches UI bg-green-50)
-        if (summaryRow && summaryRow.totalAppeals > 0
-            && summaryRow.statusBreakdown.hasCME === summaryRow.totalAppeals) {
-          data.cell.styles.fillColor = [240, 253, 244]; // bg-green-50
-          if (data.column.index === 11) {
-            data.cell.styles.textColor = [22, 101, 52]; // text-green-800
+        if (summaryRow.isCompleted) {
+          data.cell.styles.fillColor = [219, 234, 254]; // bg-blue-50
+          if (data.column.index === 15) {
+            data.cell.styles.textColor = [30, 64, 175];
+            data.cell.styles.fontStyle = 'bold';
+          }
+          return;
+        }
+        if (cmeMatchesTotal) {
+          data.cell.styles.fillColor = [254, 249, 195]; // bg-yellow-100
+          if (data.column.index === 12) {
+            data.cell.styles.textColor = [133, 77, 14]; // text-yellow-800
             data.cell.styles.fontStyle = 'bold';
           }
         }
@@ -562,6 +613,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
             <thead>
               <tr className="bg-gray-50 border-b border-gray-200">
                 <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700">Job Name</th>
+                <th className="px-2 py-3 text-center text-xs font-semibold text-gray-700" title="Personal tracker — click the checkbox once you've billed this job">Billed</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Total</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Residential</th>
                 <th className="px-4 py-3 text-center text-xs font-semibold text-gray-700">Commercial</th>
@@ -581,18 +633,28 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
             <tbody>
               {jobAppealsSummary.map((row, idx) => {
                 const cmeMatchesTotal = row.totalAppeals > 0 && row.statusBreakdown.hasCME === row.totalAppeals;
-                const isBilled = row.isCompleted && billedJobIds.has(row.jobId);
+                const isBilled = billedJobIds.has(row.jobId);
                 const rowClass = isBilled
-                  ? 'bg-emerald-50 hover:bg-emerald-100'
+                  ? 'bg-green-100 hover:bg-green-200'
                   : row.isCompleted
                     ? 'bg-blue-50 hover:bg-blue-100'
-                    : (cmeMatchesTotal ? 'bg-green-50 hover:bg-green-100' : 'hover:bg-gray-50');
+                    : (cmeMatchesTotal ? 'bg-yellow-100 hover:bg-yellow-200' : 'hover:bg-gray-50');
                 return (
                 <tr
                   key={row.jobId}
                   className={`border-b border-gray-200 ${rowClass}`}
                 >
                   <td className="px-4 py-3 text-sm font-medium text-gray-900">{row.jobName}</td>
+                  <td className="px-2 py-3 text-center">
+                    <input
+                      type="checkbox"
+                      checked={isBilled}
+                      onChange={() => toggleBilled(row.jobId)}
+                      disabled={!currentUserId}
+                      title={isBilled ? 'Billed — click to clear' : 'Click to mark as billed'}
+                      className="w-4 h-4 accent-green-600 cursor-pointer"
+                    />
+                  </td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700 font-semibold">{row.totalAppeals}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.residential !== null ? row.residential : '—'}</td>
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.commercial !== null ? row.commercial : '—'}</td>
@@ -608,17 +670,11 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
                   <td className="px-4 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
                   <td
                     className={`px-4 py-3 text-sm text-center ${
-                      row.isCompleted
-                        ? (billedJobIds.has(row.jobId)
-                          ? 'text-emerald-700 font-semibold cursor-pointer hover:underline'
-                          : 'text-blue-800 font-semibold cursor-pointer hover:underline')
-                        : 'text-gray-700'
+                      row.isCompleted ? 'text-blue-800 font-semibold' : 'text-gray-700'
                     }`}
-                    onClick={row.isCompleted ? () => toggleBilled(row.jobId) : undefined}
-                    title={row.isCompleted ? (billedJobIds.has(row.jobId) ? 'Click to revert to Completed' : 'Click to mark as Billed') : undefined}
                   >
                     {row.isCompleted
-                      ? (billedJobIds.has(row.jobId) ? 'Billed' : 'Completed')
+                      ? 'Completed'
                       : (row.hearingDate ? `${row.hearingDate}${row.hasMultipleHearings ? '*' : ''}` : '—')}
                   </td>
                 </tr>
@@ -627,6 +683,7 @@ const AppealsSummary = ({ jobs = [], onJobSelect }) => {
               {/* Totals Row */}
               <tr className="bg-blue-50 border-t-2 border-blue-200 font-bold">
                 <td className="px-4 py-3 text-sm text-gray-900">TOTALS</td>
+                <td className="px-2 py-3 text-sm text-center text-gray-900">{billedJobIds.size}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.totalAppeals}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.residential}</td>
                 <td className="px-4 py-3 text-sm text-center text-gray-900">{totals.commercial}</td>

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -2,34 +2,31 @@ import React, { useState, useEffect } from 'react';
 import { supabase, formatDateLocalYMD } from '../lib/supabaseClient';
 import { AlertCircle, Calendar, FileText, TrendingUp, FileDown } from 'lucide-react';
 
-const AppealsSummary = ({ jobs = [], onJobSelect }) => {
+const AppealsSummary = ({ jobs = [], onJobSelect, currentUser = null }) => {
   const [jobAppealsSummary, setJobAppealsSummary] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [availableYears, setAvailableYears] = useState([]);
-  // Personal "I already billed this job" tracker \u2014 per-user row in user_billed_jobs,
+  // Personal "I already billed this job" tracker — per-user row in user_billed_jobs,
   // keyed by (user_id, job_id, appeal_year). Independent of the BillingManagement module.
   const [billedJobIds, setBilledJobIds] = useState(new Set());
-  const [currentUserId, setCurrentUserId] = useState(null);
+  const currentUserId = currentUser?.id || null;
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (cancelled) return;
-      setCurrentUserId(user?.id || null);
-      if (!user?.id) { setBilledJobIds(new Set()); return; }
+      if (!currentUserId) { setBilledJobIds(new Set()); return; }
       const { data, error } = await supabase
         .from('user_billed_jobs')
         .select('job_id')
-        .eq('user_id', user.id)
+        .eq('user_id', currentUserId)
         .eq('appeal_year', selectedYear);
       if (cancelled) return;
       if (error) { console.error('Error loading billed jobs:', error); return; }
       setBilledJobIds(new Set((data || []).map(r => r.job_id)));
     })();
     return () => { cancelled = true; };
-  }, [selectedYear]);
+  }, [selectedYear, currentUserId]);
 
   const toggleBilled = async (jobId) => {
     if (!currentUserId) return;

--- a/src/components/AppealsSummary.jsx
+++ b/src/components/AppealsSummary.jsx
@@ -470,8 +470,8 @@ const AppealsSummary = ({ jobs = [], onJobSelect, currentUser = null }) => {
             data.cell.styles.textColor = [22, 101, 52]; // text-green-800
             data.cell.styles.fontStyle = 'bold';
           }
-          if (data.column.index === 15) {
-            data.cell.styles.textColor = [30, 64, 175];
+          if (data.column.index === 15 && summaryRow.isCompleted) {
+            data.cell.styles.textColor = [21, 128, 61]; // text-green-700
             data.cell.styles.fontStyle = 'bold';
           }
           return;
@@ -667,7 +667,9 @@ const AppealsSummary = ({ jobs = [], onJobSelect, currentUser = null }) => {
                   <td className="px-2 py-3 text-sm text-center text-gray-700">{row.attorneyCount}</td>
                   <td
                     className={`px-2 py-3 text-sm text-center whitespace-nowrap ${
-                      row.isCompleted ? 'text-blue-800 font-semibold' : 'text-gray-700'
+                      row.isCompleted
+                        ? (isBilled ? 'text-green-700 font-semibold' : 'text-blue-800 font-semibold')
+                        : 'text-gray-700'
                     }`}
                   >
                     {row.isCompleted

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -4567,15 +4567,6 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                                 updated[idx] = { ...updated[idx], block: e.target.value };
                                 setPendingBlockLotRows(updated);
                               }}
-                              onBlur={() => {
-                                if (row.block && row.lot) {
-                                  const key = `${row.block}-${row.lot}${row.qualifier ? `-${row.qualifier}` : ''}`;
-                                  if (!manualProperties.includes(key)) {
-                                    setManualProperties(prev => [...prev, key]);
-                                  }
-                                  setPendingBlockLotRows(prev => prev.filter((_, i) => i !== idx));
-                                }
-                              }}
                               onKeyDown={(e) => {
                                 if (e.key === 'Enter' && row.block && row.lot) {
                                   const key = `${row.block}-${row.lot}${row.qualifier ? `-${row.qualifier}` : ''}`;
@@ -4598,15 +4589,6 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                                 const updated = [...pendingBlockLotRows];
                                 updated[idx] = { ...updated[idx], lot: e.target.value };
                                 setPendingBlockLotRows(updated);
-                              }}
-                              onBlur={() => {
-                                if (row.block && row.lot) {
-                                  const key = `${row.block}-${row.lot}${row.qualifier ? `-${row.qualifier}` : ''}`;
-                                  if (!manualProperties.includes(key)) {
-                                    setManualProperties(prev => [...prev, key]);
-                                  }
-                                  setPendingBlockLotRows(prev => prev.filter((_, i) => i !== idx));
-                                }
                               }}
                               onKeyDown={(e) => {
                                 if (e.key === 'Enter' && row.block && row.lot) {


### PR DESCRIPTION
### Summary
Adds a personal "Billed" checkbox column to the Appeals Summary table, persisted per-user in Supabase, and fixes a bug where tabbing out of the Block/Lot fields prematurely committed a manual property entry before the Qualifier could be filled in.

### Problem
1. The Appeals Summary had no reliable way to track which jobs had already been billed — a previous click-to-toggle approach on the Hearing Date column used localStorage and did not persist across devices or sessions.
2. In the Sales Comparison (CME) Search and Results panel, tabbing from the Lot field to the Qualifier field immediately locked in the property entry, preventing the Qualifier from being included.

### Solution
1. Replaced the localStorage-backed billed state with a `user_billed_jobs` Supabase table keyed by `(user_id, job_id, appeal_year)`. A dedicated "Billed" checkbox column was added to the summary table, with optimistic UI updates and rollback on error.
2. Removed the `onBlur` handlers from the Block and Lot input fields so that a property is only committed on explicit Enter key press, allowing the user to tab through to the Qualifier field freely.

### Key Changes
- **`AppealsSummary.jsx`**: New `Billed` column with a checkbox (`<input type="checkbox">`) that reads/writes to `user_billed_jobs` in Supabase; billed state loads on mount and year change; totals row shows count of billed jobs; row highlighting updated so billed rows render green (takes priority over completed-blue and CME-yellow); Hearing Date column no longer toggles billed state on click; abbreviated column headers (`Resi`, `Comm`, `Vcnt Lnd`) to prevent layout overflow; PDF export updated to include the Billed column.
- **`App.js`**: Passes `currentUser` prop down to `AppealsSummary` so the component can scope billed records to the logged-in user.
- **`SalesComparisonTab.jsx`**: Removed `onBlur` handlers from Block and Lot inputs, fixing premature property commit before Qualifier is entered.

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/wild-lab-ajez9nb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-wild-lab-ajez9nb6_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 213`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>wild-lab-ajez9nb6</branchName>-->