### PR TITLE
Fix liveable area display in export modal and PDF

### DIFF
--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -4236,7 +4236,17 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                       }
 
                       const editedVal = editableProperties[propKey]?.[attr.id];
-                      const displayVal = editedVal !== undefined ? editedVal : attr.render(prop);
+                      let displayVal = editedVal !== undefined ? editedVal : attr.render(prop);
+
+                      // Special handling for Liveable Area: extract text from JSX + add asterisk for living basements
+                      if (attr.id === 'liveable_area' && editedVal === undefined) {
+                        const adjustedSFLA = getAdjustedSFLA(prop);
+                        if (adjustedSFLA) {
+                          displayVal = hasConfiguredLivingBasement(prop)
+                            ? `${adjustedSFLA.toLocaleString()}*`
+                            : adjustedSFLA.toLocaleString();
+                        }
+                      }
 
                       // Get adjustment for this comp - use edited if recalculated, otherwise original
                       let compAdj = null;

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -4298,6 +4298,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
                       const numberInitial = (() => {
                         if (editedVal !== undefined) return editedVal;
                         if (!prop) return '';
+                        if (attr.id === 'liveable_area') {
+                          const adjustedSFLA = getAdjustedSFLA(prop);
+                          return adjustedSFLA ? adjustedSFLA : '';
+                        }
                         if (
                           attr.id === 'lot_size_acre' &&
                           compFilters?.farmSalesMode &&

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -2271,6 +2271,14 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
         return (rawValue !== null && rawValue !== undefined && rawValue > 0) ? 'Yes' : 'No';
       }
 
+      // Special handling for Liveable Area: return plain text with asterisk for PDF
+      if (attr.id === 'liveable_area') {
+        const adjustedSFLA = getAdjustedSFLA(prop);
+        if (!adjustedSFLA) return 'N/A';
+        if (!hasConfiguredLivingBasement(prop)) return adjustedSFLA.toLocaleString();
+        return `${adjustedSFLA.toLocaleString()}*`;
+      }
+
       return attr.render(prop);
     };
 


### PR DESCRIPTION
### Summary
Fixes incorrect liveable area (SFLA) display in the export modal and PDF report when a comp has a living basement, ensuring the adjusted SFLA (with asterisk) is shown instead of the raw total SFLA.

### Problem
When a comp had a living basement, the detailed appraisal grid was falling back to the total SFLA (e.g., 3,918) in the export modal instead of the adjusted value (e.g., 2,718*). The PDF report also rendered the liveable area as `[object Object]` due to a JSX render value being passed where plain text was expected.

### Solution
Added special-case handling for the `liveable_area` attribute in three places within `DetailedAppraisalGrid.jsx`, using the existing `getAdjustedSFLA` and `hasConfiguredLivingBasement` helpers to compute and format the correct display value as plain text (with an asterisk suffix when applicable).

### Key Changes
- **PDF cell rendering**: Added a `liveable_area` branch in the PDF cell value resolver to return a plain-text string (e.g., `"2,718*"`) instead of a JSX element, preventing `[object Object]` output.
- **Export modal display value**: Added a `liveable_area` override for `displayVal` in the export modal column renderer so it shows the adjusted SFLA with asterisk rather than falling back to the raw total SFLA.
- **Editable number initial value**: Added a `liveable_area` branch in the `numberInitial` resolver to seed the editable input with the adjusted SFLA value instead of the raw total.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/tropic-reward-v0g1d4lh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-tropic-reward-v0g1d4lh_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 220`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>tropic-reward-v0g1d4lh</branchName>-->