### PR TITLE
Add commercial pricing bar chart and appeal loss metrics

### DIFF
--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1313,7 +1313,7 @@ const ProductionTracker = ({
                 // that this property is fully complete. Audit trail lives in override_reason.
                 inspectorStats[inspector].priced++;
                 inspectorStats[inspector].pricingWorkDays.add(workDayString);
-                if (classBreakdown[propertyClass]) {
+                if (classBreakdown[propertyClass] && isPrimary) {
                   classBreakdown[propertyClass].priced++;
                 }
               }
@@ -1321,7 +1321,7 @@ const ProductionTracker = ({
               // Override on commercial with no measure date — still credit pricing,
               // but skip the work-day add since we don't have a date to attribute it to.
               inspectorStats[inspector].priced++;
-              if (classBreakdown[propertyClass]) {
+              if (classBreakdown[propertyClass] && isPrimary) {
                 classBreakdown[propertyClass].priced++;
               }
             }
@@ -1695,13 +1695,13 @@ const ProductionTracker = ({
 
               inspectorStats[inspector].priced++;
               inspectorStats[inspector].pricingWorkDays.add(priceDate.toISOString().split('T')[0]);
-              if (classBreakdown[propertyClass]) {
+              if (classBreakdown[propertyClass] && isPrimary) {
                 classBreakdown[propertyClass].priced++;
               }
 
             } else if (currentVendor === 'Microsystems' && isPricedCode) {
               inspectorStats[inspector].priced++;
-              if (classBreakdown[propertyClass]) {
+              if (classBreakdown[propertyClass] && isPrimary) {
                 classBreakdown[propertyClass].priced++;
               }
             } else {

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Factory, Settings, Download, RefreshCw, AlertTriangle, CheckCircle, TrendingUp, DollarSign, Users, Calendar, X, ChevronDown, ChevronUp, Eye, FileText, Lock, Unlock, Save, Building } from 'lucide-react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { supabase, jobService, parseDateLocal } from '../../lib/supabaseClient';
 import * as XLSX from 'xlsx-js-style';
 
@@ -2100,6 +2101,7 @@ const ProductionTracker = ({
       };
 
       // Billing analytics with progress calculations
+      const commercialClasses = ['4A', '4B', '4C'];
       const billingResult = {
         byClass: billingByClass,
         grouped: {
@@ -2126,6 +2128,11 @@ const ProductionTracker = ({
             billable: ['6A', '6B'].reduce((sum, cls) => sum + (billingByClass[cls]?.billable || 0), 0)
           }
         },
+        mainCardPricingData: commercialClasses.map(cls => ({
+          class: cls,
+          priced: classBreakdown[cls]?.priced || 0,
+          total: billingByClass[cls]?.total || 0
+        })),
         totalBillable: Object.values(billingByClass).reduce((sum, cls) => sum + cls.billable, 0)
       };
 
@@ -3928,6 +3935,31 @@ const exportMissingPropertiesReport = () => {
                         />
                       </div>
                     </div>
+                  </div>
+
+                  {/* Main Cards Pricing Chart */}
+                  <div className="bg-white rounded-lg border border-gray-200 p-6">
+                    <h4 className="text-md font-semibold text-gray-800 mb-4">Commercial Pricing - Main Cards Only</h4>
+                    {billingAnalytics.mainCardPricingData && billingAnalytics.mainCardPricingData.length > 0 ? (
+                      <ResponsiveContainer width="100%" height={300}>
+                        <BarChart data={billingAnalytics.mainCardPricingData}>
+                          <CartesianGrid strokeDasharray="3 3" />
+                          <XAxis dataKey="class" />
+                          <YAxis />
+                          <Tooltip
+                            formatter={(value) => value.toLocaleString()}
+                            labelFormatter={(label) => `Class ${label}`}
+                          />
+                          <Legend />
+                          <Bar dataKey="priced" fill="#3b82f6" name="Priced Main Cards" />
+                          <Bar dataKey="total" fill="#e5e7eb" name="Total Main Cards" />
+                        </BarChart>
+                      </ResponsiveContainer>
+                    ) : (
+                      <div className="text-center py-6 text-gray-500">
+                        No commercial pricing data available
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -2071,22 +2071,37 @@ const ProductionTracker = ({
       };
 
       // Create missing priced properties report (commercial properties not yet priced)
+      const totalCommercial = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.total || 0), 0);
+      const totalPriced = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0);
+
+      // Include commercial properties from missingProperties that aren't inspected yet
+      const commercialMissingFromInspection = missingProperties.filter(p =>
+        ['4A', '4B', '4C'].includes(p.property_class)
+      ).map(p => ({
+        ...p,
+        property_class: p.property_class,
+        reason: `${p.reason} (no pricing)`
+      }));
+
+      // Combine both sources of missing priced properties
+      const allMissingPriced = [...missingPricedProperties, ...commercialMissingFromInspection];
+
       const missingPricedReportData = {
         summary: {
-          total_missing: missingPricedProperties.length,
-          by_class: missingPricedProperties.reduce((acc, prop) => {
+          total_missing: totalCommercial - totalPriced,
+          by_class: allMissingPriced.reduce((acc, prop) => {
             acc[prop.property_class] = (acc[prop.property_class] || 0) + 1;
             return acc;
           }, {}),
-          by_inspector: missingPricedProperties.reduce((acc, prop) => {
+          by_inspector: allMissingPriced.reduce((acc, prop) => {
             const insp = prop.inspector || 'None';
             acc[insp] = (acc[insp] || 0) + 1;
             return acc;
           }, {}),
-          total_commercial: ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.total || 0), 0),
-          total_priced: ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0)
+          total_commercial: totalCommercial,
+          total_priced: totalPriced
         },
-        detailed_missing: missingPricedProperties
+        detailed_missing: allMissingPriced
       };
 
       // Final analytics result with correct entry rate

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1201,6 +1201,7 @@ const ProductionTracker = ({
       const inspectorStats = {};
       const classBreakdown = {};
       const billingByClass = {};
+      const mainCardsPriced = {}; // NEW: Track priced main cards ONLY for billing summary
       const propertyIssues = {};
       const inspectorIssuesMap = {};
       const inspectionDataBatch = []; // For inspection_data UPSERT
@@ -1214,6 +1215,7 @@ const ProductionTracker = ({
       allClasses.forEach(cls => {
         classBreakdown[cls] = { total: 0, inspected: 0, entry: 0, refusal: 0, priced: 0 };
         billingByClass[cls] = { total: 0, inspected: 0, billable: 0 };
+        mainCardsPriced[cls] = 0; // NEW: Only count priced main cards
       });
 
       // DEBUG: Track processing counts
@@ -1313,16 +1315,22 @@ const ProductionTracker = ({
                 // that this property is fully complete. Audit trail lives in override_reason.
                 inspectorStats[inspector].priced++;
                 inspectorStats[inspector].pricingWorkDays.add(workDayString);
-                if (classBreakdown[propertyClass] && isPrimary) {
+                if (classBreakdown[propertyClass]) {
                   classBreakdown[propertyClass].priced++;
+                }
+                if (isPrimary && ['4A', '4B', '4C'].includes(propertyClass)) {
+                  mainCardsPriced[propertyClass]++;
                 }
               }
             } else if (['4A', '4B', '4C'].includes(propertyClass)) {
               // Override on commercial with no measure date — still credit pricing,
               // but skip the work-day add since we don't have a date to attribute it to.
               inspectorStats[inspector].priced++;
-              if (classBreakdown[propertyClass] && isPrimary) {
+              if (classBreakdown[propertyClass]) {
                 classBreakdown[propertyClass].priced++;
+              }
+              if (isPrimary) {
+                mainCardsPriced[propertyClass]++;
               }
             }
           }
@@ -1695,14 +1703,20 @@ const ProductionTracker = ({
 
               inspectorStats[inspector].priced++;
               inspectorStats[inspector].pricingWorkDays.add(priceDate.toISOString().split('T')[0]);
-              if (classBreakdown[propertyClass] && isPrimary) {
+              if (classBreakdown[propertyClass]) {
                 classBreakdown[propertyClass].priced++;
+              }
+              if (isPrimary) {
+                mainCardsPriced[propertyClass]++;
               }
 
             } else if (currentVendor === 'Microsystems' && isPricedCode) {
               inspectorStats[inspector].priced++;
-              if (classBreakdown[propertyClass] && isPrimary) {
+              if (classBreakdown[propertyClass]) {
                 classBreakdown[propertyClass].priced++;
+              }
+              if (isPrimary) {
+                mainCardsPriced[propertyClass]++;
               }
             } else {
               // Track commercial properties not yet priced
@@ -2129,7 +2143,7 @@ const ProductionTracker = ({
         },
         mainCardPricingData: commercialClasses.map(cls => ({
           class: cls,
-          priced: classBreakdown[cls]?.priced || 0,
+          priced: mainCardsPriced[cls] || 0,
           total: billingByClass[cls]?.total || 0
         })),
         totalBillable: Object.values(billingByClass).reduce((sum, cls) => sum + cls.billable, 0)

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -2071,8 +2071,8 @@ const ProductionTracker = ({
       };
 
       // Create missing priced properties report (commercial properties not yet priced)
-      const totalCommercial = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.total || 0), 0);
-      const totalPriced = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0);
+      const totalCommercialProps = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.total || 0), 0);
+      const totalCommercialPricedProps = ['4A', '4B', '4C'].reduce((sum, cls) => sum + (classBreakdown[cls]?.priced || 0), 0);
 
       // Include commercial properties from missingProperties that aren't inspected yet
       const commercialMissingFromInspection = missingProperties.filter(p =>
@@ -2088,7 +2088,7 @@ const ProductionTracker = ({
 
       const missingPricedReportData = {
         summary: {
-          total_missing: totalCommercial - totalPriced,
+          total_missing: totalCommercialProps - totalCommercialPricedProps,
           by_class: allMissingPriced.reduce((acc, prop) => {
             acc[prop.property_class] = (acc[prop.property_class] || 0) + 1;
             return acc;
@@ -2098,8 +2098,8 @@ const ProductionTracker = ({
             acc[insp] = (acc[insp] || 0) + 1;
             return acc;
           }, {}),
-          total_commercial: totalCommercial,
-          total_priced: totalPriced
+          total_commercial: totalCommercialProps,
+          total_priced: totalCommercialPricedProps
         },
         detailed_missing: allMissingPriced
       };

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Factory, Settings, Download, RefreshCw, AlertTriangle, CheckCircle, TrendingUp, DollarSign, Users, Calendar, X, ChevronDown, ChevronUp, Eye, FileText, Lock, Unlock, Save, Building } from 'lucide-react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { supabase, jobService, parseDateLocal } from '../../lib/supabaseClient';
 import * as XLSX from 'xlsx-js-style';
 
@@ -2726,7 +2725,8 @@ const exportMissingPropertiesReport = () => {
       blue: 'bg-blue-500',
       green: 'bg-green-500',
       purple: 'bg-purple-500',
-      gray: 'bg-gray-500'
+      gray: 'bg-gray-500',
+      indigo: 'bg-indigo-500'
     };
 
     return (
@@ -3928,38 +3928,31 @@ const exportMissingPropertiesReport = () => {
                             <div className="text-xs text-gray-600">of {billingAnalytics.progressData.personalProperty.total.toLocaleString()}</div>
                           </div>
                         </div>
-                        <ProgressBar 
-                          current={billingAnalytics.progressData.personalProperty.billable} 
-                          total={billingAnalytics.progressData.personalProperty.total} 
-                          color="gray" 
+                        <ProgressBar
+                          current={billingAnalytics.progressData.personalProperty.billable}
+                          total={billingAnalytics.progressData.personalProperty.total}
+                          color="gray"
+                        />
+                      </div>
+
+                      <div className="p-4 bg-indigo-50 rounded-lg border border-indigo-200">
+                        <div className="flex justify-between items-center mb-2">
+                          <div>
+                            <span className="font-medium text-gray-900">Commercial Priced (4A, 4B, 4C)</span>
+                            <div className="text-xs text-gray-600">Main cards priced</div>
+                          </div>
+                          <div className="text-right">
+                            <div className="font-bold text-indigo-600 text-xl">{billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.priced, 0).toLocaleString()}</div>
+                            <div className="text-xs text-indigo-600">of {billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.total, 0).toLocaleString()}</div>
+                          </div>
+                        </div>
+                        <ProgressBar
+                          current={billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.priced, 0)}
+                          total={billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.total, 0)}
+                          color="indigo"
                         />
                       </div>
                     </div>
-                  </div>
-
-                  {/* Main Cards Pricing Chart */}
-                  <div className="bg-white rounded-lg border border-gray-200 p-6">
-                    <h4 className="text-md font-semibold text-gray-800 mb-4">Commercial Pricing - Main Cards Only</h4>
-                    {billingAnalytics.mainCardPricingData && billingAnalytics.mainCardPricingData.length > 0 ? (
-                      <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={billingAnalytics.mainCardPricingData}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="class" />
-                          <YAxis />
-                          <Tooltip
-                            formatter={(value) => value.toLocaleString()}
-                            labelFormatter={(label) => `Class ${label}`}
-                          />
-                          <Legend />
-                          <Bar dataKey="priced" fill="#3b82f6" name="Priced Main Cards" />
-                          <Bar dataKey="total" fill="#e5e7eb" name="Total Main Cards" />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    ) : (
-                      <div className="text-center py-6 text-gray-500">
-                        No commercial pricing data available
-                      </div>
-                    )}
                   </div>
                 </div>
               </div>

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -3935,23 +3935,25 @@ const exportMissingPropertiesReport = () => {
                         />
                       </div>
 
-                      <div className="p-4 bg-indigo-50 rounded-lg border border-indigo-200">
-                        <div className="flex justify-between items-center mb-2">
-                          <div>
-                            <span className="font-medium text-gray-900">Commercial Priced (4A, 4B, 4C)</span>
-                            <div className="text-xs text-gray-600">Main cards priced</div>
+                      {billingAnalytics.mainCardPricingData && billingAnalytics.mainCardPricingData.length > 0 ? (
+                        <div className="p-4 bg-indigo-50 rounded-lg border border-indigo-200">
+                          <div className="flex justify-between items-center mb-2">
+                            <div>
+                              <span className="font-medium text-gray-900">Commercial Priced (4A, 4B, 4C)</span>
+                              <div className="text-xs text-gray-600">Main cards priced</div>
+                            </div>
+                            <div className="text-right">
+                              <div className="font-bold text-indigo-600 text-xl">{billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.priced, 0).toLocaleString()}</div>
+                              <div className="text-xs text-indigo-600">of {billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.total, 0).toLocaleString()}</div>
+                            </div>
                           </div>
-                          <div className="text-right">
-                            <div className="font-bold text-indigo-600 text-xl">{billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.priced, 0).toLocaleString()}</div>
-                            <div className="text-xs text-indigo-600">of {billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.total, 0).toLocaleString()}</div>
-                          </div>
+                          <ProgressBar
+                            current={billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.priced, 0)}
+                            total={billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.total, 0)}
+                            color="indigo"
+                          />
                         </div>
-                        <ProgressBar
-                          current={billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.priced, 0)}
-                          total={billingAnalytics.mainCardPricingData.reduce((sum, item) => sum + item.total, 0)}
-                          color="indigo"
-                        />
-                      </div>
+                      ) : null}
                     </div>
                   </div>
                 </div>

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -3065,11 +3065,11 @@ const exportMissingPropertiesReport = () => {
                 <div>
                   <p className="text-sm text-gray-600">Pricing Complete</p>
                   <p className="text-2xl font-bold text-purple-600">
-                    {commercialCounts.inspected > 0 ?
-                      Math.round((commercialCounts.priced / commercialCounts.inspected) * 100) : 0}%
+                    {commercialCounts.total > 0 ?
+                      Math.round((commercialCounts.priced / commercialCounts.total) * 100) : 0}%
                   </p>
                   <p className="text-xs text-gray-500 mt-1">
-                    {`${commercialCounts.priced.toLocaleString()} of ${commercialCounts.inspected.toLocaleString()} properties`}
+                    {`${commercialCounts.priced.toLocaleString()} of ${commercialCounts.total.toLocaleString()} properties`}
                   </p>
                 </div>
                 <DollarSign className="w-8 h-8 text-purple-500" />

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -3720,8 +3720,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         </div>
       )}
 
-      {/* STATS ROW 1 - TOTALS */}
-      <div className="grid grid-cols-5 gap-4">
+      {/* STATS ROW 1 - APPEAL METRICS */}
+      <div className="grid grid-cols-4 gap-4">
         <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
           <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">Total Appeals</p>
           <div className="mt-2">
@@ -3734,6 +3734,18 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
           <p className="text-xl font-bold text-blue-600 mt-2">{formatCurrency(stats.totalAssessmentExposure)}</p>
         </div>
         <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">Total Actual Loss</p>
+          <p className="text-xl font-bold text-red-600 mt-2">{formatCurrency(stats.totalActualLoss)}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">% Loss of Appeals</p>
+          <p className="text-xl font-bold text-red-600 mt-2">{stats.lossOfAppealsPercent !== null ? `${Math.round(stats.lossOfAppealsPercent * 10) / 10}%` : '-'}</p>
+        </div>
+      </div>
+
+      {/* STATS ROW 1B - RATABLE METRICS */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
           <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">% of Ratables</p>
           <p className={`text-xl font-bold mt-2 ${
             stats.totalRatables === 0 ? 'text-gray-600' :
@@ -3743,14 +3755,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
           }`}>
             {stats.totalRatables === 0 ? 'N/A' : `${Math.round(stats.ratablePercent * 100) / 100}%`}
           </p>
-        </div>
-        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
-          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">Total Actual Loss</p>
-          <p className="text-xl font-bold text-red-600 mt-2">{formatCurrency(stats.totalActualLoss)}</p>
-        </div>
-        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
-          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">% Loss of Appeals</p>
-          <p className="text-xl font-bold text-red-600 mt-2">{stats.lossOfAppealsPercent !== null ? `${Math.round(stats.lossOfAppealsPercent * 10) / 10}%` : '-'}</p>
         </div>
         <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
           <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">Total % Loss (Ratables)</p>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -913,6 +913,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       return sum + (p.values_mod_total || 0);
     }, 0);
 
+    // % Loss of Appeals Filed: (Total Actual Loss / Assessment Exposure) × 100
+    const lossOfAppealsPercent = totalAssessmentExposure > 0
+      ? (totalActualLoss / totalAssessmentExposure) * 100
+      : 0;
+
     const totalLossPercent = tempTotalRatables > 0
       ? (totalActualLoss / tempTotalRatables) * 100
       : 0;
@@ -986,6 +991,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       totalAppeals,
       totalAssessmentExposure,
       totalActualLoss,
+      lossOfAppealsPercent,
       totalLossPercent,
       totalRatables,
       ratablePercent,
@@ -2967,7 +2973,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
     summaryData.push({ Metric: 'Assessment Exposure', Value: formatCurrency(stats.totalAssessmentExposure), Percentage: '' });
     summaryData.push({ Metric: '% of Ratables', Value: `${Math.round(stats.ratablePercent * 10) / 10}%`, Percentage: '' });
     summaryData.push({ Metric: 'Total Actual Loss', Value: formatCurrency(stats.totalActualLoss), Percentage: '' });
-    summaryData.push({ Metric: 'Total % Loss (of Ratables)', Value: `${Math.round(stats.totalLossPercent * 10) / 10}%`, Percentage: '' });
+    summaryData.push({ Metric: 'Percent Loss of Appeals Filed', Value: `${Math.round(stats.lossOfAppealsPercent * 10) / 10}%`, Percentage: '' });
+    summaryData.push({ Metric: 'Total % Loss of Ratables', Value: `${Math.round(stats.totalLossPercent * 10) / 10}%`, Percentage: '' });
     summaryData.push({ Metric: '', Value: '', Percentage: '' });
 
     // Status breakdown
@@ -3742,7 +3749,11 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
           <p className="text-xl font-bold text-red-600 mt-2">{formatCurrency(stats.totalActualLoss)}</p>
         </div>
         <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
-          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">Total % Loss</p>
+          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">% Loss of Appeals</p>
+          <p className="text-xl font-bold text-red-600 mt-2">{stats.lossOfAppealsPercent !== null ? `${Math.round(stats.lossOfAppealsPercent * 10) / 10}%` : '-'}</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+          <p className="text-xs font-medium text-gray-600 uppercase tracking-wide">Total % Loss (Ratables)</p>
           <p className="text-xl font-bold text-red-600 mt-2">{stats.totalLossPercent !== null ? `${Math.round(stats.totalLossPercent * 10) / 10}%` : '-'}</p>
         </div>
       </div>


### PR DESCRIPTION
### Summary
Adds a "Commercial Priced (4A, 4B, 4C)" main-card-only progress bar to the Production Tracker's Summary for Billing tab, and introduces a "% Loss of Appeals Filed" metric to the Appeal Log with a reorganized stats layout.

### Problem
The billing summary's commercial grouping only reflected overall priced counts (which included additional/sub-cards), making it inaccurate for billing purposes. Separately, the Appeal Log lacked a distinction between loss as a percentage of appeals filed vs. loss as a percentage of the total ratable base, and the stats UI had too much dead space with an inefficient layout.

### Key Changes

**ProductionTracker – Summary for Billing:**
- Introduced `mainCardsPriced` tracker that counts only primary (main) cards priced for classes `4A`, `4B`, and `4C`, across both MCS and Microsystems vendor paths
- Added `mainCardPricingData` array to `billingResult`, exposing per-class priced/total counts for main cards only
- Rendered a new indigo-styled progress bar block — **"Commercial Priced (4A, 4B, 4C)"** — in the grouped categories section of the billing summary, displayed after the Personal Property bar
- Added `indigo` color support to the `ProgressBar` color map
- Fixed the "Pricing Complete" tile to calculate percentage against `total` commercial properties rather than only `inspected`, and updated the missing priced report to combine uninspected commercial properties with unpriced inspected ones for an accurate gap count

**AppealLogTab – Appeal Loss Metrics:**
- Computed `lossOfAppealsPercent` as `(Total Actual Loss / Assessment Exposure) × 100`, representing loss specifically among filed appeals
- Reorganized the stats UI into two rows:
  - **Row 1 (4 columns):** Total Appeals, Assessment Exposure, Total Actual Loss, % Loss of Appeals
  - **Row 2 (2 columns):** % of Ratables, Total % Loss (Ratables)
- Added `Percent Loss of Appeals Filed` as a distinct line in the Excel export summary, above the existing `Total % Loss of Ratables` row


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/sturdy-knob-cl8j0oao"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-sturdy-knob-cl8j0oao.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 239`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>sturdy-knob-cl8j0oao</branchName>-->