### PR TITLE
Fix lot size adjustment fallback in farm sales mode

### DIFF
--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -3459,9 +3459,9 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         // Farm properties: use farm_combined_lot_acre when farm sales mode is ON
         // Otherwise use the individual card's asset_lot_acre
         if (compFilters?.farmSalesMode) {
-          // Farm mode ON: use the pre-calculated combined 3A+3B acreage
-          subjectValue = subject.farm_combined_lot_acre || subject.asset_lot_acre || 0;
-          compValue = comp.farm_combined_lot_acre || comp.asset_lot_acre || 0;
+          // Farm mode ON: use the pre-calculated combined 3A+3B acreage, fall back to market_manual_lot_acre if not available
+          subjectValue = subject.farm_combined_lot_acre || subject.market_manual_lot_acre || subject.asset_lot_acre || 0;
+          compValue = comp.farm_combined_lot_acre || comp.market_manual_lot_acre || comp.asset_lot_acre || 0;
         } else {
           // Farm mode OFF: use the individual card's acreage only
           subjectValue = subject.market_manual_lot_acre || subject.asset_lot_acre || 0;

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -984,6 +984,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       // re-running Evaluate after a reload silently falls back to whole-town.
       const searchCriteriaPayload = {
         ...compFilters,
+        farmSalesMode: false,
         subject_selection: {
           manualProperties,
           subjectVCS,


### PR DESCRIPTION
### Summary
This PR fixes a silent lot size adjustment failure in farm sales mode by adding a `market_manual_lot_acre` fallback and defaulting `farmSalesMode` to `false` on new evaluations.

### Problem
Lot size adjustments were silently disappearing when farm sales mode was toggled ON. This was most visible in BRT jobs (e.g., Franklin, Kingwood) where lot sizes are stored in `market_manual_lot_acre` rather than `asset_lot_acre`. When farm sales mode was ON, the code only checked `farm_combined_lot_acre` and `asset_lot_acre`, skipping the manually calculated lot size entirely — resulting in no adjustment being applied.

### Solution
Two targeted fixes were applied in `SalesComparisonTab.jsx`:
1. Added `market_manual_lot_acre` as an intermediate fallback in the farm sales mode acreage lookup chain.
2. Explicitly set `farmSalesMode: false` in the search criteria payload so new evaluations default to farm sales mode OFF.

### Key Changes
- **Fallback chain updated**: When farm sales mode is ON, acreage resolution now follows `farm_combined_lot_acre → market_manual_lot_acre → asset_lot_acre` for both subject and comp properties, ensuring BRT jobs with manually calculated lot sizes are handled correctly.
- **Default `farmSalesMode: false`**: Added `farmSalesMode: false` to the `searchCriteriaPayload` so that any new or re-run evaluation defaults to farm sales mode OFF, preventing unintended lot size behavior for users who never explicitly toggled the setting.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/platinum-puzzle-dgnmppih"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-platinum-puzzle-dgnmppih_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 226`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>platinum-puzzle-dgnmppih</branchName>-->