### PR TITLE
Fix custom bracket reverting on recalc in Detailed Evaluation

### DIFF
--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1696,8 +1696,23 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     if (!adjustmentDef) return 0;
 
     const bracketIndex = getBracketIndex(compSalesPrice);
-    const adjustmentValue = adjustmentDef[`bracket_${bracketIndex}`] || 0;
-    const adjustmentType = adjustmentDef.adjustment_type || 'flat';
+    let adjustmentValue = 0;
+    let adjustmentType = adjustmentDef.adjustment_type || 'flat';
+
+    // Check if using a custom bracket (matches CME tab logic)
+    if (detailedTabBracket && detailedTabBracket.startsWith('custom_')) {
+      const customBracket = (result?.customBrackets || []).find(b => b.bracket_id === detailedTabBracket);
+      if (customBracket && customBracket.adjustment_values) {
+        const customValue = customBracket.adjustment_values[adjustmentDef.adjustment_id];
+        if (customValue) {
+          adjustmentValue = customValue.value || 0;
+          adjustmentType = customValue.type || adjustmentDef.adjustment_type;
+        }
+      }
+    } else {
+      // Standard bracket — look up column
+      adjustmentValue = adjustmentDef[`bracket_${bracketIndex}`] || 0;
+    }
 
     const subjectNum = parseFloat(subjectVal) || 0;
     const compNum = parseFloat(compVal) || 0;
@@ -1724,7 +1739,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       default:
         return 0;
     }
-  }, [getBracketIndex]);
+  }, [getBracketIndex, detailedTabBracket, result?.customBrackets]);
 
   // Recalculate all adjustments based on edited values.
   //
@@ -1964,7 +1979,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
     setEditedAdjustments(newAdjustments);
     setHasEdits(false);
-  }, [comps, subject, editableProperties, editedAdjustments, getRawValue, calculateSingleAdjustment, allAttributes, adjustmentGrid, getConditionRank, miscRows, activeMiscRows]);
+  }, [comps, subject, editableProperties, editedAdjustments, getRawValue, calculateSingleAdjustment, allAttributes, adjustmentGrid, getConditionRank, miscRows, activeMiscRows, detailedTabBracket]);
 
   const openExportModal = useCallback(async () => {
     setEditableProperties({});

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -40,7 +40,7 @@ const EditableInput = React.memo(function EditableInput({
   );
 });
 
-const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null, activeResultSetId = null, onSentToAppealLog = null }) => {
+const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], customBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null, activeResultSetId = null, onSentToAppealLog = null }) => {
   const subject = result.subject;
   // Real comps coming from the comparables search. Manual "M" comps (entered
   // directly in the export modal for out-of-town properties) are layered on
@@ -1701,7 +1701,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
     // Check if using a custom bracket (matches CME tab logic)
     if (detailedTabBracket && detailedTabBracket.startsWith('custom_')) {
-      const customBracket = (result?.customBrackets || []).find(b => b.bracket_id === detailedTabBracket);
+      const customBracket = (customBrackets || []).find(b => b.bracket_id === detailedTabBracket);
       if (customBracket && customBracket.adjustment_values) {
         const customValue = customBracket.adjustment_values[adjustmentDef.adjustment_id];
         if (customValue) {
@@ -1739,7 +1739,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       default:
         return 0;
     }
-  }, [getBracketIndex, detailedTabBracket, result?.customBrackets]);
+  }, [getBracketIndex, detailedTabBracket, customBrackets]);
 
   // Recalculate all adjustments based on edited values.
   //

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -260,6 +260,12 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   // appellant comps were saved.
   const [appellantCompsState, setAppellantCompsState] = useState([]);
 
+  // Preserve the bracket selection from the result (mappedBracket) so it persists
+  // during recalculation in the export modal. When the modal opens, we capture the
+  // bracket used during the original evaluation and use it consistently, preventing
+  // custom brackets from reverting to the default/auto bracket on recalc.
+  const [detailedTabBracket, setDetailedTabBracket] = useState(null);
+
   // Local in-memory overrides for geocode coordinates set via the inline
   // GeocodeStatusChip edit modal. Keyed by property_composite_key. Lets the
   // user fix a missing/wrong geocode and have the map + PDF reflect it
@@ -1663,21 +1669,27 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
   // Helper: Get bracket index based on compFilters, mapped bracket, and comp price
   const getBracketIndex = useCallback((compNormTime) => {
-    // If a specific bracket is selected (not auto), use it
+    // Priority 1: Use the preserved bracket from the export modal (custom or standard)
+    // This ensures recalculation uses the same bracket as the original evaluation
+    if (detailedTabBracket && detailedTabBracket !== 'auto') {
+      const match = detailedTabBracket.match(/bracket_(\d+)/);
+      if (match) return parseInt(match[1]);
+    }
+    // Priority 2: If a specific bracket is selected in compFilters (not auto), use it
     if (compFilters?.adjustmentBracket && compFilters.adjustmentBracket !== 'auto') {
       const match = compFilters.adjustmentBracket.match(/bracket_(\d+)/);
       if (match) return parseInt(match[1]);
     }
-    // If auto with a mapped bracket for this subject, use the mapped bracket
+    // Priority 3: If auto with a mapped bracket for this subject, use the mapped bracket
     if (result.mappedBracket) {
       const match = result.mappedBracket.match(/bracket_(\d+)/);
       if (match) return parseInt(match[1]);
     }
-    // Fall back to price-based bracket
+    // Priority 4: Fall back to price-based bracket
     if (!compNormTime || !cmeBrackets?.length) return 0;
     const bracket = cmeBrackets.findIndex(b => compNormTime >= b.min && compNormTime <= b.max);
     return bracket >= 0 ? bracket : 0;
-  }, [compFilters, cmeBrackets, result.mappedBracket]);
+  }, [detailedTabBracket, compFilters, cmeBrackets, result.mappedBracket]);
 
   // Calculate adjustment for a single attribute between subject and comp
   const calculateSingleAdjustment = useCallback((subjectVal, compVal, adjustmentDef, compSalesPrice) => {
@@ -1962,6 +1974,8 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     setMiscRows([makeMiscRow(), makeMiscRow()]);
     setAppellantCompsState([]);
     setAppealUploadStatus(null);
+    // Capture the bracket from this result so recalculation preserves it
+    setDetailedTabBracket(result.mappedBracket || compFilters?.adjustmentBracket || null);
     setShowExportModal(true);
 
     // Auto-detect appeal number for subject AND load appellant_comps so the
@@ -3668,6 +3682,7 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       : opts.closeModal !== false;
     if (shouldClose) {
       setShowExportModal(false);
+      setDetailedTabBracket(null);
     }
   }, [allAttributes, rowVisibility, showAdjustments, subject, comps, result, editableProperties, editedAdjustments, recalculatedProjectedAssessment, getAdjustment, GARAGE_OPTIONS, jobData, marketLandData, allProperties, codeDefinitions, vendorType, includeMap, includePhotos, photoStripParcels, hideAppellantEvidence, hideDirectorsRatio, hideWeightedValuation, mapHasSubject, mapData, compDistances, appellantDistances, aggregatedSubject, aggregatedComps, applyGeocodePatch, miscRows, activeMiscRows, miscIsActive]);
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -2165,7 +2165,6 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   };
 
   const handleClearManualComps = () => {
-    setManualSubject({ block: '', lot: '', qualifier: '' });
     setManualComps([
       { block: '', lot: '', qualifier: '' },
       { block: '', lot: '', qualifier: '' },

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -6455,6 +6455,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                   adjustmentGrid={adjustmentGrid}
                   compFilters={compFilters}
                   cmeBrackets={CME_BRACKETS}
+                  customBrackets={customBrackets}
                   isJobContainerLoading={isJobContainerLoading}
                   allProperties={properties}
                   marketLandData={marketLandData}


### PR DESCRIPTION
### Summary
Fixes a bug where custom adjustment brackets would revert to the default bracket when recalculating in the Final Valuation – Sales Comparison (CME) – Detailed Evaluation export modal. Also fixes the "Clear Comps" button incorrectly clearing the subject in addition to the comps.

### Problem
When a user applied a custom adjustment bracket (instead of one of the standard default brackets) and then made a change in the Detailed Evaluation export modal (e.g., changing a comp's condition) and hit recalculate, the modal was falling back to the default/auto bracket for adjustment lookups. This caused custom adjustment values (e.g., open porch at $2,000) to be replaced with the default bracket values (e.g., $7,000), silently corrupting the evaluation. Additionally, the "Clear Comps" button was also clearing the subject fields, contrary to its label.

### Solution
A new piece of state (`detailedTabBracket`) is introduced in `DetailedAppraisalGrid` to capture and preserve the bracket in use when the export modal opens. This captured bracket is given the highest priority in `getBracketIndex` and `calculateSingleAdjustment`, ensuring recalculation always uses the same bracket — including custom brackets — as the original evaluation. The `customBrackets` prop is also threaded down from `SalesComparisonTab` so custom bracket adjustment values can be resolved correctly. The subject reset was removed from `handleClearManualComps`.

### Key Changes
- **New `detailedTabBracket` state** in `DetailedAppraisalGrid`: captured on modal open from `result.mappedBracket` or `compFilters.adjustmentBracket`, and cleared on modal close.
- **Updated `getBracketIndex`**: adds Priority 1 check for `detailedTabBracket` before falling back to `compFilters`, `result.mappedBracket`, or price-based auto-detection.
- **Updated `calculateSingleAdjustment`**: when `detailedTabBracket` is a `custom_*` bracket, looks up adjustment values from the `customBrackets` array instead of the standard bracket column, matching the CME tab logic.
- **`customBrackets` prop** added to `DetailedAppraisalGrid` and passed down from `SalesComparisonTab`.
- **`handleClearManualComps`** no longer resets `manualSubject`, so "Clear Comps" only clears the comp fields as intended.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/rust-fragment-kvnvpe1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-rust-fragment-kvnvpe1b_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 219`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>rust-fragment-kvnvpe1b</branchName>-->