### PR TITLE
Add open invoices Excel export and remove employment status filter

### DIFF
--- a/src/components/BillingManagement.jsx
+++ b/src/components/BillingManagement.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { supabase, parseDateLocal, formatDateLocalYMD } from '../lib/supabaseClient';
-import * as XLSX from 'xlsx';
+import * as XLSX from 'xlsx-js-style';
 
 // Development logging wrapper
 const isDevelopment = process.env.NODE_ENV === 'development';
@@ -1494,6 +1494,80 @@ const calculateDistributionMetrics = async () => {
       setShowOpenInvoices(true);
     } catch (error) {
       console.error('Error loading open invoices:', error);
+    }
+  };
+
+  const exportOpenInvoicesToExcel = () => {
+    try {
+      const wb = XLSX.utils.book_new();
+
+      // Prepare data for export
+      const exportData = getSortedInvoices().map(invoice => ({
+        'Municipality': invoice.job_name,
+        'Invoice #': invoice.invoice_number,
+        'Date': new Date(invoice.billing_date).toLocaleDateString(),
+        'Open Balance': parseFloat(invoice.amount_billed),
+        'Age (Days)': calculateInvoiceAge(invoice.billing_date)
+      }));
+
+      // Create worksheet from data
+      const ws = XLSX.utils.json_to_sheet(exportData);
+
+      // Apply styling (matching ProductionTracker style)
+      const range = XLSX.utils.decode_range(ws['!ref']);
+
+      // Style header row (row 0)
+      for (let C = range.s.c; C <= range.e.c; ++C) {
+        const cellAddress = XLSX.utils.encode_cell({ r: 0, c: C });
+        if (!ws[cellAddress]) continue;
+
+        ws[cellAddress].s = {
+          font: { name: 'Leelawadee', sz: 10, bold: true },
+          alignment: { horizontal: 'center', vertical: 'center' },
+          fill: { fgColor: { rgb: 'FFE8E8E8' } }
+        };
+      }
+
+      // Style data rows with alternating colors
+      for (let R = range.s.r + 1; R <= range.e.r; ++R) {
+        for (let C = range.s.c; C <= range.e.c; ++C) {
+          const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
+          if (!ws[cellAddress]) continue;
+
+          // Currency formatting for Open Balance column (column 3)
+          const isCurrencyColumn = C === 3;
+          const isAgeColumn = C === 4;
+
+          ws[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10 },
+            alignment: { horizontal: isCurrencyColumn || isAgeColumn ? 'right' : 'left', vertical: 'center' },
+            fill: { fgColor: { rgb: R % 2 === 0 ? 'FFFFFFFF' : 'FFFAFAFA' } }
+          };
+
+          // Apply number format for currency
+          if (isCurrencyColumn) {
+            ws[cellAddress].z = '$#,##0.00';
+          }
+        }
+      }
+
+      // Set column widths
+      ws['!cols'] = [
+        { wch: 30 }, // Municipality
+        { wch: 15 }, // Invoice #
+        { wch: 12 }, // Date
+        { wch: 15 }, // Open Balance
+        { wch: 12 }  // Age
+      ];
+
+      XLSX.utils.book_append_sheet(wb, ws, 'Open Invoices');
+
+      // Generate filename with timestamp
+      const timestamp = new Date().toISOString().split('T')[0];
+      XLSX.writeFile(wb, `Open_Invoices_${timestamp}.xlsx`);
+    } catch (error) {
+      console.error('Error exporting invoices:', error);
+      alert('Failed to export invoices');
     }
   };
 
@@ -4260,6 +4334,16 @@ const calculateDistributionMetrics = async () => {
                 <span className="text-lg font-medium text-orange-600">
                   Total: {formatCurrency(allOpenInvoices.reduce((sum, inv) => sum + parseFloat(inv.amount_billed), 0))}
                 </span>
+                <button
+                  onClick={exportOpenInvoicesToExcel}
+                  className="px-3 py-1 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 transition-colors"
+                  title="Export to Excel"
+                >
+                  <svg className="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 16v-4m0 0V8m0 4h4m-4 0H8" />
+                  </svg>
+                  Export
+                </button>
                 <button
                   onClick={() => setShowOpenInvoices(false)}
                   className="text-gray-500 hover:text-gray-700"

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -922,14 +922,12 @@ const JobContainer = ({
         // Only load employees when ProductionTracker is enabled (PPA jobs)
         // Filter by the job's organization to prevent LOJIK clients appearing as inspectors
         // Also exclude Admin role — admins are not inspectors
-        // Exclude inactive employees — only active/full_time/part_time/contractor allowed
         try {
           let empQuery = supabase
             .from('employees')
             .select('*')
             .eq('organization_id', jobOrgId || PPA_ORG_ID)
             .not('role', 'eq', 'Admin')
-            .in('employment_status', ['active', 'full_time', 'part_time', 'contractor'])
             .order('last_name', { ascending: true });
 
           const { data, error } = await withTimeout(


### PR DESCRIPTION
### Summary
Adds an Excel export button to the All Open Invoices modal in Billing Management, and removes the employment status filter from the Production Tracker inspector query to prevent valid historical inspections from being excluded.

### Problem
Two issues were identified:
1. The Billing component lacked a way to export open invoices to Excel for reporting purposes.
2. A recently added employment status filter in Production Tracker was incorrectly excluding inspectors who were active during a job's inspection window but have since become inactive — causing thousands of properties to appear as missing in jobs like Point Pleasant Beach.

### Solution
- Added a styled Excel export function (`exportOpenInvoicesToExcel`) to the Billing component, consistent with existing export patterns across the app.
- Removed the `.in('employment_status', ...)` filter from the employee query in `JobContainer` so that all non-admin employees tied to the job's organization are considered valid inspectors, regardless of current employment status.

### Key Changes
- **`BillingManagement.jsx`**: Switched from `xlsx` to `xlsx-js-style` to support cell styling; added `exportOpenInvoicesToExcel` function with Leelawadee font, alternating row colors, currency formatting, and auto column widths; added a green "Export" button beneath the All Open Invoices modal header.
- **`JobContainer.jsx`**: Removed `.in('employment_status', ['active', 'full_time', 'part_time', 'contractor'])` filter from the inspector employee query, restoring correct behavior for multi-month/multi-year jobs where inspector employment status may have changed after inspections were completed.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/lace-registry-f1betddx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-lace-registry-f1betddx_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 229`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>lace-registry-f1betddx</branchName>-->