### PR TITLE
Add appeal badges, fix SFLA recalc, and restrict View As

### DIFF
--- a/src/components/AdminJobManagement.jsx
+++ b/src/components/AdminJobManagement.jsx
@@ -2728,6 +2728,24 @@ const AdminJobManagement = ({
                                   <div className="text-xs text-orange-600 font-medium">📁 New file data available</div>
                                 )}
                               </div>
+
+                              {/* Appeal Workflow Badges */}
+                              {(job.workflow_stats?.checklist_second_attempts_complete || job.workflow_stats?.checklist_third_attempts_complete) && (
+                                <div className="flex items-center justify-between mb-2 px-3">
+                                  <div className="flex items-center space-x-3">
+                                    {job.workflow_stats?.checklist_second_attempts_complete && (
+                                      <div className="flex items-center space-x-1 px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                        <span>✓ 2nd Attempts</span>
+                                      </div>
+                                    )}
+                                    {job.workflow_stats?.checklist_third_attempts_complete && (
+                                      <div className="flex items-center space-x-1 px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                        <span>✓ 3rd Attempts</span>
+                                      </div>
+                                    )}
+                                  </div>
+                                </div>
+                              )}
                             </>
                           ) : (
                             <>

--- a/src/components/UserManagement.jsx
+++ b/src/components/UserManagement.jsx
@@ -13,6 +13,9 @@ const UserManagement = ({ onViewAs }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(null);
   const [selectedUser, setSelectedUser] = useState(null);
   const [employeeOrgLinks, setEmployeeOrgLinks] = useState({});
+
+  const PRIMARY_OWNER_ID = '5df85ca3-7a54-4798-a665-c31da8d9caad';
+  const isAdminOnly = !!onViewAs; // onViewAs is only passed from App.js when isAdmin is true
   
   // Form states
   const [newUser, setNewUser] = useState({
@@ -742,7 +745,7 @@ const UserManagement = ({ onViewAs }) => {
                               Delete
                             </button>
                           )}
-                          {onViewAs && (
+                          {isAdminOnly && onViewAs && (
                             <button
                               onClick={() => onViewAs(user)}
                               style={{

--- a/src/components/UserManagement.jsx
+++ b/src/components/UserManagement.jsx
@@ -742,7 +742,7 @@ const UserManagement = ({ onViewAs }) => {
                               Delete
                             </button>
                           )}
-                          {isDevMode && onViewAs && (
+                          {onViewAs && (
                             <button
                               onClick={() => onViewAs(user)}
                               style={{

--- a/src/components/job-modules/ManagementChecklist.jsx
+++ b/src/components/job-modules/ManagementChecklist.jsx
@@ -460,11 +460,40 @@ useEffect(() => {
         });
       
       if (error) throw error;
-      
+
+      // Update workflow_stats when second-attempt or third-attempt items are marked complete
+      if (newStatus === 'completed' && (itemId === 'second-attempt' || itemId === 'third-attempt')) {
+        try {
+          const updateData = {};
+          if (itemId === 'second-attempt') {
+            updateData.workflow_stats = {
+              ...(jobData?.workflow_stats || {}),
+              checklist_second_attempts_complete: true
+            };
+          } else if (itemId === 'third-attempt') {
+            updateData.workflow_stats = {
+              ...(jobData?.workflow_stats || {}),
+              checklist_third_attempts_complete: true
+            };
+          }
+
+          const { error: updateError } = await supabase
+            .from('jobs')
+            .update(updateData)
+            .eq('id', jobData.id);
+
+          if (updateError) {
+            console.error(`Error updating workflow_stats for ${itemId}:`, updateError);
+          }
+        } catch (err) {
+          console.error(`Failed to update workflow_stats for ${itemId}:`, err);
+        }
+      }
+
       // Update local state
-      setChecklistItems(items => items.map(item => 
-        item.id === itemId ? { 
-          ...item, 
+      setChecklistItems(items => items.map(item =>
+        item.id === itemId ? {
+          ...item,
           status: newStatus,
           completed_at: newStatus === 'completed' ? new Date().toISOString() : null,
           completed_by: newStatus === 'completed' ? (currentUser?.name || 'Jim Duda') : null

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1828,6 +1828,11 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
         if (rendered && rendered !== 'N/A') return rendered;
       }
 
+      // Liveable Area: use adjusted SFLA to respect additional_card_config and basement_config
+      if (attrId === 'liveable_area') {
+        return getAdjustedSFLA(prop);
+      }
+
       return getRawValue(prop, attrId);
     };
 


### PR DESCRIPTION
### Summary
This PR adds 2nd/3rd attempt completion badges to job tiles, fixes the SFLA adjustment recalculation to respect additional card and basement configurations, and restricts the "View As" button to admin-only access.

### Problem
Three separate issues were identified:
1. When a user completed the 2nd or 3rd attempt checklist items, there was no visual indicator on the job tile to reflect that status.
2. On recalculation after an edit (e.g., changing a sales code), the SFLA adjustment was ignoring the job's `additional_card_config` and `basement_config`, causing it to use the raw total SFLA instead of the correctly adjusted value.
3. The "View As" button in User Management was gated behind `isDevMode`, making it invisible on the main branch where it was needed by the admin.

### Solution
- Workflow stats (`checklist_second_attempts_complete`, `checklist_third_attempts_complete`) are now written to the `jobs` table in Supabase when the respective checklist items are marked complete, and badge UI is rendered on the job tile when those flags are set.
- The `DetailedAppraisalGrid` now routes `liveable_area` through `getAdjustedSFLA()` so that card combination and basement config are always respected during recalculation.
- The "View As" button visibility is now controlled by `isAdminOnly` (derived from whether `onViewAs` is passed, which only happens when `isAdmin` is true in `App.js`), removing the `isDevMode` dependency.

### Key Changes
- **`AdminJobManagement.jsx`**: Added "✓ 2nd Attempts" and "✓ 3rd Attempts" green pill badges to job tiles, rendered when `workflow_stats.checklist_second_attempts_complete` or `checklist_third_attempts_complete` are truthy.
- **`ManagementChecklist.jsx`**: On completion of `second-attempt` or `third-attempt` checklist items, updates `workflow_stats` in the `jobs` Supabase table to persist the completion flags.
- **`DetailedAppraisalGrid.jsx`**: Added a `liveable_area` override in the attribute renderer to call `getAdjustedSFLA(prop)`, ensuring basement and additional card configs are respected on recalculation.
- **`UserManagement.jsx`**: Replaced `isDevMode` gate with `isAdminOnly` flag (derived from `onViewAs` prop presence) to make "View As" available on the main branch for admins only.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/crucial-alliance-aiiaiwdr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-crucial-alliance-aiiaiwdr.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 235`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>crucial-alliance-aiiaiwdr</branchName>-->