### PR TITLE
Fix farm sales mode default and inactive employee filter

### DIFF
--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -922,12 +922,14 @@ const JobContainer = ({
         // Only load employees when ProductionTracker is enabled (PPA jobs)
         // Filter by the job's organization to prevent LOJIK clients appearing as inspectors
         // Also exclude Admin role — admins are not inspectors
+        // Exclude inactive employees — only active/full_time/part_time/contractor allowed
         try {
           let empQuery = supabase
             .from('employees')
             .select('*')
             .eq('organization_id', jobOrgId || PPA_ORG_ID)
             .not('role', 'eq', 'Admin')
+            .in('employment_status', ['active', 'full_time', 'part_time', 'contractor'])
             .order('last_name', { ascending: true });
 
           const { data, error } = await withTimeout(

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -102,7 +102,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
     individualAdjPct: 0,
     netAdjPct: 0,
     grossAdjPct: 0,
-    farmSalesMode: true // When enabled, farm subjects only compare to farm comps and use combined 3A+3B lot size
+    farmSalesMode: false // When enabled, farm subjects only compare to farm comps and use combined 3A+3B lot size
   });
   
   // ==================== EVALUATION STATE ====================

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -984,7 +984,6 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
       // re-running Evaluate after a reload silently falls back to whole-town.
       const searchCriteriaPayload = {
         ...compFilters,
-        farmSalesMode: false,
         subject_selection: {
           manualProperties,
           subjectVCS,


### PR DESCRIPTION
### Summary
This PR fixes two bugs: the farm sales mode toggle now defaults to OFF on initial load in the Sales Comparison tab, and the Production Tracker employee list now excludes inactive employees.

### Problem
1. **Farm Sales Mode**: On initial load into the Sales Comparison tab, the `farmSalesMode` filter was defaulting to `true` (checked/enabled), when the expected behavior is for it to start unchecked (disabled).
2. **Inactive Employee Initials**: The Production Tracker was including employees with inactive employment statuses (e.g., an inactive employee sharing initials with a new hire), which could cause inspection data to be attributed to the wrong person or an invalid employee.

### Solution
- Changed the `farmSalesMode` default state value from `true` to `false` so the toggle is unchecked on initial load.
- Removed a redundant `farmSalesMode: false` override in the search criteria payload that was masking the saved toggle state.
- Added an `.in('employment_status', [...])` filter to the Supabase employee query so only active, full-time, part-time, or contractor employees are returned.

### Key Changes
- **`SalesComparisonTab.jsx`**: Changed `farmSalesMode` initial state default from `true` → `false`; removed the hardcoded `farmSalesMode: false` override in the search criteria payload so saved toggle values are respected correctly.
- **`JobContainer.jsx`**: Added `.in('employment_status', ['active', 'full_time', 'part_time', 'contractor'])` to the employee query, ensuring inactive employees are never surfaced as valid inspectors in the Production Tracker.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/semi-component-d1i1o5di"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-semi-component-d1i1o5di_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 228`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>semi-component-d1i1o5di</branchName>-->