### PR TITLE
Add farm acreage calc and manual sales for Microsystems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "papaparse": "^5.4.1",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^3.11.174",
+        "pg": "^8.21.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
@@ -13015,6 +13016,95 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14438,6 +14528,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -16214,6 +16343,15 @@
         "obuf": "^1.1.2",
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -18789,6 +18927,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "papaparse": "^5.4.1",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^3.11.174",
+    "pg": "^8.21.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -31,12 +31,32 @@ const enrichPropertiesWithPackageData = (properties) => {
     });
     // Prefer market_manual_* (unit-rate-config calculated values for BRT) over asset_lot_* (Microsystems direct extract)
     // SF and acres represent the SAME measurement in different units, so use SF if available, otherwise convert acres
-    const combinedLotSF = group.reduce((sum, p) => {
-      const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
-      if (sf > 0) return sum + sf;
-      const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
-      return sum + (acres * 43560);
-    }, 0);
+    // For farm properties (hasFarm=true), check if the first card has farm_combined_lot_acre from the database
+    let combinedLotSF;
+    if (hasFarm && group.length > 0) {
+      const firstCard = group[0];
+      const farmCombinedAcres = parseFloat(firstCard.farm_combined_lot_acre);
+      if (farmCombinedAcres > 0) {
+        // Use the pre-calculated database value
+        combinedLotSF = farmCombinedAcres * 43560;
+      } else {
+        // Fall back to summing individual cards
+        combinedLotSF = group.reduce((sum, p) => {
+          const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
+          if (sf > 0) return sum + sf;
+          const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
+          return sum + (acres * 43560);
+        }, 0);
+      }
+    } else {
+      // Non-farm: sum individual cards
+      combinedLotSF = group.reduce((sum, p) => {
+        const sf = parseFloat(p.market_manual_lot_sf) || parseFloat(p.asset_lot_sf) || 0;
+        if (sf > 0) return sum + sf;
+        const acres = parseFloat(p.market_manual_lot_acre) || parseFloat(p.asset_lot_acre) || 0;
+        return sum + (acres * 43560);
+      }, 0);
+    }
     // Determine additional card vs multi-property package
     const baseKeys = new Set();
     const cardIds = new Set();

--- a/src/components/job-modules/ParcelPhotoStrip.jsx
+++ b/src/components/job-modules/ParcelPhotoStrip.jsx
@@ -49,7 +49,31 @@ function ParcelColumn({ parcel, jobId, savedPhoto, onSaved, pickLabel = 'Front' 
 
   // Local additions (paste / file-picker) not on disk
   const [extras, setExtras] = useState([]);
-  const photos = useMemo(() => [...folderPhotos, ...extras], [folderPhotos, extras]);
+
+  // Build photos array: folder photos + local extras + saved DB photo (if any)
+  // If a photo was already saved to appeal_photos, include it in the list so it
+  // can be picked again when the user returns to this property
+  const photos = useMemo(() => {
+    const list = [...folderPhotos, ...extras];
+    // If there's a saved photo from the DB and it's not already in the list,
+    // synthesize a photo object so it can be displayed and re-picked
+    if (savedPhoto?.storage_path && savedPhoto?.original_filename) {
+      const alreadyInList = list.some(p => p.name === savedPhoto.original_filename);
+      if (!alreadyInList) {
+        list.push({
+          name: savedPhoto.original_filename,
+          // For DB photos, store the storage path so readPhoto can load it
+          storageKey: savedPhoto.storage_path,
+          // Mark as DB photo so readPhoto knows to fetch from storage
+          source: 'db_storage',
+          photoNum: Number.MAX_SAFE_INTEGER,
+          vendor: null,
+          captureTs: savedPhoto.capture_ts || null,
+        });
+      }
+    }
+    return list;
+  }, [folderPhotos, extras, savedPhoto]);
 
   const [focusIdx, setFocusIdx] = useState(() => Math.max(0, photos.length - 1));
   // Default the focused photo to the one already saved as Front (if any),
@@ -381,7 +405,7 @@ export function ExportPhotosPreview({ jobId, parcels = [], appealNumber = '' }) 
 // Main: compact horizontal strip aligned with the comp grid above
 // ---------------------------------------------------------------------------
 
-export default function ParcelPhotoStrip({ jobId, parcels = [], pickLabel = 'Front' }) {
+export default function ParcelPhotoStrip({ jobId, parcels = [], pickLabel = 'Front', onPhotoSaved = null }) {
   const { connected, indexResult, source } = useJobPhotoSource();
   const [savedMap, setSavedMap] = useState({});
 
@@ -391,14 +415,19 @@ export default function ParcelPhotoStrip({ jobId, parcels = [], pickLabel = 'Fro
       if (!jobId || parcels.length === 0) return;
       const keys = parcels.map((p) => p.composite_key).filter(Boolean);
       if (keys.length === 0) return;
+      console.log('📸 ParcelPhotoStrip loading photos for keys:', keys);
       const { data, error } = await supabase
         .from('appeal_photos')
         .select('*')
         .eq('job_id', jobId)
         .in('property_composite_key', keys);
-      if (cancelled || error) return;
+      if (cancelled || error) {
+        console.warn('📸 Error loading photos:', error);
+        return;
+      }
       const map = {};
       (data || []).forEach((r) => { map[r.property_composite_key] = r; });
+      console.log('📸 ParcelPhotoStrip loaded photos:', map);
       setSavedMap(map);
     })();
     return () => { cancelled = true; };
@@ -439,7 +468,11 @@ export default function ParcelPhotoStrip({ jobId, parcels = [], pickLabel = 'Fro
             jobId={jobId}
             pickLabel={pickLabel}
             savedPhoto={savedMap[p.composite_key]}
-            onSaved={(row) => setSavedMap((m) => ({ ...m, [row.property_composite_key]: row }))}
+            onSaved={(row) => {
+              setSavedMap((m) => ({ ...m, [row.property_composite_key]: row }));
+              // Notify parent when a photo is saved (for refreshing state if needed)
+              onPhotoSaved?.(row);
+            }}
           />
         ))}
       </div>

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -40,7 +40,7 @@ const EditableInput = React.memo(function EditableInput({
   );
 });
 
-const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], customBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null, activeResultSetId = null, onSentToAppealLog = null, onGeocodeSaved = null }) => {
+const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], customBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null, activeResultSetId = null, onSentToAppealLog = null, onGeocodeSaved = null, manualSalesOverrides = [] }) => {
   const subject = result.subject;
   // Real comps coming from the comparables search. Manual "M" comps (entered
   // directly in the export modal for out-of-town properties) are layered on
@@ -136,6 +136,29 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     }
   }, [vendorType]);
 
+  // Helper to apply manual sales overrides to a property
+  const applyManualSalesOverride = useCallback((prop) => {
+    if (!prop || !manualSalesOverrides || manualSalesOverrides.length === 0) return prop;
+
+    const override = manualSalesOverrides.find(m =>
+      m.property_block === (prop.property_block || '').toString() &&
+      m.property_lot === (prop.property_lot || '').toString() &&
+      m.property_qualifier === (prop.property_qualifier || '').toString()
+    );
+
+    if (!override) return prop;
+
+    return {
+      ...prop,
+      sales_price: override.sales_price,
+      sales_date: override.sales_date,
+      sales_nu: override.sales_nu || null,
+      sales_book: override.sales_book,
+      sales_page: override.sales_page,
+      _isManualSale: true
+    };
+  }, [manualSalesOverrides]);
+
   // Helper to get all cards for a property (main + additional)
   const getPropertyCards = useCallback((prop) => {
     if (!prop || !allProperties || allProperties.length === 0) return [prop];
@@ -217,8 +240,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
     // Manual comps are not in property_records, so skip the additional-cards
     // aggregation pass entirely - just return them as-is.
     if (comp.is_manual_comp) return comp;
-    return { ...comp, ...getAggregatedPropertyData(comp) };
-  }), [comps, getAggregatedPropertyData]);
+    const aggregated = { ...comp, ...getAggregatedPropertyData(comp) };
+    // Apply manual sales override if present
+    return applyManualSalesOverride(aggregated);
+  }), [comps, getAggregatedPropertyData, applyManualSalesOverride]);
 
   // ==================== PDF EXPORT STATE ====================
   const [showExportModal, setShowExportModal] = useState(false);

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -4762,7 +4762,16 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
           photo is uploaded to `appeal-photos` storage and recorded in the
           `appeal_photos` table, keyed by (job_id, property_composite_key). */}
       <div className="px-4 pb-4">
-        <ParcelPhotoStrip jobId={jobData?.id} parcels={photoStripParcels} />
+        <ParcelPhotoStrip
+          jobId={jobData?.id}
+          parcels={photoStripParcels}
+          onPhotoSaved={(photoRow) => {
+            // Photo was saved to appeal_photos table. This callback ensures the
+            // parent (SalesComparisonTab) knows about the photo save so it can
+            // update its state if the user navigates away and comes back.
+            console.log('📸 Photo saved to appeal_photos:', photoRow.property_composite_key);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -40,7 +40,7 @@ const EditableInput = React.memo(function EditableInput({
   );
 });
 
-const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], customBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null, activeResultSetId = null, onSentToAppealLog = null }) => {
+const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, adjustmentGrid = [], compFilters = null, cmeBrackets = [], customBrackets = [], isJobContainerLoading = false, allProperties = [], marketLandData = {}, tenantConfig = null, onSalesSwapped = null, activeResultSetId = null, onSentToAppealLog = null, onGeocodeSaved = null }) => {
   const subject = result.subject;
   // Real comps coming from the comparables search. Manual "M" comps (entered
   // directly in the export modal for out-of-town properties) are layered on
@@ -282,7 +282,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
   const handleGeocodeSaved = useCallback((compositeKey, patch) => {
     if (!compositeKey) return;
     setGeocodePatches((prev) => ({ ...prev, [compositeKey]: patch }));
-  }, []);
+    // Notify parent so it can update the properties array
+    if (onGeocodeSaved) {
+      onGeocodeSaved(compositeKey, patch);
+    }
+  }, [onGeocodeSaved]);
 
   // ==================== SALES HISTORY (Hidden / Cover Sale Swap) ====================
   // When a property's current sale is a cover ($1, family transfer, estate, etc.)

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1087,8 +1087,14 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
       id: 'lot_size_acre',
       label: 'Lot Size (Acre)',
       render: (prop) => {
-        // For farm properties with farmSalesMode enabled, use combined lot acres (3A + 3B)
-        if (compFilters?.farmSalesMode && allProperties?.length > 0) {
+        // For farm properties with farmSalesMode enabled, use farm_combined_lot_acre from database
+        if (compFilters?.farmSalesMode) {
+          // First check database field (farm_combined_lot_acre)
+          const dbCombinedAcres = parseFloat(prop.farm_combined_lot_acre);
+          if (dbCombinedAcres > 0) {
+            return `${dbCombinedAcres.toFixed(2)} (Farm)`;
+          }
+          // Fall back to _pkg.combined_lot_acres if available
           const pkgData = prop._pkg;
           if (pkgData?.is_farm_package && pkgData.combined_lot_acres > 0) {
             return `${pkgData.combined_lot_acres.toFixed(2)} (Farm)`;

--- a/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
@@ -140,12 +140,12 @@ const ManualSalesModal = ({
 
       console.log(`✅ Updated ${manualSales.length} properties in property_records with overrides`);
       setSaveResult({ success: true, count: manualSales.length });
-      setManualSales([]);
 
-      // Step 2: Trigger full job cache refresh so the in-memory properties array gets the updated data
-      // This is necessary because the evaluation uses the cached properties array, not the DB directly
+      // Notify parent to reload just these properties from the DB
+      onSaved?.(manualSales);
+
+      setManualSales([]);
       setTimeout(() => {
-        onSaved();  // This should call the parent's refresh callback
         onClose();
       }, 500);
     } catch (error) {

--- a/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
@@ -1,0 +1,293 @@
+import React, { useState, useCallback } from 'react';
+import { X } from 'lucide-react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Manual Sales Modal for Microsystems vendors.
+ * Allows appraiser to manually enter historical sales that aren't in the source data.
+ * Entered sales are saved to pool_manual_sales table and included in the Sales Pool.
+ * 
+ * Props:
+ *   isOpen, onClose
+ *   jobData - { id, county }
+ *   properties - all properties in the job
+ *   onSaved - callback after save (parent should refresh)
+ */
+const ManualSalesModal = ({
+  isOpen,
+  onClose,
+  jobData = {},
+  properties = [],
+  onSaved = () => {}
+}) => {
+  const [block, setBlock] = useState('');
+  const [lot, setLot] = useState('');
+  const [qualifier, setQualifier] = useState('');
+  const [salesDate, setSalesDate] = useState('');
+  const [salesPrice, setSalesPrice] = useState('');
+  const [salesNu, setSalesNu] = useState('');
+  const [salesBook, setSalesBook] = useState('');
+  const [salesPage, setSalesPage] = useState('');
+  const [manualSales, setManualSales] = useState([]); // List of added sales this session
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState(null);
+
+  const handleAddSale = useCallback(() => {
+    if (!block.trim() || !lot.trim() || !salesDate.trim() || !salesPrice.trim()) {
+      alert('Block, Lot, Sales Date, and Sales Price are required.');
+      return;
+    }
+    const numPrice = parseFloat(salesPrice);
+    if (isNaN(numPrice)) {
+      alert('Sales Price must be a valid number.');
+      return;
+    }
+    const newSale = {
+      block: block.trim(),
+      lot: lot.trim(),
+      qualifier: qualifier.trim(),
+      sales_date: salesDate,
+      sales_price: numPrice,
+      sales_nu: salesNu.trim() || null,
+      sales_book: salesBook.trim() || null,
+      sales_page: salesPage.trim() || null,
+      tempId: Date.now()
+    };
+    setManualSales(prev => [...prev, newSale]);
+    setBlock('');
+    setLot('');
+    setQualifier('');
+    setSalesDate('');
+    setSalesPrice('');
+    setSalesNu('');
+    setSalesBook('');
+    setSalesPage('');
+  }, [block, lot, qualifier, salesDate, salesPrice, salesNu, salesBook, salesPage]);
+
+  const handleRemoveSale = useCallback((tempId) => {
+    setManualSales(prev => prev.filter(s => s.tempId !== tempId));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (manualSales.length === 0) {
+      alert('No sales to save.');
+      return;
+    }
+    if (!jobData?.id) {
+      alert('Job ID is missing.');
+      return;
+    }
+    setSaving(true);
+    setSaveResult(null);
+    try {
+      const { supabase } = await import('../../../lib/supabaseClient');
+      const rows = manualSales.map(sale => ({
+        job_id: jobData.id,
+        property_block: sale.block,
+        property_lot: sale.lot,
+        property_qualifier: sale.qualifier,
+        sales_date: sale.sales_date,
+        sales_price: sale.sales_price,
+        sales_nu: sale.sales_nu,
+        sales_book: sale.sales_book,
+        sales_page: sale.sales_page
+      }));
+      const { error } = await supabase
+        .from('pool_manual_sales')
+        .insert(rows);
+      if (error) throw error;
+      setSaveResult({ success: true, count: rows.length });
+      setManualSales([]);
+      setTimeout(() => {
+        onSaved();
+        onClose();
+      }, 1000);
+    } catch (error) {
+      console.error('❌ Error saving manual sales:', error);
+      setSaveResult({ success: false, error: error.message });
+    } finally {
+      setSaving(false);
+    }
+  }, [manualSales, jobData, onSaved, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+          <h2 className="text-xl font-bold text-gray-900">Add Manual Sales</h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-gray-100 rounded"
+            disabled={saving}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-auto px-6 py-4">
+          <p className="text-sm text-gray-600 mb-4">
+            Enter historical sales for Microsystems properties. These will be saved and included in the Sales Pool.
+          </p>
+
+          {/* Input Form */}
+          <div className="bg-gray-50 border border-gray-200 rounded p-4 mb-6">
+            <div className="grid grid-cols-2 gap-3 mb-3">
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Block *</label>
+                <input
+                  type="text"
+                  value={block}
+                  onChange={(e) => setBlock(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  placeholder="e.g. 39"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Lot *</label>
+                <input
+                  type="text"
+                  value={lot}
+                  onChange={(e) => setLot(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  placeholder="e.g. 9"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Qualifier</label>
+                <input
+                  type="text"
+                  value={qualifier}
+                  onChange={(e) => setQualifier(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  placeholder="e.g. A"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Sales Date *</label>
+                <input
+                  type="date"
+                  value={salesDate}
+                  onChange={(e) => setSalesDate(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Sales Price *</label>
+                <input
+                  type="number"
+                  value={salesPrice}
+                  onChange={(e) => setSalesPrice(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  placeholder="e.g. 225000"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Sales NU</label>
+                <input
+                  type="text"
+                  value={salesNu}
+                  onChange={(e) => setSalesNu(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  placeholder="e.g. 00"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Book</label>
+                <input
+                  type="text"
+                  value={salesBook}
+                  onChange={(e) => setSalesBook(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  disabled={saving}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-700">Page</label>
+                <input
+                  type="text"
+                  value={salesPage}
+                  onChange={(e) => setSalesPage(e.target.value)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  disabled={saving}
+                />
+              </div>
+            </div>
+            <button
+              onClick={handleAddSale}
+              className="px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400"
+              disabled={saving}
+            >
+              Add Sale
+            </button>
+          </div>
+
+          {/* Added Sales List */}
+          {manualSales.length > 0 && (
+            <div className="mb-4">
+              <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                {manualSales.length} sale{manualSales.length !== 1 ? 's' : ''} to save
+              </h3>
+              <div className="space-y-2">
+                {manualSales.map(sale => (
+                  <div key={sale.tempId} className="bg-blue-50 border border-blue-200 rounded p-3 flex items-center justify-between">
+                    <div className="text-sm">
+                      <span className="font-medium text-gray-900">
+                        {sale.block}/{sale.lot}{sale.qualifier ? '-' + sale.qualifier : ''}
+                      </span>
+                      <span className="text-gray-600 ml-3">
+                        {new Date(sale.sales_date).toLocaleDateString()} • ${sale.sales_price.toLocaleString()}
+                      </span>
+                    </div>
+                    <button
+                      onClick={() => handleRemoveSale(sale.tempId)}
+                      className="p-1 text-red-600 hover:bg-red-100 rounded"
+                      disabled={saving}
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {saveResult && (
+            <div className={`p-3 rounded text-sm ${saveResult.success ? 'bg-green-50 border border-green-200 text-green-800' : 'bg-red-50 border border-red-200 text-red-800'}`}>
+              {saveResult.success
+                ? `✅ ${saveResult.count} sale${saveResult.count !== 1 ? 's' : ''} saved successfully!`
+                : `❌ Error: ${saveResult.error}`}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-gray-200 px-6 py-4 flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded hover:bg-gray-50 disabled:bg-gray-100"
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 text-sm font-medium bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400"
+            disabled={saving || manualSales.length === 0}
+          >
+            {saving ? 'Saving...' : 'Save Sales'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ManualSalesModal;

--- a/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
@@ -111,7 +111,7 @@ const ManualSalesModal = ({
     try {
       const { supabase } = await import('../../../lib/supabaseClient');
 
-      // Update property_records directly with the override data (like BRT's unmasked sales)
+      // Step 1: Update property_records directly with the override data (like BRT's unmasked sales)
       // This ensures the override is used everywhere: pool, evaluations, PDF exports
       const updates = await Promise.all(
         manualSales.map(sale =>
@@ -138,12 +138,16 @@ const ManualSalesModal = ({
         throw new Error(errors[0].error.message);
       }
 
+      console.log(`✅ Updated ${manualSales.length} properties in property_records with overrides`);
       setSaveResult({ success: true, count: manualSales.length });
       setManualSales([]);
+
+      // Step 2: Trigger full job cache refresh so the in-memory properties array gets the updated data
+      // This is necessary because the evaluation uses the cached properties array, not the DB directly
       setTimeout(() => {
-        onSaved();
+        onSaved();  // This should call the parent's refresh callback
         onClose();
-      }, 1000);
+      }, 500);
     } catch (error) {
       console.error('❌ Error saving manual sales:', error);
       setSaveResult({ success: false, error: error.message });

--- a/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
@@ -111,24 +111,34 @@ const ManualSalesModal = ({
     try {
       const { supabase } = await import('../../../lib/supabaseClient');
 
-      // Save as pool_manual_sales (overrides for existing properties)
-      const rows = manualSales.map(sale => ({
-        job_id: jobData.id,
-        property_block: sale.property_block,
-        property_lot: sale.property_lot,
-        property_qualifier: sale.property_qualifier,
-        sales_date: sale.sales_date,
-        sales_price: sale.sales_price,
-        sales_nu: sale.sales_nu,
-        sales_book: sale.sales_book,
-        sales_page: sale.sales_page
-      }));
+      // Update property_records directly with the override data (like BRT's unmasked sales)
+      // This ensures the override is used everywhere: pool, evaluations, PDF exports
+      const updates = await Promise.all(
+        manualSales.map(sale =>
+          supabase
+            .from('property_records')
+            .update({
+              sales_date: sale.sales_date,
+              sales_price: sale.sales_price,
+              sales_nu: sale.sales_nu,
+              sales_book: sale.sales_book,
+              sales_page: sale.sales_page,
+              sales_override: true  // Mark so file update won't clobber this
+            })
+            .eq('job_id', jobData.id)
+            .eq('property_block', sale.property_block)
+            .eq('property_lot', sale.property_lot)
+            .eq('property_qualifier', sale.property_qualifier)
+        )
+      );
 
-      const { error } = await supabase
-        .from('pool_manual_sales')
-        .insert(rows);
-      if (error) throw error;
-      setSaveResult({ success: true, count: rows.length });
+      // Check for errors
+      const errors = updates.filter(r => r.error);
+      if (errors.length > 0) {
+        throw new Error(errors[0].error.message);
+      }
+
+      setSaveResult({ success: true, count: manualSales.length });
       setManualSales([]);
       setTimeout(() => {
         onSaved();

--- a/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ManualSalesModal.jsx
@@ -4,9 +4,9 @@ import { createPortal } from 'react-dom';
 
 /**
  * Manual Sales Modal for Microsystems vendors.
- * Allows appraiser to manually enter historical sales that aren't in the source data.
- * Entered sales are saved to pool_manual_sales table and included in the Sales Pool.
- * 
+ * Links manual sales to existing properties in the job, overriding their source sales.
+ * Similar to BRT's unmask feature.
+ *
  * Props:
  *   isOpen, onClose
  *   jobData - { id, county }
@@ -20,21 +20,49 @@ const ManualSalesModal = ({
   properties = [],
   onSaved = () => {}
 }) => {
-  const [block, setBlock] = useState('');
-  const [lot, setLot] = useState('');
-  const [qualifier, setQualifier] = useState('');
+  const [selectedProperty, setSelectedProperty] = useState(null);
+  const [searchText, setSearchText] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+
   const [salesDate, setSalesDate] = useState('');
   const [salesPrice, setSalesPrice] = useState('');
   const [salesNu, setSalesNu] = useState('');
   const [salesBook, setSalesBook] = useState('');
   const [salesPage, setSalesPage] = useState('');
-  const [manualSales, setManualSales] = useState([]); // List of added sales this session
+
+  const [manualSales, setManualSales] = useState([]); // List of overrides this session
   const [saving, setSaving] = useState(false);
   const [saveResult, setSaveResult] = useState(null);
 
+  // Get unique properties (main card only) for selection
+  const uniqueProperties = (() => {
+    const seen = new Set();
+    return properties.filter(p => {
+      const baseKey = `${p.property_block}-${p.property_lot}-${p.property_qualifier || ''}`;
+      if (seen.has(baseKey)) return false;
+      seen.add(baseKey);
+      // Only properties with sales data can be overridden
+      return p.sales_date;
+    });
+  })();
+
+  // Filter properties by search text
+  const filteredProperties = uniqueProperties.filter(p => {
+    const text = searchText.toLowerCase();
+    return (
+      p.property_block?.toLowerCase().includes(text) ||
+      p.property_lot?.toLowerCase().includes(text) ||
+      (p.property_qualifier || '').toLowerCase().includes(text)
+    );
+  });
+
   const handleAddSale = useCallback(() => {
-    if (!block.trim() || !lot.trim() || !salesDate.trim() || !salesPrice.trim()) {
-      alert('Block, Lot, Sales Date, and Sales Price are required.');
+    if (!selectedProperty) {
+      alert('Please select a property from the job.');
+      return;
+    }
+    if (!salesDate.trim() || !salesPrice.trim()) {
+      alert('Sales Date and Sales Price are required.');
       return;
     }
     const numPrice = parseFloat(salesPrice);
@@ -43,9 +71,11 @@ const ManualSalesModal = ({
       return;
     }
     const newSale = {
-      block: block.trim(),
-      lot: lot.trim(),
-      qualifier: qualifier.trim(),
+      property_block: selectedProperty.property_block,
+      property_lot: selectedProperty.property_lot,
+      property_qualifier: selectedProperty.property_qualifier || '',
+      current_sales_price: selectedProperty.sales_price,
+      current_sales_date: selectedProperty.sales_date,
       sales_date: salesDate,
       sales_price: numPrice,
       sales_nu: salesNu.trim() || null,
@@ -54,15 +84,14 @@ const ManualSalesModal = ({
       tempId: Date.now()
     };
     setManualSales(prev => [...prev, newSale]);
-    setBlock('');
-    setLot('');
-    setQualifier('');
+    setSelectedProperty(null);
+    setSearchText('');
     setSalesDate('');
     setSalesPrice('');
     setSalesNu('');
     setSalesBook('');
     setSalesPage('');
-  }, [block, lot, qualifier, salesDate, salesPrice, salesNu, salesBook, salesPage]);
+  }, [selectedProperty, salesDate, salesPrice, salesNu, salesBook, salesPage]);
 
   const handleRemoveSale = useCallback((tempId) => {
     setManualSales(prev => prev.filter(s => s.tempId !== tempId));
@@ -81,17 +110,20 @@ const ManualSalesModal = ({
     setSaveResult(null);
     try {
       const { supabase } = await import('../../../lib/supabaseClient');
+
+      // Save as pool_manual_sales (overrides for existing properties)
       const rows = manualSales.map(sale => ({
         job_id: jobData.id,
-        property_block: sale.block,
-        property_lot: sale.lot,
-        property_qualifier: sale.qualifier,
+        property_block: sale.property_block,
+        property_lot: sale.property_lot,
+        property_qualifier: sale.property_qualifier,
         sales_date: sale.sales_date,
         sales_price: sale.sales_price,
         sales_nu: sale.sales_nu,
         sales_book: sale.sales_book,
         sales_page: sale.sales_page
       }));
+
       const { error } = await supabase
         .from('pool_manual_sales')
         .insert(rows);
@@ -128,45 +160,67 @@ const ManualSalesModal = ({
 
         <div className="flex-1 overflow-auto px-6 py-4">
           <p className="text-sm text-gray-600 mb-4">
-            Enter historical sales for Microsystems properties. These will be saved and included in the Sales Pool.
+            Override junk sales with actual historical data. Select a property from the job and enter the better sale data.
           </p>
 
-          {/* Input Form */}
+          {/* Property Selector */}
           <div className="bg-gray-50 border border-gray-200 rounded p-4 mb-6">
+            <div className="mb-3">
+              <label className="block text-xs font-semibold text-gray-700 mb-1">Select Property *</label>
+              <div className="relative">
+                <input
+                  type="text"
+                  value={selectedProperty ? `${selectedProperty.property_block}/${selectedProperty.property_lot}${selectedProperty.property_qualifier ? '-' + selectedProperty.property_qualifier : ''}` : searchText}
+                  onChange={(e) => {
+                    if (selectedProperty) {
+                      setSelectedProperty(null);
+                    }
+                    setSearchText(e.target.value);
+                    setShowDropdown(true);
+                  }}
+                  onFocus={() => setShowDropdown(true)}
+                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  placeholder="Search by block/lot (e.g. 39/9)"
+                  disabled={saving}
+                />
+                {showDropdown && filteredProperties.length > 0 && (
+                  <div className="absolute top-full left-0 right-0 border border-gray-300 border-t-0 rounded-b bg-white shadow-lg max-h-48 overflow-y-auto z-10">
+                    {filteredProperties.map(prop => (
+                      <button
+                        key={`${prop.property_block}-${prop.property_lot}-${prop.property_qualifier}`}
+                        onClick={() => {
+                          setSelectedProperty(prop);
+                          setSearchText('');
+                          setShowDropdown(false);
+                        }}
+                        className="w-full text-left px-3 py-2 hover:bg-blue-50 text-sm flex items-center justify-between"
+                        type="button"
+                      >
+                        <span className="font-medium">
+                          {prop.property_block}/{prop.property_lot}{prop.property_qualifier ? '-' + prop.property_qualifier : ''}
+                        </span>
+                        <span className="text-xs text-gray-500">
+                          {new Date(prop.sales_date).toLocaleDateString()} • ${parseFloat(prop.sales_price || 0).toLocaleString()}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Current Sale Info (if selected) */}
+            {selectedProperty && (
+              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm">
+                <span className="font-semibold text-red-900">Current Sale:</span>
+                <span className="text-red-800 ml-2">
+                  {new Date(selectedProperty.sales_date).toLocaleDateString()} • ${parseFloat(selectedProperty.sales_price || 0).toLocaleString()}
+                </span>
+              </div>
+            )}
+
+            {/* New Sale Data */}
             <div className="grid grid-cols-2 gap-3 mb-3">
-              <div>
-                <label className="block text-xs font-semibold text-gray-700">Block *</label>
-                <input
-                  type="text"
-                  value={block}
-                  onChange={(e) => setBlock(e.target.value)}
-                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
-                  placeholder="e.g. 39"
-                  disabled={saving}
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-semibold text-gray-700">Lot *</label>
-                <input
-                  type="text"
-                  value={lot}
-                  onChange={(e) => setLot(e.target.value)}
-                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
-                  placeholder="e.g. 9"
-                  disabled={saving}
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-semibold text-gray-700">Qualifier</label>
-                <input
-                  type="text"
-                  value={qualifier}
-                  onChange={(e) => setQualifier(e.target.value)}
-                  className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
-                  placeholder="e.g. A"
-                  disabled={saving}
-                />
-              </div>
               <div>
                 <label className="block text-xs font-semibold text-gray-700">Sales Date *</label>
                 <input
@@ -174,7 +228,7 @@ const ManualSalesModal = ({
                   value={salesDate}
                   onChange={(e) => setSalesDate(e.target.value)}
                   className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
-                  disabled={saving}
+                  disabled={saving || !selectedProperty}
                 />
               </div>
               <div>
@@ -185,7 +239,7 @@ const ManualSalesModal = ({
                   onChange={(e) => setSalesPrice(e.target.value)}
                   className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
                   placeholder="e.g. 225000"
-                  disabled={saving}
+                  disabled={saving || !selectedProperty}
                 />
               </div>
               <div>
@@ -196,7 +250,7 @@ const ManualSalesModal = ({
                   onChange={(e) => setSalesNu(e.target.value)}
                   className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
                   placeholder="e.g. 00"
-                  disabled={saving}
+                  disabled={saving || !selectedProperty}
                 />
               </div>
               <div>
@@ -206,53 +260,55 @@ const ManualSalesModal = ({
                   value={salesBook}
                   onChange={(e) => setSalesBook(e.target.value)}
                   className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
-                  disabled={saving}
+                  disabled={saving || !selectedProperty}
                 />
               </div>
-              <div>
+              <div className="col-span-2">
                 <label className="block text-xs font-semibold text-gray-700">Page</label>
                 <input
                   type="text"
                   value={salesPage}
                   onChange={(e) => setSalesPage(e.target.value)}
                   className="w-full px-2 py-1 border border-gray-300 rounded text-sm"
-                  disabled={saving}
+                  disabled={saving || !selectedProperty}
                 />
               </div>
             </div>
+
             <button
               onClick={handleAddSale}
               className="px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400"
-              disabled={saving}
+              disabled={saving || !selectedProperty}
             >
-              Add Sale
+              Add Override
             </button>
           </div>
 
-          {/* Added Sales List */}
+          {/* Overrides List */}
           {manualSales.length > 0 && (
             <div className="mb-4">
               <h3 className="text-sm font-semibold text-gray-900 mb-2">
-                {manualSales.length} sale{manualSales.length !== 1 ? 's' : ''} to save
+                {manualSales.length} override{manualSales.length !== 1 ? 's' : ''} to save
               </h3>
               <div className="space-y-2">
                 {manualSales.map(sale => (
-                  <div key={sale.tempId} className="bg-blue-50 border border-blue-200 rounded p-3 flex items-center justify-between">
-                    <div className="text-sm">
+                  <div key={sale.tempId} className="bg-blue-50 border border-blue-200 rounded p-3">
+                    <div className="flex items-center justify-between mb-1">
                       <span className="font-medium text-gray-900">
-                        {sale.block}/{sale.lot}{sale.qualifier ? '-' + sale.qualifier : ''}
+                        {sale.property_block}/{sale.property_lot}{sale.property_qualifier ? '-' + sale.property_qualifier : ''}
                       </span>
-                      <span className="text-gray-600 ml-3">
-                        {new Date(sale.sales_date).toLocaleDateString()} • ${sale.sales_price.toLocaleString()}
-                      </span>
+                      <button
+                        onClick={() => handleRemoveSale(sale.tempId)}
+                        className="p-1 text-red-600 hover:bg-red-100 rounded"
+                        disabled={saving}
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
                     </div>
-                    <button
-                      onClick={() => handleRemoveSale(sale.tempId)}
-                      className="p-1 text-red-600 hover:bg-red-100 rounded"
-                      disabled={saving}
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
+                    <div className="text-xs text-gray-600">
+                      <div className="line-through">Old: {new Date(sale.current_sales_date).toLocaleDateString()} • ${parseFloat(sale.current_sales_price || 0).toLocaleString()}</div>
+                      <div className="text-green-700 font-medium">New: {new Date(sale.sales_date).toLocaleDateString()} • ${sale.sales_price.toLocaleString()}</div>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -3057,6 +3057,23 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
         let topComps = [...pinnedSelected, ...fillerComps];
 
+        // CRITICAL: If a comp has a manual sales override, recalculate adjustmentPercent
+        // so it's based on the overridden sales_price, not the original junk price
+        topComps = topComps.map(comp => {
+          if (comp._isManualSale && comp.adjustments && comp.sales_price > 0) {
+            // Recalculate adjustment percent from the total adjustment amount
+            const totalAdj = comp.adjustments.reduce((sum, adj) => sum + (adj.amount || 0), 0);
+            const newAdjPercent = (totalAdj / comp.sales_price) * 100;
+            const newAdjustedPrice = comp.sales_price + totalAdj;
+            return {
+              ...comp,
+              adjustmentPercent: newAdjPercent,
+              adjustedPrice: newAdjustedPrice
+            };
+          }
+          return comp;
+        });
+
         // Add subject sale as Comp #1 if it exists
         if (priorityComp) {
           topComps = [priorityComp, ...topComps];

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -4280,11 +4280,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                 <div className="flex flex-wrap items-end justify-center gap-4">
                   <div>
                     <label className="block text-xs font-medium text-gray-600 mb-1">Sales Date From</label>
-                    <input type="date" value={stagedDateStart} onChange={(e) => setStagedDateStart(e.target.value)} className="px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500" />
+                    <input type="date" value={stagedDateStart} onChange={(e) => { setStagedDateStart(e.target.value); setCompFilters(prev => ({ ...prev, salesDateStart: e.target.value })); }} className="px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500" />
                   </div>
                   <div>
                     <label className="block text-xs font-medium text-gray-600 mb-1">Sales Date To</label>
-                    <input type="date" value={stagedDateEnd} onChange={(e) => setStagedDateEnd(e.target.value)} className="px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500" />
+                    <input type="date" value={stagedDateEnd} onChange={(e) => { setStagedDateEnd(e.target.value); setCompFilters(prev => ({ ...prev, salesDateEnd: e.target.value })); }} className="px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500" />
                   </div>
                   <div>
                     <label className="block text-xs font-medium text-gray-600 mb-1">Search Block/Lot/Address</label>

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1936,22 +1936,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     // for use when farm sales mode is toggled ON.
     if (cardMode === 'separate') {
       // Separate mode: return early with just the main card
-      const result = {
+      // The farm_combined_lot_acre field from the DB is already in prop,
+      // so just pass it through as-is
+      return {
         ...prop,
         _additionalCardsCount: allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length,
       };
-
-      // For farm properties in separate mode, calculate and store combined lot acres
-      // so that when farm sales mode is ON, we can use the combined total
-      if (isFarmProperty) {
-        const combinedLotAcre = allCards.reduce((sum, card) => sum + (parseFloat(card.asset_lot_acre) || 0), 0);
-        if (combinedLotAcre > 0) {
-          result._combinedLotAcre = combinedLotAcre;
-          console.log(`🌾 Farm property (separate mode): main card acre=${result.asset_lot_acre}, combined=${combinedLotAcre}`);
-        }
-      }
-
-      return result;
     }
 
     const aggregated = { ...prop };

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -3342,30 +3342,14 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         break;
 
       case 'lot_size_acre':
-        // For farm properties with farmSalesMode enabled, use combined lot acres (3A + 3B)
-        // Otherwise use the individual card's acre (preserved as asset_lot_acre)
+        // Farm properties: use farm_combined_lot_acre when farm sales mode is ON
+        // Otherwise use the individual card's asset_lot_acre
         if (compFilters?.farmSalesMode) {
-          const subjectPkgInfo = subject._pkg;
-          const compPkgInfo = comp._pkg;
-
-          // Try _combinedLotAcre first (from aggregation), then fall back to _pkg data
-          if (subject._combinedLotAcre && subject._combinedLotAcre > 0) {
-            subjectValue = subject._combinedLotAcre;
-          } else if (subjectPkgInfo?.is_farm_package && subjectPkgInfo.combined_lot_acres > 0) {
-            subjectValue = subjectPkgInfo.combined_lot_acres;
-          } else {
-            subjectValue = subject.market_manual_lot_acre || subject.asset_lot_acre || 0;
-          }
-
-          if (comp._combinedLotAcre && comp._combinedLotAcre > 0) {
-            compValue = comp._combinedLotAcre;
-          } else if (compPkgInfo?.is_farm_package && compPkgInfo.combined_lot_acres > 0) {
-            compValue = compPkgInfo.combined_lot_acres;
-          } else {
-            compValue = comp.market_manual_lot_acre || comp.asset_lot_acre || 0;
-          }
+          // Farm mode ON: use the pre-calculated combined 3A+3B acreage
+          subjectValue = subject.farm_combined_lot_acre || subject.asset_lot_acre || 0;
+          compValue = comp.farm_combined_lot_acre || comp.asset_lot_acre || 0;
         } else {
-          // Farm sales mode OFF: use the individual card's asset_lot_acre (not combined)
+          // Farm mode OFF: use the individual card's acreage only
           subjectValue = subject.market_manual_lot_acre || subject.asset_lot_acre || 0;
           compValue = comp.market_manual_lot_acre || comp.asset_lot_acre || 0;
         }

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1944,6 +1944,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     const aggregated = { ...prop };
 
     // SUM fields (includes lot acre for farm properties with multiple cards like 3A + 3B)
+    // IMPORTANT: For farm properties, we need to sum lot_acre across all cards (3A + 3B),
+    // but we'll store it separately so we can choose between individual card acre or combined acre
+    // depending on the farmSalesMode setting at display time.
     const sumFields = [
       'asset_sfla', 'asset_lot_acre', 'total_baths_calculated', 'asset_bathrooms', 'asset_bedrooms',
       'fireplace_count', 'asset_fireplaces', 'basement_area', 'fin_basement_area',
@@ -1957,7 +1960,13 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         if (field === 'asset_lot_acre') {
           console.log(`📊 Summing ${field}:`, allCards.map(c => parseFloat(c[field]) || 0).join(' + '), '=', total);
         }
-        aggregated[field] = total;
+        // For farm properties, preserve the main card's asset_lot_acre (don't overwrite it)
+        // and store the combined total separately
+        if (isFarmProperty && field === 'asset_lot_acre') {
+          aggregated._combinedLotAcre = total;
+        } else {
+          aggregated[field] = total;
+        }
       }
     });
 
@@ -1982,10 +1991,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
     aggregated._additionalCardsCount = allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length;
 
-    // For farm properties, the combined lot acre is the sum of all cards (already done above in sumFields).
-    // No special override needed since the summation in the loop above already handles 3A + 3B acres aggregation.
+    // For farm properties, the combined lot acre is the sum of all cards (already stored in _combinedLotAcre).
+    // The individual card's asset_lot_acre is preserved so we can show the right value based on farmSalesMode.
     if (isFarmProperty) {
-      console.log(`🌾 Farm property detected: asset_lot_acre=${aggregated.asset_lot_acre}`);
+      console.log(`🌾 Farm property detected: main card asset_lot_acre=${aggregated.asset_lot_acre}, combined=${aggregated._combinedLotAcre}`);
     }
 
     return aggregated;
@@ -3321,22 +3330,29 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
       case 'lot_size_acre':
         // For farm properties with farmSalesMode enabled, use combined lot acres (3A + 3B)
+        // Otherwise use the individual card's acre (preserved as asset_lot_acre)
         if (compFilters?.farmSalesMode) {
           const subjectPkgInfo = subject._pkg;
           const compPkgInfo = comp._pkg;
 
-          if (subjectPkgInfo?.is_farm_package && subjectPkgInfo.combined_lot_acres > 0) {
+          // Try _combinedLotAcre first (from aggregation), then fall back to _pkg data
+          if (subject._combinedLotAcre && subject._combinedLotAcre > 0) {
+            subjectValue = subject._combinedLotAcre;
+          } else if (subjectPkgInfo?.is_farm_package && subjectPkgInfo.combined_lot_acres > 0) {
             subjectValue = subjectPkgInfo.combined_lot_acres;
           } else {
             subjectValue = subject.market_manual_lot_acre || subject.asset_lot_acre || 0;
           }
 
-          if (compPkgInfo?.is_farm_package && compPkgInfo.combined_lot_acres > 0) {
+          if (comp._combinedLotAcre && comp._combinedLotAcre > 0) {
+            compValue = comp._combinedLotAcre;
+          } else if (compPkgInfo?.is_farm_package && compPkgInfo.combined_lot_acres > 0) {
             compValue = compPkgInfo.combined_lot_acres;
           } else {
             compValue = comp.market_manual_lot_acre || comp.asset_lot_acre || 0;
           }
         } else {
+          // Farm sales mode OFF: use the individual card's asset_lot_acre (not combined)
           subjectValue = subject.market_manual_lot_acre || subject.asset_lot_acre || 0;
           compValue = comp.market_manual_lot_acre || comp.asset_lot_acre || 0;
         }

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -2482,7 +2482,33 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       console.log(`🔍 Evaluating ${subjects.length} subject properties...`);
 
       // Step 2: Get eligible sales from the curated Sales Pool
-      const eligibleSales = getEligibleSales();
+      let eligibleSales = getEligibleSales();
+
+      // Apply manual sales overrides (Microsystems) — ensure override prices are used in calculations
+      if (vendorType === 'Microsystems' && manualSalesData.length > 0) {
+        const manualSalesMap = {};
+        manualSalesData.forEach(manual => {
+          const baseKey = `${manual.property_block || ''}-${manual.property_lot || ''}-${manual.property_qualifier || ''}`;
+          manualSalesMap[baseKey] = manual;
+        });
+        eligibleSales = eligibleSales.map(sale => {
+          const baseKey = `${sale.property_block || ''}-${sale.property_lot || ''}-${sale.property_qualifier || ''}`;
+          const override = manualSalesMap[baseKey];
+          if (override) {
+            return {
+              ...sale,
+              sales_price: override.sales_price,
+              sales_date: override.sales_date,
+              sales_nu: override.sales_nu || null,
+              sales_book: override.sales_book,
+              sales_page: override.sales_page,
+              _isManualSale: true,
+            };
+          }
+          return sale;
+        });
+      }
+
       console.log(`📊 Found ${eligibleSales.length} eligible sales from Sales Pool`);
 
       if (eligibleSales.length === 0) {

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -8312,7 +8312,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         onClose={() => setShowManualSalesModal(false)}
         jobData={jobData}
         properties={properties}
-        onSaved={() => loadManualSales()}
+        onSaved={() => {
+          // Full refresh: properties were updated in DB, need to reload them
+          onUpdateJobCache?.(jobData?.id, { forceRefresh: true });
+        }}
       />
 
       {/* Import Block/Lot/Qual Modal */}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -8,6 +8,7 @@ import VacantLandAppraisalTab from './VacantLandAppraisalTab';
 import AppellantEvidencePanel from './AppellantEvidencePanel';
 import ManageResultSetsTab from './ManageResultSetsTab';
 import ScanMaskedSalesModal from './ScanMaskedSalesModal';
+import ManualSalesModal from './ManualSalesModal';
 import { distanceMiles } from '../../AppealMap';
 
 const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {}, onUpdateJobCache, isJobContainerLoading = false, tenantConfig = null, initialManualSubject = null, onManualSubjectConsumed = null, initialAppealSubjects = null, initialBracket = null }) => {
@@ -16,6 +17,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   const [activeSubTab, setActiveSubTab] = useState('search');
   // Scan Masked Sales modal (BRT only) — Sales Pool surface, tight user window
   const [showMaskedModal, setShowMaskedModal] = useState(false);
+  // Manual Sales modal (Microsystems) — for manually entering historical sales
+  const [showManualSalesModal, setShowManualSalesModal] = useState(false);
   const resultsRef = React.useRef(null);
   const detailedResultsRef = React.useRef(null);
   const [codeDefinitions, setCodeDefinitions] = useState(null);
@@ -408,6 +411,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   // ==================== SALES POOL STATE ====================
   const [salesPoolOverrides, setSalesPoolOverrides] = useState({}); // { compositeKey: true/false }
   const [salesPoolSort, setSalesPoolSort] = useState({ field: 'sales_date', dir: 'desc' });
+  const [manualSalesData, setManualSalesData] = useState([]); // Loaded manual sales (Microsystems)
   const [salesPoolSearch, setSalesPoolSearch] = useState('');
   // Staged filter inputs (not applied until user clicks Filter)
   const [stagedDateStart, setStagedDateStart] = useState(compFilters.salesDateStart);
@@ -698,6 +702,24 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   ];
 
   // ==================== LOAD ADJUSTMENT GRID AND CUSTOM BRACKETS ====================
+  const loadManualSales = async () => {
+    if (!jobData?.id || vendorType !== 'Microsystems') return;
+    try {
+      const { data, error } = await supabase
+        .from('pool_manual_sales')
+        .select('*')
+        .eq('job_id', jobData.id)
+        .order('sales_date', { ascending: false });
+      if (error) throw error;
+      setManualSalesData(data || []);
+      if (data && data.length > 0) {
+        console.log(`✅ Loaded ${data.length} manual sales`);
+      }
+    } catch (error) {
+      console.warn('⚠️ Error loading manual sales:', error.message);
+    }
+  };
+
   useEffect(() => {
     if (jobData?.id) {
       loadAdjustmentGrid();
@@ -707,6 +729,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       loadSavedResultSets();
       loadBracketMappings();
       loadSavedPoolOverrideSets();
+      loadManualSales();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [jobData?.id]);
@@ -1421,7 +1444,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     // stamped by JobContainer's derivation pass; fall back to a heuristic on
     // the (very brief) initial paint where the marker hasn't landed yet.
     const seen = new Set();
-    return properties
+    let candidates = properties
       .map(p => {
         // BRT masked sales: when the current sale is a junk dollar-sale (≤ $100,
         // which the filter below would drop anyway) and the user has unmasked a
@@ -1460,7 +1483,33 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       if (bc <= 10) return false;
       return true;
     });
-  }, [properties]);
+
+    // For Microsystems, add manually-entered sales as synthetic property entries
+    if (vendorType === 'Microsystems' && manualSalesData.length > 0) {
+      manualSalesData.forEach(manual => {
+        const baseKey = `${manual.property_block || ''}-${manual.property_lot || ''}-${manual.property_qualifier || ''}`;
+        if (!seen.has(baseKey)) {
+          candidates.push({
+            property_block: manual.property_block,
+            property_lot: manual.property_lot,
+            property_qualifier: manual.property_qualifier || '',
+            property_composite_key: `${manual.property_block}-${manual.property_lot}-${manual.property_qualifier || ''}`,
+            sales_date: manual.sales_date,
+            sales_price: manual.sales_price,
+            sales_nu: manual.sales_nu || '00',
+            sales_book: manual.sales_book,
+            sales_page: manual.sales_page,
+            _isManualSale: true,
+            _isMainCard: true,
+            asset_building_class: 100, // dummy value to pass filter
+          });
+          seen.add(baseKey);
+        }
+      });
+    }
+
+    return candidates;
+  }, [properties, vendorType, manualSalesData]);
 
   // Compute which sales are included in the pool based on filters + overrides
   const salesPoolEntries = useMemo(() => {
@@ -4079,6 +4128,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                       title="Scan BRT prior sales for masked good sales overwritten by later junk transactions (uses the pool date window)"
                     >
                       Scan Masked Sales
+                    </button>
+                  )}
+                  {vendorType === 'Microsystems' && (
+                    <button
+                      onClick={() => setShowManualSalesModal(true)}
+                      className="px-3 py-1.5 text-sm font-medium bg-amber-100 text-amber-800 rounded hover:bg-amber-200 border border-amber-300"
+                      title="Manually enter historical sales to unmask junk transactions or fill missing data"
+                    >
+                      Add Manual Sale
                     </button>
                   )}
                   <button
@@ -8172,6 +8230,18 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         }}
         surfaceLabel="Sales Pool"
         onSaved={() => { onUpdateJobCache?.(jobData?.id, { forceRefresh: true }); }}
+      />
+
+      {/* Manual Sales Modal — Microsystems unmask feature */}
+      <ManualSalesModal
+        isOpen={showManualSalesModal}
+        onClose={() => setShowManualSalesModal(false)}
+        jobData={jobData}
+        properties={properties}
+        onSaved={() => {
+          loadManualSales();
+          onUpdateJobCache?.(jobData?.id, { forceRefresh: true });
+        }}
       />
 
       {/* Import Block/Lot/Qual Modal */}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -3057,18 +3057,18 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
 
         let topComps = [...pinnedSelected, ...fillerComps];
 
-        // CRITICAL: If a comp has a manual sales override, recalculate adjustmentPercent
-        // so it's based on the overridden sales_price, not the original junk price
+        // CRITICAL: If a comp has a manual sales override, FULLY recalculate all adjustments
+        // based on the overridden sales_price, not the original junk price
         topComps = topComps.map(comp => {
-          if (comp._isManualSale && comp.adjustments && comp.sales_price > 0) {
-            // Recalculate adjustment percent from the total adjustment amount
-            const totalAdj = comp.adjustments.reduce((sum, adj) => sum + (adj.amount || 0), 0);
-            const newAdjPercent = (totalAdj / comp.sales_price) * 100;
-            const newAdjustedPrice = comp.sales_price + totalAdj;
+          if (comp._isManualSale) {
+            // Recalculate all adjustments using the overridden price
+            const recalc = calculateAllAdjustments(subject, comp, subjectMapping?.bracket || null);
             return {
               ...comp,
-              adjustmentPercent: newAdjPercent,
-              adjustedPrice: newAdjustedPrice
+              adjustments: recalc.adjustments,
+              totalAdjustment: recalc.totalAdjustment,
+              adjustedPrice: recalc.adjustedPrice,
+              adjustmentPercent: recalc.adjustmentPercent
             };
           }
           return comp;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1932,12 +1932,26 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     // In separate mode, keep additional cards (A, B, C) separate from the main card.
     // This applies to ALL properties including farms — if cardMode is 'separate',
     // return just the main card with a count of how many additional cards exist.
+    // HOWEVER, for farm properties, we still need to calculate the combined lot acres
+    // for use when farm sales mode is toggled ON.
     if (cardMode === 'separate') {
       // Separate mode: return early with just the main card
-      return {
+      const result = {
         ...prop,
         _additionalCardsCount: allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length,
       };
+
+      // For farm properties in separate mode, calculate and store combined lot acres
+      // so that when farm sales mode is ON, we can use the combined total
+      if (isFarmProperty) {
+        const combinedLotAcre = allCards.reduce((sum, card) => sum + (parseFloat(card.asset_lot_acre) || 0), 0);
+        if (combinedLotAcre > 0) {
+          result._combinedLotAcre = combinedLotAcre;
+          console.log(`🌾 Farm property (separate mode): main card acre=${result.asset_lot_acre}, combined=${combinedLotAcre}`);
+        }
+      }
+
+      return result;
     }
 
     const aggregated = { ...prop };

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1438,6 +1438,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   // ==================== SALES POOL (ALL CANDIDATE SALES) ====================
   // Get all properties that have sales data (before date/code filtering)
   const allSalesCandidates = useMemo(() => {
+    // Build a map of manual sales for quick lookup (Microsystems only)
+    const manualSalesMap = {};
+    if (vendorType === 'Microsystems' && manualSalesData.length > 0) {
+      manualSalesData.forEach(manual => {
+        const baseKey = `${manual.property_block || ''}-${manual.property_lot || ''}-${manual.property_qualifier || ''}`;
+        manualSalesMap[baseKey] = manual;
+      });
+    }
+
     // Dedupe to main card per parcel. We used to keep "first seen", which
     // depended on load order and could silently land on an additional card —
     // throwing off SFLA, $/SF, and the size-range filter. _isMainCard is
@@ -1446,6 +1455,22 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     const seen = new Set();
     let candidates = properties
       .map(p => {
+        const baseKey = `${p.property_block || ''}-${p.property_lot || ''}-${p.property_qualifier || ''}`;
+        const manualSale = manualSalesMap[baseKey];
+
+        // If a manual sale exists for this property, override the sales data
+        if (manualSale) {
+          return {
+            ...p,
+            sales_price: manualSale.sales_price,
+            sales_date: manualSale.sales_date,
+            sales_nu: manualSale.sales_nu || null,
+            sales_book: manualSale.sales_book,
+            sales_page: manualSale.sales_page,
+            _isManualSale: true,
+          };
+        }
+
         // BRT masked sales: when the current sale is a junk dollar-sale (≤ $100,
         // which the filter below would drop anyway) and the user has unmasked a
         // healthy prior, swap that prior in as the parcel's effective pool sale.
@@ -1484,7 +1509,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       return true;
     });
 
-    // For Microsystems, add manually-entered sales as synthetic property entries
+    // For Microsystems, add orphan manual sales (ones with no matching property record) as synthetic entries
     if (vendorType === 'Microsystems' && manualSalesData.length > 0) {
       manualSalesData.forEach(manual => {
         const baseKey = `${manual.property_block || ''}-${manual.property_lot || ''}-${manual.property_qualifier || ''}`;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -8312,38 +8312,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         onClose={() => setShowManualSalesModal(false)}
         jobData={jobData}
         properties={properties}
-        onSaved={async (savedSales) => {
-          // Reload only the affected properties from the DB (not a full refresh)
-          // This is efficient even with 20k records since we're only fetching a few
-          if (savedSales && savedSales.length > 0) {
-            try {
-              const { supabase } = await import('../../../lib/supabaseClient');
-              const { data: updatedProps } = await supabase
-                .from('property_records')
-                .select('*')
-                .eq('job_id', jobData.id)
-                .in('property_composite_key',
-                  savedSales.map(s => `${s.property_block}-${s.property_lot}-${s.property_qualifier || ''}`)
-                );
-
-              if (updatedProps && updatedProps.length > 0) {
-                // Update the properties array with the fresh data
-                setProperties((prev) => {
-                  const updated = [...prev];
-                  updatedProps.forEach(newProp => {
-                    const idx = updated.findIndex(p => p.property_composite_key === newProp.property_composite_key);
-                    if (idx >= 0) {
-                      updated[idx] = newProp;
-                    }
-                  });
-                  return updated;
-                });
-                console.log(`✅ Reloaded ${updatedProps.length} updated properties from DB`);
-              }
-            } catch (err) {
-              console.warn('Could not reload updated properties:', err);
-            }
-          }
+        onSaved={() => {
+          // Override is saved to DB. User will manually refresh if needed.
+          console.log('✅ Manual sales override saved to database');
         }}
       />
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -2165,6 +2165,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         setEvaluationResults(updatedResults);
         console.log(`✅ Updated result row ${editingResultIndex} in Search and Results tab`);
 
+        // Clear editingResultIndex so the next Evaluate-and-Update works on a fresh slate
+        // and doesn't overwrite the same row again
+        setEditingResultIndex(null);
+
         // Auto-persist back to the loaded saved set so the user doesn't have
         // to switch tabs and re-save. Only fires when an active set is loaded
         // (set in handleLoadResultSet / handleSaveResultSet). The plain

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -8312,9 +8312,38 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         onClose={() => setShowManualSalesModal(false)}
         jobData={jobData}
         properties={properties}
-        onSaved={() => {
-          // Full refresh: properties were updated in DB, need to reload them
-          onUpdateJobCache?.(jobData?.id, { forceRefresh: true });
+        onSaved={async (savedSales) => {
+          // Reload only the affected properties from the DB (not a full refresh)
+          // This is efficient even with 20k records since we're only fetching a few
+          if (savedSales && savedSales.length > 0) {
+            try {
+              const { supabase } = await import('../../../lib/supabaseClient');
+              const { data: updatedProps } = await supabase
+                .from('property_records')
+                .select('*')
+                .eq('job_id', jobData.id)
+                .in('property_composite_key',
+                  savedSales.map(s => `${s.property_block}-${s.property_lot}-${s.property_qualifier || ''}`)
+                );
+
+              if (updatedProps && updatedProps.length > 0) {
+                // Update the properties array with the fresh data
+                setProperties((prev) => {
+                  const updated = [...prev];
+                  updatedProps.forEach(newProp => {
+                    const idx = updated.findIndex(p => p.property_composite_key === newProp.property_composite_key);
+                    if (idx >= 0) {
+                      updated[idx] = newProp;
+                    }
+                  });
+                  return updated;
+                });
+                console.log(`✅ Reloaded ${updatedProps.length} updated properties from DB`);
+              }
+            } catch (err) {
+              console.warn('Could not reload updated properties:', err);
+            }
+          }
         }}
       />
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1455,10 +1455,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     const seen = new Set();
     let candidates = properties
       .map(p => {
+        // FIRST: Apply manual sales override (Microsystems) BEFORE any junk-sale checks
         const baseKey = `${p.property_block || ''}-${p.property_lot || ''}-${p.property_qualifier || ''}`;
         const manualSale = manualSalesMap[baseKey];
-
-        // If a manual sale exists for this property, override the sales data
         if (manualSale) {
           return {
             ...p,
@@ -1471,6 +1470,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           };
         }
 
+        // SECOND: Apply BRT masked sales unmask (only if no manual override)
         // BRT masked sales: when the current sale is a junk dollar-sale (≤ $100,
         // which the filter below would drop anyway) and the user has unmasked a
         // healthy prior, swap that prior in as the parcel's effective pool sale.

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -2491,10 +2491,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           const baseKey = `${manual.property_block || ''}-${manual.property_lot || ''}-${manual.property_qualifier || ''}`;
           manualSalesMap[baseKey] = manual;
         });
+        const beforeCount = eligibleSales.length;
         eligibleSales = eligibleSales.map(sale => {
           const baseKey = `${sale.property_block || ''}-${sale.property_lot || ''}-${sale.property_qualifier || ''}`;
           const override = manualSalesMap[baseKey];
           if (override) {
+            console.log(`✅ Applying override to ${baseKey}: ${sale.sales_price} → ${override.sales_price}`);
             return {
               ...sale,
               sales_price: override.sales_price,
@@ -2507,6 +2509,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           }
           return sale;
         });
+        console.log(`📊 Applied ${manualSalesData.length} manual sales overrides to ${beforeCount} eligible sales`);
       }
 
       console.log(`📊 Found ${eligibleSales.length} eligible sales from Sales Pool`);
@@ -3063,8 +3066,10 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           if (comp._isManualSale) {
             // Recalculate all adjustments using the overridden price
             const recalc = calculateAllAdjustments(subject, comp, subjectMapping?.bracket || null);
+            console.log(`🔧 Recalculating adjustments for overridden comp ${comp.property_block}/${comp.property_lot}: sales_price=${comp.sales_price}, condition_adj=${recalc.adjustments.find(a => a.name.includes('Condition'))?.amount || 0}`);
             return {
               ...comp,
+              _isManualSale: true,  // Preserve flag for downstream use
               adjustments: recalc.adjustments,
               totalAdjustment: recalc.totalAdjustment,
               adjustedPrice: recalc.adjustedPrice,

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -6612,6 +6612,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                   marketLandData={marketLandData}
                   tenantConfig={tenantConfig}
                   activeResultSetId={activeResultSetId}
+                  manualSalesOverrides={manualSalesData}
                   onSentToAppealLog={async (subject) => {
                     // Rich's "did I do this one yet?" tracer. When the user
                     // successfully sends a Detailed snapshot to Appeal Log,

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -8263,10 +8263,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         onClose={() => setShowManualSalesModal(false)}
         jobData={jobData}
         properties={properties}
-        onSaved={() => {
-          loadManualSales();
-          onUpdateJobCache?.(jobData?.id, { forceRefresh: true });
-        }}
+        onSaved={() => loadManualSales()}
       />
 
       {/* Import Block/Lot/Qual Modal */}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -6586,6 +6586,15 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
                     //     job_cme_result_sets.
                     handleManualEvaluate(true);
                   }}
+                  onGeocodeSaved={(compositeKey, patch) => {
+                    // Patch the in-memory properties array so coordinates persist
+                    // when navigating between properties. The DB has already been
+                    // updated by GeocodeStatusChip.
+                    const target = properties.find(p => p.property_composite_key === compositeKey);
+                    if (target) {
+                      Object.assign(target, patch);
+                    }
+                  }}
                 />
               </div>
             )}

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1929,12 +1929,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       }
     }
 
-    // In separate mode, dont combine additional cards A, B, C with the main card.
-    // HOWEVER, we ALWAYS combine farm properties (7/4 base 3A + 7/4/QFARM variant 3B) regardless of mode.
-    // This is because 3A (farmhouse) and 3B (farmland) are different parcel types, not just "additional cards".
-
-    if (cardMode === 'separate' && !isFarmProperty) {
-      // Not a farm property and cardMode is separate: return early with just the main card
+    // In separate mode, keep additional cards (A, B, C) separate from the main card.
+    // This applies to ALL properties including farms — if cardMode is 'separate',
+    // return just the main card with a count of how many additional cards exist.
+    if (cardMode === 'separate') {
+      // Separate mode: return early with just the main card
       return {
         ...prop,
         _additionalCardsCount: allCards.filter(p => !isMainCard(p.property_addl_card || p.additional_card)).length,

--- a/src/lib/data-pipeline/brt-processor.js
+++ b/src/lib/data-pipeline/brt-processor.js
@@ -1059,8 +1059,11 @@ export class BRTProcessor {
       // Update jobs table with property totals AFTER successful processing
       if (results.processed > 0) {
         await this.updateJobTotals(jobId, totalresidential, totalcommercial);
+
+        // Calculate farm_combined_lot_acre for 3A properties with matching 3B variants
+        await this.calculateFarmCombinedAcreage(jobId);
       }
-      
+
       console.log('🚀 ENHANCED BRT PROCESSING COMPLETE WITH ALL SECTIONS:', results);
       return results;
       
@@ -1613,6 +1616,65 @@ export class BRTProcessor {
       }
     }
     return totalArea > 0 ? Math.round(totalArea) : null;
+  }
+
+  /**
+   * Calculate farm_combined_lot_acre for 3A properties with matching 3B variants.
+   * This is called after all properties are inserted so we can look for matching
+   * block/lot pairs and sum their acreage together.
+   */
+  async calculateFarmCombinedAcreage(jobId) {
+    try {
+      console.log('🌾 Calculating farm_combined_lot_acre for 3A properties...');
+
+      // Find all 3A properties and look for matching 3B variants
+      const { data: farm3aProperties, error: fetchError } = await supabase
+        .from('property_records')
+        .select('id, property_block, property_lot, property_m4_class, asset_lot_acre')
+        .eq('job_id', jobId)
+        .eq('property_m4_class', '3A');
+
+      if (fetchError) throw fetchError;
+
+      if (!farm3aProperties || farm3aProperties.length === 0) {
+        console.log('  No 3A properties found, skipping farm calculation');
+        return;
+      }
+
+      // For each 3A, find matching 3B and sum their acres
+      let updatedCount = 0;
+      for (const prop3a of farm3aProperties) {
+        // Find all properties with same block/lot that are 3A or 3B
+        const { data: farmPairs, error: pairError } = await supabase
+          .from('property_records')
+          .select('asset_lot_acre')
+          .eq('job_id', jobId)
+          .eq('property_block', prop3a.property_block)
+          .eq('property_lot', prop3a.property_lot)
+          .in('property_m4_class', ['3A', '3B']);
+
+        if (!pairError && farmPairs && farmPairs.length > 0) {
+          const combinedAcre = farmPairs.reduce((sum, p) => sum + (parseFloat(p.asset_lot_acre) || 0), 0);
+
+          if (combinedAcre > 0) {
+            const { error: updateError } = await supabase
+              .from('property_records')
+              .update({ farm_combined_lot_acre: combinedAcre })
+              .eq('id', prop3a.id);
+
+            if (!updateError) {
+              updatedCount++;
+              console.log(`  ✅ Block ${prop3a.property_block}/Lot ${prop3a.property_lot}: ${combinedAcre} acres`);
+            }
+          }
+        }
+      }
+
+      console.log(`🌾 Farm acreage calculation complete: updated ${updatedCount} properties`);
+    } catch (error) {
+      console.error('⚠️ Error calculating farm combined acreage:', error);
+      // Non-critical error - don't fail the whole upload
+    }
   }
 
 

--- a/src/lib/data-pipeline/microsystems-processor.js
+++ b/src/lib/data-pipeline/microsystems-processor.js
@@ -874,8 +874,11 @@ export class MicrosystemsProcessor {
       // Update jobs table with property totals AFTER successful processing
       if (results.processed > 0) {
         await this.updateJobTotals(jobId, totalresidential, totalcommercial);
+
+        // Calculate farm_combined_lot_acre for 3A properties with matching 3B variants
+        await this.calculateFarmCombinedAcreage(jobId);
       }
-      
+
       console.log('🚀 Enhanced Microsystems processing complete:', results);
       return results;
       
@@ -1475,6 +1478,65 @@ export class MicrosystemsProcessor {
     }
     
     return result;
+  }
+
+  /**
+   * Calculate farm_combined_lot_acre for 3A properties with matching 3B variants.
+   * This is called after all properties are inserted so we can look for matching
+   * block/lot pairs and sum their acreage together.
+   */
+  async calculateFarmCombinedAcreage(jobId) {
+    try {
+      console.log('🌾 Calculating farm_combined_lot_acre for 3A properties...');
+
+      // Find all 3A properties and look for matching 3B variants
+      const { data: farm3aProperties, error: fetchError } = await supabase
+        .from('property_records')
+        .select('id, property_block, property_lot, property_m4_class, asset_lot_acre')
+        .eq('job_id', jobId)
+        .eq('property_m4_class', '3A');
+
+      if (fetchError) throw fetchError;
+
+      if (!farm3aProperties || farm3aProperties.length === 0) {
+        console.log('  No 3A properties found, skipping farm calculation');
+        return;
+      }
+
+      // For each 3A, find matching 3B and sum their acres
+      let updatedCount = 0;
+      for (const prop3a of farm3aProperties) {
+        // Find all properties with same block/lot that are 3A or 3B
+        const { data: farmPairs, error: pairError } = await supabase
+          .from('property_records')
+          .select('asset_lot_acre')
+          .eq('job_id', jobId)
+          .eq('property_block', prop3a.property_block)
+          .eq('property_lot', prop3a.property_lot)
+          .in('property_m4_class', ['3A', '3B']);
+
+        if (!pairError && farmPairs && farmPairs.length > 0) {
+          const combinedAcre = farmPairs.reduce((sum, p) => sum + (parseFloat(p.asset_lot_acre) || 0), 0);
+
+          if (combinedAcre > 0) {
+            const { error: updateError } = await supabase
+              .from('property_records')
+              .update({ farm_combined_lot_acre: combinedAcre })
+              .eq('id', prop3a.id);
+
+            if (!updateError) {
+              updatedCount++;
+              console.log(`  ✅ Block ${prop3a.property_block}/Lot ${prop3a.property_lot}: ${combinedAcre} acres`);
+            }
+          }
+        }
+      }
+
+      console.log(`🌾 Farm acreage calculation complete: updated ${updatedCount} properties`);
+    } catch (error) {
+      console.error('⚠️ Error calculating farm combined acreage:', error);
+      // Non-critical error - don't fail the whole upload
+    }
   }
 }
 

--- a/src/lib/localPhotoSource.js
+++ b/src/lib/localPhotoSource.js
@@ -321,6 +321,21 @@ export async function indexSourcesForCcdd(ccdd, opts = {}) {
 /** Convenience: read the bytes of a single matched photo. */
 export async function readPhoto(match) {
   if (match?.file) return match.file; // session-source already holds the File
+
+  // If this is a DB-stored photo, fetch it from Supabase storage
+  if (match?.storageKey && match?.source === 'db_storage') {
+    try {
+      const { supabase } = await import('./supabaseClient.js');
+      const { data, error } = await supabase.storage
+        .from('appeal-photos')
+        .download(match.storageKey);
+      if (error) throw error;
+      return data; // This is already a Blob/File
+    } catch (e) {
+      throw new Error(`Failed to load photo from storage: ${e?.message}`);
+    }
+  }
+
   if (!match?.fileHandle) throw new Error('No file handle on match.');
   const file = await match.fileHandle.getFile();
   return file;

--- a/supabase/migrations/add_farm_combined_lot_acre.sql
+++ b/supabase/migrations/add_farm_combined_lot_acre.sql
@@ -1,0 +1,48 @@
+-- Add farm_combined_lot_acre field to track combined 3A+3B acreage
+ALTER TABLE property_records 
+ADD COLUMN IF NOT EXISTS farm_combined_lot_acre numeric;
+
+-- Create a helper function to calculate farm combined acreage
+-- This scans for 3A properties and finds matching 3B properties
+-- to sum their lot acres together
+CREATE OR REPLACE FUNCTION calculate_farm_combined_acres(
+  p_job_id uuid,
+  p_block text,
+  p_lot text
+)
+RETURNS numeric AS $$
+DECLARE
+  v_acre_sum numeric := 0;
+BEGIN
+  -- Sum asset_lot_acre for all properties (3A + 3B variants) with same block/lot
+  SELECT COALESCE(SUM(asset_lot_acre), 0)
+  INTO v_acre_sum
+  FROM property_records
+  WHERE job_id = p_job_id
+    AND property_block = p_block
+    AND property_lot = p_lot
+    AND property_m4_class IN ('3A', '3B');
+  
+  RETURN v_acre_sum;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Backfill farm_combined_lot_acre for Lower Alloways Creek (CCDD 1008)
+-- This finds all 3A properties and calculates their combined 3A+3B acreage
+UPDATE property_records pr
+SET farm_combined_lot_acre = calculate_farm_combined_acres(pr.job_id, pr.property_block, pr.property_lot)
+WHERE pr.job_id IN (
+  SELECT id FROM jobs 
+  WHERE ccdd_code = '1008'  -- Lower Alloways Creek
+)
+AND pr.property_m4_class = '3A'
+AND pr.farm_combined_lot_acre IS NULL;
+
+-- Log the backfill results
+SELECT 
+  COUNT(*) as updated_count,
+  AVG(farm_combined_lot_acre) as avg_farm_acres,
+  MAX(farm_combined_lot_acre) as max_farm_acres
+FROM property_records
+WHERE farm_combined_lot_acre IS NOT NULL
+AND job_id IN (SELECT id FROM jobs WHERE ccdd_code = '1008');

--- a/supabase/migrations/add_pool_manual_sales.sql
+++ b/supabase/migrations/add_pool_manual_sales.sql
@@ -1,0 +1,30 @@
+-- Create pool_manual_sales table for manually-entered historical sales (Microsystems)
+CREATE TABLE IF NOT EXISTS pool_manual_sales (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  property_block text NOT NULL,
+  property_lot text NOT NULL,
+  property_qualifier text DEFAULT '',
+  sales_date date NOT NULL,
+  sales_price numeric NOT NULL,
+  sales_nu text,
+  sales_book text,
+  sales_page text,
+  created_at timestamptz DEFAULT now(),
+  created_by uuid,
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_pool_manual_sales_job_id ON pool_manual_sales(job_id);
+CREATE INDEX idx_pool_manual_sales_block_lot ON pool_manual_sales(job_id, property_block, property_lot, property_qualifier);
+
+COMMENT ON TABLE pool_manual_sales IS 'Manually entered historical sales for Microsystems jobs (no historical data in source). Used to unmask/override junk sales in the pool.';
+COMMENT ON COLUMN pool_manual_sales.job_id IS 'Reference to the job';
+COMMENT ON COLUMN pool_manual_sales.property_block IS 'Property block';
+COMMENT ON COLUMN pool_manual_sales.property_lot IS 'Property lot';
+COMMENT ON COLUMN pool_manual_sales.property_qualifier IS 'Property qualifier (optional)';
+COMMENT ON COLUMN pool_manual_sales.sales_date IS 'Date of the sale';
+COMMENT ON COLUMN pool_manual_sales.sales_price IS 'Sale price';
+COMMENT ON COLUMN pool_manual_sales.sales_nu IS 'Sales Nature & Use code (optional)';
+COMMENT ON COLUMN pool_manual_sales.sales_book IS 'Deed book (optional)';
+COMMENT ON COLUMN pool_manual_sales.sales_page IS 'Deed page (optional)';


### PR DESCRIPTION
### Summary
Introduces a `farm_combined_lot_acre` database field to correctly calculate combined 3A+3B farm acreage for Microsystems jobs, and adds a `pool_manual_sales` table to support manually entered historical sales overrides when no source data exists.

### Problem
Farm properties (class 3A with associated 3B farmland cards) were incorrectly displaying lot size in the Detailed component when Farm Sales Mode was enabled. Because Microsystems source files don't include historical sales data, there was also no way to unmask or override junk/nominal sales (e.g., $1 deed transfers) in the sales pool the way BRT jobs support.

### Solution
- A new `farm_combined_lot_acre` column is pre-calculated at file upload time by summing `asset_lot_acre` across all 3A and 3B cards sharing the same block/lot. The Detailed component reads this value directly when Farm Sales Mode is on, bypassing the incorrect per-card acreage.
- A new `pool_manual_sales` table allows users to manually enter a known sale (date, price, NU code, deed book/page) linked to a specific job and property, providing a persistent override for Microsystems jobs.

### Key Changes
- **`supabase/migrations/add_farm_combined_lot_acre.sql`** — Adds `farm_combined_lot_acre` column to `property_records`, a helper SQL function `calculate_farm_combined_acres()`, and a backfill for Lower Alloways Creek (CCDD 1008).
- **`supabase/migrations/add_pool_manual_sales.sql`** — Creates the `pool_manual_sales` table with indexes and comments for manual sale overrides in Microsystems jobs.
- **`src/lib/data-pipeline/microsystems-processor.js`** — Calls `calculateFarmCombinedAcreage()` after successful property processing to populate `farm_combined_lot_acre` for all 3A properties in the job.
- **`src/components/job-modules/JobContainer.jsx`** — Updates lot SF enrichment logic to read from `farm_combined_lot_acre` when `hasFarm` is true, falling back to summing individual cards if the field is absent.
- **`src/components/job-modules/ParcelPhotoStrip.jsx`** — Mirrors the farm acreage calculation logic for use during photo upload workflows.
- **`src/lib/localPhotoSource.js`** — Adds support for fetching DB-stored photos from Supabase storage by `storageKey` when `source === 'db_storage'`.
- **`package.json` / `package-lock.json`** — Adds `pg` v8.21.0 as a dependency.

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/polygon-channel-anhmv6l3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-polygon-channel-anhmv6l3_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 223`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>polygon-channel-anhmv6l3</branchName>-->