### PR TITLE
Fix appeal log totals, hours format, and archive sort

### DIFF
--- a/src/components/AdminJobManagement.jsx
+++ b/src/components/AdminJobManagement.jsx
@@ -70,7 +70,21 @@ const AdminJobManagement = ({
   const isPpaJob = (job) => !job.organization_id || job.organization_id === PPA_ORG_ID;
   const scopedJobs = jobScope === 'ppa' ? jobs.filter(isPpaJob) : jobs.filter(j => !isPpaJob(j));
   const scopedPlanning = jobScope === 'ppa' ? planningJobs.filter(isPpaJob) : planningJobs.filter(j => !isPpaJob(j));
-  const scopedArchived = jobScope === 'ppa' ? archivedJobs.filter(isPpaJob) : archivedJobs.filter(j => !isPpaJob(j));
+  const scopedArchived = (jobScope === 'ppa' ? archivedJobs.filter(isPpaJob) : archivedJobs.filter(j => !isPpaJob(j)))
+    .sort((a, b) => {
+      const getYear = (job) => {
+        if (job.archived_at) {
+          return new Date(job.archived_at).getFullYear();
+        }
+        return 0;
+      };
+      const yearA = getYear(a);
+      const yearB = getYear(b);
+      if (yearB !== yearA) {
+        return yearB - yearA; // Sort by year descending (newest first)
+      }
+      return (a.name || '').localeCompare(b.name || ''); // Then alphabetically by name
+    });
   const [managers, setManagers] = useState(propsManagers || []);
   const [showCreateJob, setShowCreateJob] = useState(false);
   const [showCreatePlanning, setShowCreatePlanning] = useState(false);

--- a/src/components/PayrollManagement.jsx
+++ b/src/components/PayrollManagement.jsx
@@ -663,7 +663,7 @@ const loadInitialData = async () => {
           const style = { ...totalsStyle };
           // Format numeric columns
           if (C === 1) {
-            style.numFmt = '0.##'; // Hours - preserve decimals
+            style.numFmt = '0.0'; // Hours - always show one decimal
           } else if (C >= 2) {
             style.numFmt = '0.00'; // Currency columns
           }
@@ -682,7 +682,7 @@ const loadInitialData = async () => {
             if (typeof ws[cellAddress].v === 'string') {
               style.alignment = { horizontal: 'center', vertical: 'center' };
             } else {
-              style.numFmt = '0.##';
+              style.numFmt = '0.0';
             }
           }
           // Numeric columns (Appt OT, Field Bonus, TOTAL OT)

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -974,6 +974,14 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
     const crossCount = filtered.filter(a => a.appeal_type === 'cross').length;
     const unknownTypeCount = totalAppeals - petitionerCount - representedCount - assessorCount - crossCount;
 
+    // Table totals (for TOTALS row in table)
+    const tableTotals = {
+      currentAssessment: filtered.reduce((sum, a) => sum + (a.current_assessment || 0), 0),
+      cmeProjectedValue: filtered.reduce((sum, a) => sum + (Number(a.cme_projected_value) || 0), 0),
+      judgment: settledAppeals.reduce((sum, a) => sum + (a.judgment_value || 0), 0),
+      loss: settledAppeals.reduce((sum, a) => sum + (a.loss || 0), 0)
+    };
+
     return {
       totalAppeals,
       totalAssessmentExposure,
@@ -992,7 +1000,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       crossCount,
       unknownTypeCount,
       allPropertiesCount,
-      totalPropertiesCount
+      totalPropertiesCount,
+      tableTotals
     };
   }, [filteredAppeals, properties]);
 
@@ -4547,13 +4556,13 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
               {/* Tax Court */}
               <td style={{ minWidth: '100px' }}></td>
               {/* Current Assessment */}
-              <td className="px-3 py-3 whitespace-nowrap text-right" style={{ minWidth: '120px', maxWidth: '120px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (a.current_assessment || 0), 0))}</td>
+              <td className="px-3 py-3 text-right" style={{ minWidth: '140px' }}>{formatCurrency(stats.tableTotals.currentAssessment)}</td>
               {/* CME Value */}
-              <td className="px-3 py-3 whitespace-nowrap text-blue-600 text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.reduce((sum, a) => sum + (Number(a.cme_projected_value) || 0), 0))}</td>
+              <td className="px-3 py-3 text-blue-600 text-right" style={{ minWidth: '140px' }}>{formatCurrency(stats.tableTotals.cmeProjectedValue)}</td>
               {/* Judgment */}
-              <td className="px-3 py-3 whitespace-nowrap text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.judgment_value || 0), 0))}</td>
+              <td className="px-3 py-3 text-right" style={{ minWidth: '140px' }}>{formatCurrency(stats.tableTotals.judgment)}</td>
               {/* Loss */}
-              <td className="px-3 py-3 whitespace-nowrap text-red-600 text-right" style={{ minWidth: '100px', maxWidth: '100px' }}>{formatCurrency(filteredAppeals.filter(a => a.judgment_value !== null && a.judgment_value !== undefined).reduce((sum, a) => sum + (a.loss || 0), 0))}</td>
+              <td className="px-3 py-3 text-red-600 text-right" style={{ minWidth: '140px' }}>{formatCurrency(stats.tableTotals.loss)}</td>
               {/* Action */}
               <td></td>
             </tr>


### PR DESCRIPTION
### Summary
This PR fixes inconsistent totals in the Appeal Log table footer, corrects the hours column format in the ADP payroll export, and adds year-descending then alphabetical sorting to archived jobs in the Admin Job Management view.

### Problem
- The Appeal Log table TOTALS row was computing judgment and loss totals over all filtered appeals instead of only settled appeals, causing incorrect values to display.
- The ADP payroll export hours column displayed values like `88.` (no trailing decimal digit) instead of the expected `88.0`.
- Archived jobs in the PPA admin view had no defined sort order, making it harder to find recent jobs as the list grew.

### Solution
- Moved table-level totals into the memoized `stats` object so judgment and loss sums are correctly scoped to `settledAppeals`, matching the intent of the existing logic.
- Changed the Excel number format for the hours column from `0.##` (optional decimals) to `0.0` (always one decimal place).
- Added a `.sort()` on `scopedArchived` that orders by `archived_at` year descending, then alphabetically by job name within each year.

### Key Changes
- **`AppealLogTab.jsx`** – Added `tableTotals` to the memoized `stats` object; judgment and loss totals now use `settledAppeals` instead of all `filteredAppeals`. Table footer cells reference `stats.tableTotals` and use consistent column widths (`minWidth: 140px`, no `maxWidth` cap).
- **`PayrollManagement.jsx`** – Updated `numFmt` for the hours column from `'0.##'` to `'0.0'` in both the totals row and the regular data rows of the ADP export.
- **`AdminJobManagement.jsx`** – `scopedArchived` now sorts by year (newest first, derived from `archived_at`) and then alphabetically by job name within the same year.

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/slim-stack-kdl5wopd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-slim-stack-kdl5wopd.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 237`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>slim-stack-kdl5wopd</branchName>-->