### PR TITLE
Fix farm + additional card aggregation for Microsystems

### DIFF
--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1883,12 +1883,27 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   };
 
   // Helper to get all cards for a property (main + additional)
+  // For farms: includes both the 3A (base) and 3B/QFARM (farmland) parcels
   const getPropertyCards = (prop) => {
     if (!prop) return [prop];
-    const baseKey = `${prop.property_block || ''}-${prop.property_lot || ''}-${prop.property_qualifier || ''}`;
+    const block = prop.property_block || '';
+    const lot = prop.property_lot || '';
+    const qual = (prop.property_qualifier || '').trim();
+
+    // Normalize qualifier for farm grouping: 7/4/QFARM and 7/4 should group together
+    // QFARM or any Q-prefixed qualifier indicates farm land parcel paired with the base property
+    const isQualifier = qual.toUpperCase().startsWith('Q');
+    const baseQual = isQualifier ? '' : qual;
+
     return properties.filter(p => {
-      const pBaseKey = `${p.property_block || ''}-${p.property_lot || ''}-${p.property_qualifier || ''}`;
-      return pBaseKey === baseKey;
+      const pBlock = p.property_block || '';
+      const pLot = p.property_lot || '';
+      const pQual = (p.property_qualifier || '').trim();
+      const pIsQualifier = pQual.toUpperCase().startsWith('Q');
+      const pBaseQual = pIsQualifier ? '' : pQual;
+
+      // Match: same block/lot, and either same non-Q qualifier or both are Q-prefixed
+      return pBlock === block && pLot === lot && pBaseQual === baseQual;
     });
   };
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1915,11 +1915,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     console.log(`🔗 Aggregating ${allCards.length} cards for ${prop.property_block}/${prop.property_lot}/${prop.property_qualifier}:`,
       allCards.map(c => `${c.property_addl_card}(${parseFloat(c.asset_lot_acre)||0}ac)`).join(' + '));
 
-    // Honor additional_card_handling_config. In 'separate' mode the user wants
-    // each parcel evaluated against the main card only — no SFLA / amenity sums.
-    // We still surface the additional-cards count so the (+N cards) badge stays
-    // visible everywhere it renders today.
-    if (prop._cardMode === 'separate') {
+    // Honor additional_card_handling_config from job settings (not per-card _cardMode, which may vary)
+    // In 'separate' mode the user wants each parcel evaluated against the main card only —
+    // no SFLA / amenity sums. We still surface the additional-cards count so the
+    // (+N cards) badge stays visible everywhere it renders today.
+    const cardMode = marketLandData?.additional_card_handling_config?.mode === 'separate' ? 'separate' : 'combine';
+    if (cardMode === 'separate') {
       return {
         ...prop,
         _additionalCardsCount: allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length,

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1939,7 +1939,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
     sumFields.forEach(field => {
       const total = allCards.reduce((sum, card) => sum + (parseFloat(card[field]) || 0), 0);
-      if (total > 0) aggregated[field] = total;
+      if (total > 0) {
+        if (field === 'asset_lot_acre') {
+          console.log(`📊 Summing ${field}:`, allCards.map(c => parseFloat(c[field]) || 0).join(' + '), '=', total);
+        }
+        aggregated[field] = total;
+      }
     });
 
     // AVERAGE: year_built
@@ -1966,7 +1971,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     // For farm properties, ensure asset_lot_acre matches the combined lot from _pkg
     // This keeps the editable value in sync with the display render function
     if (aggregated._pkg?.is_farm_package && aggregated._pkg?.combined_lot_acres > 0) {
+      console.log(`🌾 Farm package override: _pkg.combined_lot_acres=${aggregated._pkg?.combined_lot_acres}, was=${aggregated.asset_lot_acre}`);
       aggregated.asset_lot_acre = aggregated._pkg.combined_lot_acres;
+    } else {
+      console.log(`🚫 No farm override: _pkg.is_farm_package=${aggregated._pkg?.is_farm_package}, combined_lot_acres=${aggregated._pkg?.combined_lot_acres}, final acres=${aggregated.asset_lot_acre}`);
     }
 
     return aggregated;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1888,22 +1888,22 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     if (!prop) return [prop];
     const block = prop.property_block || '';
     const lot = prop.property_lot || '';
-    const qual = (prop.property_qualifier || '').trim();
+    const qual = (prop.property_qualifier || '').trim().toUpperCase();
 
     // Normalize qualifier for farm grouping: 7/4/QFARM and 7/4 should group together
-    // QFARM or any Q-prefixed qualifier indicates farm land parcel paired with the base property
-    const isQualifier = qual.toUpperCase().startsWith('Q');
-    const baseQual = isQualifier ? '' : qual;
+    // For matching purposes, treat Q-prefixed qualifiers (QFARM, etc.) as part of the
+    // same base property (block/lot) as the non-qualified version. This allows
+    // 3A farmhouse (7/4) and 3B farmland (7/4/QFARM) to aggregate together.
+    const qualForMatching = qual.startsWith('Q') ? '' : qual;
 
     return properties.filter(p => {
       const pBlock = p.property_block || '';
       const pLot = p.property_lot || '';
-      const pQual = (p.property_qualifier || '').trim();
-      const pIsQualifier = pQual.toUpperCase().startsWith('Q');
-      const pBaseQual = pIsQualifier ? '' : pQual;
+      const pQual = (p.property_qualifier || '').trim().toUpperCase();
+      const pQualForMatching = pQual.startsWith('Q') ? '' : pQual;
 
-      // Match: same block/lot, and either same non-Q qualifier or both are Q-prefixed
-      return pBlock === block && pLot === lot && pBaseQual === baseQual;
+      // Match: same block/lot, and both have same non-Q qualifier (or both are Q-prefixed)
+      return pBlock === block && pLot === lot && pQualForMatching === qualForMatching;
     });
   };
 
@@ -1911,6 +1911,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   const aggregatePropertyData = (prop) => {
     const allCards = getPropertyCards(prop);
     if (allCards.length <= 1) return prop; // No additional cards, return as-is
+
+    console.log(`🔗 Aggregating ${allCards.length} cards for ${prop.property_block}/${prop.property_lot}/${prop.property_qualifier}:`,
+      allCards.map(c => `${c.property_addl_card}(${parseFloat(c.asset_lot_acre)||0}ac)`).join(' + '));
 
     // Honor additional_card_handling_config. In 'separate' mode the user wants
     // each parcel evaluated against the main card only — no SFLA / amenity sums.

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1915,12 +1915,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     console.log(`🔗 Aggregating ${allCards.length} cards for ${prop.property_block}/${prop.property_lot}/${prop.property_qualifier}:`,
       allCards.map(c => `${c.property_addl_card}(${parseFloat(c.asset_lot_acre)||0}ac)`).join(' + '));
 
-    // Honor additional_card_handling_config from job settings (not per-card _cardMode, which may vary)
-    // In 'separate' mode the user wants each parcel evaluated against the main card only —
-    // no SFLA / amenity sums. We still surface the additional-cards count so the
-    // (+N cards) badge stays visible everywhere it renders today.
     const cardMode = marketLandData?.additional_card_handling_config?.mode === 'separate' ? 'separate' : 'combine';
-    if (cardMode === 'separate') {
+    const isFarmPackage = prop._pkg?.is_farm_package && prop._pkg?.combined_lot_acres > 0;
+
+    // In 'separate' mode, we DON'T combine additional cards (A, B, C, etc.) with the main card.
+    // HOWEVER, we ALWAYS combine farm packages (7/4 base + 7/4/QFARM variant) regardless of mode.
+    // This is because 3A (farmhouse) and 3B (farmland) are different parcel types, not just "additional cards".
+
+    if (cardMode === 'separate' && !isFarmPackage) {
+      // Not a farm package and cardMode is separate: return early with just the main card
       return {
         ...prop,
         _additionalCardsCount: allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length,
@@ -1970,11 +1973,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
     // For farm properties, ensure asset_lot_acre matches the combined lot from _pkg
     // This keeps the editable value in sync with the display render function
-    if (aggregated._pkg?.is_farm_package && aggregated._pkg?.combined_lot_acres > 0) {
+    if (isFarmPackage) {
       console.log(`🌾 Farm package override: _pkg.combined_lot_acres=${aggregated._pkg?.combined_lot_acres}, was=${aggregated.asset_lot_acre}`);
       aggregated.asset_lot_acre = aggregated._pkg.combined_lot_acres;
-    } else {
-      console.log(`🚫 No farm override: _pkg.is_farm_package=${aggregated._pkg?.is_farm_package}, combined_lot_acres=${aggregated._pkg?.combined_lot_acres}, final acres=${aggregated.asset_lot_acre}`);
     }
 
     return aggregated;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1916,7 +1916,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       allCards.map(c => `${c.property_addl_card}(${parseFloat(c.asset_lot_acre)||0}ac)`).join(' + '));
 
     const cardMode = marketLandData?.additional_card_handling_config?.mode === 'separate' ? 'separate' : 'combine';
-    const isFarmPackage = prop._pkg?.is_farm_package && prop._pkg?.combined_lot_acres > 0;
+
+    // Check if ANY card in the group is marked as a farm package.
+    // The farm package metadata might be on different cards (e.g., main card has is_farm_package=true,
+    // but the QFARM variant might have different _pkg). We check all of them.
+    const isFarmPackage = allCards.some(card => card._pkg?.is_farm_package && card._pkg?.combined_lot_acres > 0);
 
     // In 'separate' mode, we DON'T combine additional cards (A, B, C, etc.) with the main card.
     // HOWEVER, we ALWAYS combine farm packages (7/4 base + 7/4/QFARM variant) regardless of mode.
@@ -1974,8 +1978,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     // For farm properties, ensure asset_lot_acre matches the combined lot from _pkg
     // This keeps the editable value in sync with the display render function
     if (isFarmPackage) {
-      console.log(`🌾 Farm package override: _pkg.combined_lot_acres=${aggregated._pkg?.combined_lot_acres}, was=${aggregated.asset_lot_acre}`);
-      aggregated.asset_lot_acre = aggregated._pkg.combined_lot_acres;
+      // Find the farm package info from any card in the group (it might be on a different card than the main one)
+      const farmPackageInfo = allCards.find(card => card._pkg?.is_farm_package && card._pkg?.combined_lot_acres > 0)?._pkg;
+      if (farmPackageInfo) {
+        console.log(`🌾 Farm package override: combined_lot_acres=${farmPackageInfo.combined_lot_acres}, was=${aggregated.asset_lot_acre}`);
+        aggregated.asset_lot_acre = farmPackageInfo.combined_lot_acres;
+      }
     }
 
     return aggregated;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1917,17 +1917,20 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
     const cardMode = marketLandData?.additional_card_handling_config?.mode === 'separate' ? 'separate' : 'combine';
 
-    // Check if ANY card in the group is marked as a farm package.
-    // The farm package metadata might be on different cards (e.g., main card has is_farm_package=true,
-    // but the QFARM variant might have different _pkg). We check all of them.
-    const isFarmPackage = allCards.some(card => card._pkg?.is_farm_package && card._pkg?.combined_lot_acres > 0);
+    // Check if this is a farm property by looking at the class codes (3A or 3B).
+    // This handles both the _pkg.is_farm_package flag AND cases where 3A and 3B
+    // are on different sales records and don't share the same _pkg grouping.
+    const isFarmProperty = allCards.some(card => {
+      const cls = (card.property_m4_class || card.property_class || '').toString().trim().toUpperCase();
+      return cls === '3A' || cls === '3B';
+    });
 
     // In 'separate' mode, we DON'T combine additional cards (A, B, C, etc.) with the main card.
-    // HOWEVER, we ALWAYS combine farm packages (7/4 base + 7/4/QFARM variant) regardless of mode.
+    // HOWEVER, we ALWAYS combine farm properties (7/4 base 3A + 7/4/QFARM variant 3B) regardless of mode.
     // This is because 3A (farmhouse) and 3B (farmland) are different parcel types, not just "additional cards".
 
-    if (cardMode === 'separate' && !isFarmPackage) {
-      // Not a farm package and cardMode is separate: return early with just the main card
+    if (cardMode === 'separate' && !isFarmProperty) {
+      // Not a farm property and cardMode is separate: return early with just the main card
       return {
         ...prop,
         _additionalCardsCount: allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length,
@@ -1975,15 +1978,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
     aggregated._additionalCardsCount = allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length;
 
-    // For farm properties, ensure asset_lot_acre matches the combined lot from _pkg
-    // This keeps the editable value in sync with the display render function
-    if (isFarmPackage) {
-      // Find the farm package info from any card in the group (it might be on a different card than the main one)
-      const farmPackageInfo = allCards.find(card => card._pkg?.is_farm_package && card._pkg?.combined_lot_acres > 0)?._pkg;
-      if (farmPackageInfo) {
-        console.log(`🌾 Farm package override: combined_lot_acres=${farmPackageInfo.combined_lot_acres}, was=${aggregated.asset_lot_acre}`);
-        aggregated.asset_lot_acre = farmPackageInfo.combined_lot_acres;
-      }
+    // For farm properties, the combined lot acre is the sum of all cards (already done above in sumFields).
+    // No special override needed here since the summation already handles 3A + 3B aggregation.
+    if (isFarmProperty) {
+      console.log(`🌾 Farm property detected: aggregated.asset_lot_acre=${aggregated.asset_lot_acre}`);
     }
 
     return aggregated;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1983,12 +1983,17 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       } catch (_) { /* non-critical */ }
 
       // Find subject by block, lot, qualifier (normalize for comparison)
-      const subjectRaw = properties.find(p => {
+      // Prefer the main card if multiple cards exist for this block/lot/qualifier
+      const allMatches = properties.filter(p => {
         const blockMatch = (p.property_block || '').trim().toUpperCase() === manualSubject.block.trim().toUpperCase();
         const lotMatch = (p.property_lot || '').trim().toUpperCase() === manualSubject.lot.trim().toUpperCase();
         const qualMatch = (p.property_qualifier || '').trim().toUpperCase() === (manualSubject.qualifier || '').trim().toUpperCase();
         return blockMatch && lotMatch && qualMatch;
       });
+
+      const subjectRaw = allMatches.length > 0
+        ? (allMatches.find(p => isMainCard(p.property_addl_card)) || allMatches[0])
+        : null;
 
       if (!subjectRaw) {
         alert(`Subject property not found: Block ${manualSubject.block}, Lot ${manualSubject.lot}${manualSubject.qualifier ? `, Qual ${manualSubject.qualifier}` : ''}\n\nMake sure the property exists in this job.`);
@@ -2006,12 +2011,16 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
       for (const compEntry of manualComps) {
         if (compEntry.block && compEntry.lot) {
-          const compRaw = properties.find(p => {
+          const allCompMatches = properties.filter(p => {
             const blockMatch = (p.property_block || '').trim().toUpperCase() === compEntry.block.trim().toUpperCase();
             const lotMatch = (p.property_lot || '').trim().toUpperCase() === compEntry.lot.trim().toUpperCase();
             const qualMatch = (p.property_qualifier || '').trim().toUpperCase() === (compEntry.qualifier || '').trim().toUpperCase();
             return blockMatch && lotMatch && qualMatch;
           });
+
+          const compRaw = allCompMatches.length > 0
+            ? (allCompMatches.find(p => isMainCard(p.property_addl_card)) || allCompMatches[0])
+            : null;
 
           if (!compRaw) {
             // Property not found in database
@@ -2246,19 +2255,34 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
       if (manualProperties.length > 0) {
         // Use manually entered properties (match by block/lot/qualifier, same as detailed tab)
-        subjects = properties.filter(p => {
-          if (!isResidentialProperty(p)) return false;
-          return manualProperties.some(key => {
-            const parts = key.split('-');
-            const block = (parts[0] || '').trim().toUpperCase();
-            const lot = (parts[1] || '').trim().toUpperCase();
-            const qual = (parts[2] || '').trim().toUpperCase();
-            const blockMatch = (p.property_block || '').trim().toUpperCase() === block;
-            const lotMatch = (p.property_lot || '').trim().toUpperCase() === lot;
-            const qualMatch = (p.property_qualifier || '').trim().toUpperCase() === qual;
-            return blockMatch && lotMatch && qualMatch;
-          });
+        // For multi-card properties, prefer the main card only
+        const subjectsByBaseKey = {};
+        manualProperties.forEach(key => {
+          const parts = key.split('-');
+          const block = (parts[0] || '').trim().toUpperCase();
+          const lot = (parts[1] || '').trim().toUpperCase();
+          const qual = (parts[2] || '').trim().toUpperCase();
+          const baseKey = `${block}|${lot}|${qual}`;
+          if (!subjectsByBaseKey[baseKey]) {
+            subjectsByBaseKey[baseKey] = { block, lot, qual };
+          }
         });
+
+        subjects = Object.values(subjectsByBaseKey)
+          .map(({ block, lot, qual }) => {
+            const matches = properties.filter(p => {
+              if (!isResidentialProperty(p)) return false;
+              const blockMatch = (p.property_block || '').trim().toUpperCase() === block;
+              const lotMatch = (p.property_lot || '').trim().toUpperCase() === lot;
+              const qualMatch = (p.property_qualifier || '').trim().toUpperCase() === qual;
+              return blockMatch && lotMatch && qualMatch;
+            });
+            // Prefer the main card if multiple cards exist
+            return matches.length > 0
+              ? (matches.find(p => isMainCard(p.property_addl_card)) || matches[0])
+              : null;
+          })
+          .filter(p => p !== null);
       } else {
         // Use VCS + Type/Use filters
         subjects = properties.filter(p => {

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1920,12 +1920,16 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     // Check if this is a farm property by looking at the class codes (3A or 3B).
     // This handles both the _pkg.is_farm_package flag AND cases where 3A and 3B
     // are on different sales records and don't share the same _pkg grouping.
-    const isFarmProperty = allCards.some(card => {
+    let isFarmProperty = false;
+    for (const card of allCards) {
       const cls = (card.property_m4_class || card.property_class || '').toString().trim().toUpperCase();
-      return cls === '3A' || cls === '3B';
-    });
+      if (cls === '3A' || cls === '3B') {
+        isFarmProperty = true;
+        break;
+      }
+    }
 
-    // In 'separate' mode, we DON'T combine additional cards (A, B, C, etc.) with the main card.
+    // In separate mode, dont combine additional cards A, B, C with the main card.
     // HOWEVER, we ALWAYS combine farm properties (7/4 base 3A + 7/4/QFARM variant 3B) regardless of mode.
     // This is because 3A (farmhouse) and 3B (farmland) are different parcel types, not just "additional cards".
 
@@ -1979,9 +1983,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     aggregated._additionalCardsCount = allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length;
 
     // For farm properties, the combined lot acre is the sum of all cards (already done above in sumFields).
-    // No special override needed here since the summation already handles 3A + 3B aggregation.
+    // No special override needed since the summation in the loop above already handles 3A + 3B acres aggregation.
     if (isFarmProperty) {
-      console.log(`🌾 Farm property detected: aggregated.asset_lot_acre=${aggregated.asset_lot_acre}`);
+      console.log(`🌾 Farm property detected: asset_lot_acre=${aggregated.asset_lot_acre}`);
     }
 
     return aggregated;


### PR DESCRIPTION
### Summary
Fixes acreage aggregation and subject card selection for properties that are simultaneously farm packages (3A/3B) and multi-card properties in Microsystems, where the main card is identified by `M` rather than a numeric `1`.

### Problem
When evaluating a Microsystems farm property (e.g., Block 7 Lot 4) with both a 3A farmhouse card and a 3B/QFARM farmland card, the system was failing to aggregate acreage correctly — showing only 1.00 acre instead of the combined total. Additionally, when card mode was set to "separate," farm parcels were incorrectly skipped from aggregation, and subject/comp lookups could resolve to an additional card instead of the main card.

### Solution
- Updated `getPropertyCards` to normalize Q-prefixed qualifiers (e.g., `QFARM`) so that 3A and 3B parcels sharing the same block/lot are grouped together regardless of qualifier.
- Updated `aggregatePropertyCards` to detect farm properties by class code (`3A`/`3B`) and always combine them, even when card mode is `separate`.
- Replaced `find` with `filter` + main-card preference logic when resolving subjects and comps, ensuring the main card (`M` or equivalent) is always preferred over additional cards.
- Removed the old `_pkg.combined_lot_acres` override in favor of direct summation across all cards in `sumFields`.

### Key Changes
- **`getPropertyCards`**: Strips Q-prefixed qualifiers before matching so `7/4/QFARM` groups with `7/4` as the same base property.
- **`aggregatePropertyCards`**: Detects farm properties via `property_m4_class` / `property_class` codes (`3A`/`3B`); bypasses `separate` card mode for farm packages so acreage is always summed.
- **Subject/comp resolution**: Changed from `.find()` to `.filter()` + `isMainCard()` preference to avoid resolving to an additional card when multiple cards match the same block/lot/qualifier.
- **Manual subject evaluation**: Same main-card preference logic applied when building the subjects list from manually entered properties.
- **Removed**: `_pkg.combined_lot_acres` override — direct summation now handles 3A + 3B acreage correctly without needing a separate override step.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/mystic-trail-q6pdkcki"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-mystic-trail-q6pdkcki_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 222`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>mystic-trail-q6pdkcki</branchName>-->