### PR TITLE
Add Stop button for evaluation and exclude large blob columns

### DIFF
--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -265,11 +265,46 @@ const JobContainer = ({
         return Promise.race([promise, timeoutPromise]);
       };
 
-      // Get ALL job data in ONE comprehensive query FIRST with timeout
+      // Get ALL job data in ONE comprehensive query FIRST with timeout.
+      // Explicit column list EXCLUDES raw_file_content and code_file_content
+      // (multi-MB TEXT blobs that no consumer of jobData reads — they're only
+      // needed by the reprocessing flows, which fetch them directly).
       const { data: jobData, error: jobError } = await withTimeout(
         supabase
           .from('jobs')
-          .select('*')  // Get ALL fields for this job
+          .select(`
+            id, job_name, client_name, status, start_date, end_date, created_by,
+            created_at, updated_at, target_completion_date, priority, ccdd_code,
+            county, state, vendor_type, workflow_stats, vendor_detection,
+            source_file_status, code_file_status, municipality, percent_billed,
+            has_property_assignments, assigned_has_commercial, code_file_name,
+            code_file_uploaded_at, parsed_code_definitions, source_file_name,
+            source_file_version_id, source_file_uploaded_at, code_file_version,
+            infoby_category_config, total_properties, totalcommercial,
+            totalresidential, billing_setup_complete, job_type, payment_status,
+            assessor_email, external_inspectors, assessor_name, project_type,
+            validation_status, project_start_date, raw_file_size,
+            raw_file_rows_count, raw_file_parsed_at, unit_rate_config,
+            staged_unit_rate_config, source_file_version, archived_at, archived_by,
+            current_class_1_count, current_class_1_total, current_class_1_abatements,
+            current_class_2_count, current_class_2_total, current_class_2_abatements,
+            current_class_3a_count, current_class_3a_total,
+            current_class_3b_count, current_class_3b_total,
+            current_class_4_count, current_class_4_total, current_class_4_abatements,
+            current_class_6_count, current_class_6_total,
+            current_total_count, current_total_total, current_commercial_base_pct,
+            rate_calc_budget, rate_calc_current_rate, rate_calc_buffer_for_loss,
+            previous_projected_class_1_count, previous_projected_class_1_total,
+            previous_projected_class_2_count, previous_projected_class_2_total,
+            previous_projected_class_3a_count, previous_projected_class_3a_total,
+            previous_projected_class_3b_count, previous_projected_class_3b_total,
+            previous_projected_class_4_count, previous_projected_class_4_total,
+            previous_projected_class_6_count, previous_projected_class_6_total,
+            previous_projected_total_count, previous_projected_total_total,
+            attribute_condition_config, organization_id, turnover_date,
+            year_of_value, director_ratio, needs_reprocessing, story_height_config,
+            parent_job_id, appeal_summary_snapshot, type_use_normalization_map
+          `)
           .eq('id', selectedJob.id)
           .single(),
         10000,

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -101,6 +101,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   const [evaluationMode, setEvaluationMode] = useState('fresh'); // 'fresh' or 'keep'
   const [isEvaluating, setIsEvaluating] = useState(false);
   const [evaluationProgress, setEvaluationProgress] = useState({ current: 0, total: 0 });
+  const cancelEvaluationRef = React.useRef(false);
   const [preEvalCheck, setPreEvalCheck] = useState(null); // { configMissing, adjustmentsMissing } | null
   const [evaluationResults, setEvaluationResults] = useState(null);
   const [savedEvaluations, setSavedEvaluations] = useState([]); // Set-aside evaluations from DB
@@ -2177,6 +2178,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       }
     } catch (_) { /* non-critical */ }
 
+    cancelEvaluationRef.current = false;
     setIsEvaluating(true);
     setEvaluationProgress({ current: 0, total: 0 });
 
@@ -2325,6 +2327,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       }
 
       for (let i = 0; i < subjects.length; i++) {
+        if (cancelEvaluationRef.current) break;
         // Aggregate subject data across all cards (main + additional)
         const subject = aggregatePropertyData(subjects[i]);
 
@@ -2873,6 +2876,16 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           hasSubjectSale: !!priorityComp,
           mappedBracket: subjectMapping?.bracket || null
         });
+      }
+
+      // If the user stopped evaluation mid-run, bail out before doing any
+      // merging, display, or auto-save. Partial results are intentionally
+      // discarded so we don't persist an inconsistent set.
+      if (cancelEvaluationRef.current) {
+        console.log(`🛑 Evaluation stopped at ${results.length}/${subjects.length} — discarding partial results.`);
+        setIsEvaluating(false);
+        setEvaluationProgress({ current: 0, total: 0 });
+        return;
       }
 
       // Display results immediately - no DB save during evaluation
@@ -5280,23 +5293,41 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     </label>
                   </div>
 
-                  <button
-                    onClick={handleEvaluate}
-                    disabled={isEvaluating}
-                    className="mt-3 px-8 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 font-semibold text-lg"
-                  >
-                    {isEvaluating
-                      ? `Evaluating ${evaluationProgress.current}/${evaluationProgress.total}...`
-                      : 'Evaluate'
-                    }
-                  </button>
+                  <div className="mt-3 flex items-center justify-center gap-3">
+                    <button
+                      onClick={handleEvaluate}
+                      disabled={isEvaluating}
+                      className="px-8 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 font-semibold text-lg"
+                    >
+                      {isEvaluating
+                        ? `Evaluating ${evaluationProgress.current}/${evaluationProgress.total}...`
+                        : 'Evaluate'
+                      }
+                    </button>
+                    {isEvaluating && (
+                      <button
+                        onClick={() => {
+                          if (window.confirm('Stop the evaluation now? Partial results will be discarded.')) {
+                            cancelEvaluationRef.current = true;
+                          }
+                        }}
+                        className="px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 font-semibold text-lg"
+                        title="Stop the current evaluation and discard partial results"
+                      >
+                        Stop
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 {/* Progress Bar */}
                 {isEvaluating && evaluationProgress.total > 0 && (
                   <div className="mt-4 flex justify-center">
                     <span className="text-sm font-semibold text-blue-700 animate-pulse">
-                      Evaluating {evaluationProgress.current} of {evaluationProgress.total} properties...
+                      {cancelEvaluationRef.current
+                        ? `Stopping after current property (${evaluationProgress.current} of ${evaluationProgress.total})...`
+                        : `Evaluating ${evaluationProgress.current} of ${evaluationProgress.total} properties...`
+                      }
                     </span>
                   </div>
                 )}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -5306,11 +5306,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     </button>
                     {isEvaluating && (
                       <button
-                        onClick={() => {
-                          if (window.confirm('Stop the evaluation now? Partial results will be discarded.')) {
-                            cancelEvaluationRef.current = true;
-                          }
-                        }}
+                        onClick={() => { cancelEvaluationRef.current = true; }}
                         className="px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 font-semibold text-lg"
                         title="Stop the current evaluation and discard partial results"
                       >

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -921,7 +921,7 @@ export const interpretCodes = {
 
       const { data: job, error } = await supabase
         .from('jobs')
-        .select('parsed_code_definitions, code_file_content, vendor_type')
+        .select('parsed_code_definitions, vendor_type')
         .eq('id', jobId)
         .single();
 
@@ -3242,7 +3242,36 @@ export const jobService = {
       const { data, error } = await supabase
         .from('jobs')
         .select(`
-          *,
+          id,
+          job_name,
+          ccdd_code,
+          municipality,
+          client_name,
+          job_number,
+          start_date,
+          county,
+          state,
+          vendor_type,
+          status,
+          end_date,
+          target_completion_date,
+          total_properties,
+          totalresidential,
+          totalcommercial,
+          source_file_status,
+          code_file_status,
+          vendor_detection,
+          workflow_stats,
+          percent_billed,
+          has_property_assignments,
+          assigned_has_commercial,
+          assigned_property_count,
+          created_at,
+          source_file_uploaded_at,
+          code_file_uploaded_at,
+          updated_at,
+          source_file_version,
+          code_file_version,
           job_assignments (
             id,
             role,
@@ -4438,7 +4467,7 @@ export const propertyService = {
     try {
       const { data: job, error: jobError } = await supabase
         .from('jobs')
-        .select('raw_file_content, raw_file_parsed_at, updated_at')
+        .select('raw_file_size, raw_file_parsed_at, updated_at')
         .eq('id', jobId)
         .single();
 
@@ -4453,7 +4482,7 @@ export const propertyService = {
       if (countError) throw countError;
 
       return {
-        hasSourceFile: !!job.raw_file_content,
+        hasSourceFile: !!(job.raw_file_size && job.raw_file_size > 0),
         sourceFileParsedAt: job.raw_file_parsed_at,
         lastUpdated: job.updated_at,
         recordsNeedingReprocessing: needsReprocessingCount || 0,


### PR DESCRIPTION
### Summary
Adds a **Stop** button to the Sales Comparison evaluation flow so users can cancel a long-running evaluation mid-run without persisting partial results. Also eliminates heavy multi-MB blob columns (`raw_file_content`, `code_file_content`) from broad `SELECT *` queries to reduce Disk I/O pressure on the Supabase instance.

### Problem
The Supabase project was hitting its Disk I/O budget limit, causing the instance to become unresponsive — particularly when a full-town evaluation (e.g. 200,000+ properties) was triggered. Additionally, there was no way to cancel an in-progress evaluation once started, forcing users to navigate away and hope the process stopped.

### Solution
- Replaced all `SELECT *` queries on the `jobs` table with explicit column lists that exclude `raw_file_content` and `code_file_content` (multi-MB TEXT blobs not needed by most consumers).
- Introduced a `cancelEvaluationRef` ref in `SalesComparisonTab` that acts as a cancellation flag checked at each iteration of the evaluation loop.
- Added a **Stop** button that appears during evaluation, sets the cancel flag immediately, and discards partial results cleanly without auto-saving.
- Removed the confirmation popup before stopping — Stop now stops immediately.

### Key Changes
- **`JobContainer.jsx`**: Replaced `SELECT *` with an explicit column list on the `jobs` fetch, excluding `raw_file_content` and `code_file_content`.
- **`SalesComparisonTab.jsx`**:
  - Added `cancelEvaluationRef` (`React.useRef(false)`) to track cancellation state.
  - Evaluation loop checks `cancelEvaluationRef.current` at each property iteration and breaks early if set.
  - Post-loop guard discards partial results and resets state if cancelled.
  - Added a red **Stop** button rendered alongside the Evaluate button during active evaluation.
  - Progress bar text updates to indicate "Stopping after current property..." when cancel is pending.
- **`supabaseClient.js`**:
  - `interpretCodes`: Removed `code_file_content` from the `jobs` select.
  - `jobService` list query: Replaced `SELECT *` with an explicit column list (excludes blobs).
  - `propertyService`: Replaced `raw_file_content` presence check with `raw_file_size > 0` to avoid fetching the blob entirely.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/marble-talon-k1tov0sy"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-marble-talon-k1tov0sy_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 215`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>marble-talon-k1tov0sy</branchName>-->