### PR TITLE
Add Edmunds Audit tool, appeal judgment refresh, and select-all

### DIFF
--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -8,6 +8,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [scanResults, setScanResults] = useState(null);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
+  const [activeResultTab, setActiveResultTab] = useState('matches'); // matches, discrepancies, ghosts
 
   // Fuzzy string matching
   const stringSimilarity = (str1, str2) => {
@@ -60,16 +61,13 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     });
   };
 
-  // Build composite key like the rest of the system
-  const buildCompositeKey = (block, lot, qualifier = '', card = '', address = '') => {
-    const ccdd = jobData?.ccdd_code || jobData?.ccdd || '';
-    const year = jobData?.year_of_value || new Date().getFullYear();
+  // Build composite key - match on block/lot/qualifier/card only (address is compared separately)
+  const buildCompositeKey = (block, lot, qualifier = '', card = '') => {
     const blockStr = String(block || '').trim();
     const lotStr = String(lot || '').trim();
     const qualStr = String(qualifier || '').trim();
     const cardStr = String(card || '').trim();
-    const addrStr = String(address || '').trim().substring(0, 20); // Truncate for matching
-    return `${ccdd}_${year}_${blockStr}_${lotStr}_${qualStr}_${cardStr}_${addrStr}`.toUpperCase();
+    return `${blockStr}_${lotStr}_${qualStr}_${cardStr}`.toUpperCase();
   };
 
   // Detect if lot is subdivided (e.g., lot "1" split into "1.01", "1.02")
@@ -222,22 +220,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       const primaryCopilot = getPrimaryProperties();
       const allCopilot = properties;
 
-      // Build composite key map for Copilot using: ccdd_year_block_lot_qualifier_card_address
+      // Build composite key map for Copilot using: block_lot_qualifier_card only
       const copilotMap = new Map();
       primaryCopilot.forEach(p => {
-        // Use abbreviated address for matching
-        const addr = String(p.property_location || '').trim().substring(0, 20).toUpperCase();
         const card = getPrimaryCardIndicator(); // Primary card only
-        const key = buildCompositeKey(p.property_block, p.property_lot, p.property_qualifier, card, addr);
+        const key = buildCompositeKey(p.property_block, p.property_lot, p.property_qualifier, card);
         copilotMap.set(key, p);
-      });
-
-      // Also build a block/lot only map for ghost detection
-      const blockLotMap = new Map();
-      primaryCopilot.forEach(p => {
-        const key = `${String(p.property_block || '').trim()}_${String(p.property_lot || '').trim()}_${String(p.property_qualifier || '').trim()}`;
-        if (!blockLotMap.has(key)) blockLotMap.set(key, []);
-        blockLotMap.get(key).push(p);
       });
 
       // Match records
@@ -246,8 +234,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       const ghostRecords = [];
 
       edmundsRecords.forEach(edmundsRec => {
-        const addr = String(edmundsRec.property_location || '').trim().substring(0, 20).toUpperCase();
-        const key = buildCompositeKey(edmundsRec.block, edmundsRec.lot, edmundsRec.qualifier, getPrimaryCardIndicator(), addr);
+        const key = buildCompositeKey(edmundsRec.block, edmundsRec.lot, edmundsRec.qualifier, getPrimaryCardIndicator());
 
         const copilotRec = copilotMap.get(key);
 
@@ -437,98 +424,175 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
             </div>
           </div>
 
-          {/* Discrepancies */}
-          {scanResults.discrepancies > 0 && (
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
-                <AlertTriangle className="w-5 h-5 text-yellow-600" />
-                Discrepancies Found ({scanResults.discrepancies})
-              </h3>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Block</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Lot</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Issues</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Severity</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {scanResults.detailedDiscrepancies.map((match, idx) => (
-                      <tr key={idx} className="border-t hover:bg-gray-50">
-                        <td className="px-4 py-2">{match.edmunds.block}</td>
-                        <td className="px-4 py-2">{match.edmunds.lot}</td>
-                        <td className="px-4 py-2 text-xs">
-                          {match.discrepancies.map(d => `${d.field} (${(d.similarity * 100).toFixed(0)}%)`).join(', ')}
-                        </td>
-                        <td className="px-4 py-2">
-                          <span className={`px-2 py-1 rounded text-xs font-medium ${
-                            match.severity === 'critical'
-                              ? 'bg-red-100 text-red-800'
-                              : 'bg-yellow-100 text-yellow-800'
-                          }`}>
-                            {match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
-                          </span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+          {/* Results Tabs */}
+          <div className="bg-white rounded-lg border border-gray-200">
+            <div className="border-b border-gray-200 flex">
+              <button
+                onClick={() => setActiveResultTab('matches')}
+                className={`px-6 py-3 font-medium text-sm border-b-2 ${
+                  activeResultTab === 'matches'
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                ✓ Exact Matches ({scanResults.exactMatches})
+              </button>
+              <button
+                onClick={() => setActiveResultTab('discrepancies')}
+                className={`px-6 py-3 font-medium text-sm border-b-2 ${
+                  activeResultTab === 'discrepancies'
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                ⚠️ Discrepancies ({scanResults.discrepancies})
+              </button>
+              <button
+                onClick={() => setActiveResultTab('ghosts')}
+                className={`px-6 py-3 font-medium text-sm border-b-2 ${
+                  activeResultTab === 'ghosts'
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                👻 Phantom Properties ({scanResults.ghosts})
+              </button>
             </div>
-          )}
 
-          {/* Ghost Records */}
-          {scanResults.ghosts > 0 && (
-            <div className="bg-white rounded-lg border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
-                <AlertCircle className="w-5 h-5 text-red-600" />
-                Phantom Properties ({scanResults.ghosts})
-              </h3>
-              <div className="overflow-x-auto mb-4">
-                <table className="w-full text-sm">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Category</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Owner (Edmunds)</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Class (Edmunds)</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Address (Edmunds)</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">City, State ZIP</th>
-                      <th className="px-4 py-2 text-left font-medium text-gray-700">Details</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {scanResults.detailedGhosts.map((ghost, idx) => (
-                      <tr key={idx} className="border-t hover:bg-red-50">
-                        <td className="px-4 py-2 font-medium">{ghost.edmunds.block}/{ghost.edmunds.lot}</td>
-                        <td className="px-4 py-2">
-                          <span className={`px-2 py-1 rounded text-xs font-medium ${
-                            ghost.category === 'Subdivided'
-                              ? 'bg-blue-100 text-blue-800'
-                              : ghost.category === 'Additional Lot'
-                              ? 'bg-green-100 text-green-800'
-                              : 'bg-red-100 text-red-800'
-                          }`}>
-                            {ghost.category}
-                          </span>
-                        </td>
-                        <td className="px-4 py-2 text-xs">{ghost.edmunds.owner || '—'}</td>
-                        <td className="px-4 py-2 text-xs">{ghost.edmunds.property_m4_class || '—'}</td>
-                        <td className="px-4 py-2 text-xs">{ghost.edmunds.property_location || '—'}</td>
-                        <td className="px-4 py-2 text-xs">
-                          {ghost.edmunds.owner_city && `${ghost.edmunds.owner_city}, ${ghost.edmunds.state} ${ghost.edmunds.zip}`}
-                          {!ghost.edmunds.owner_city && '—'}
-                        </td>
-                        <td className="px-4 py-2 text-xs text-gray-600">{ghost.details}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+            <div className="p-6">
+              {activeResultTab === 'matches' && (
+                <div>
+                  <p className="text-sm text-gray-600 mb-4">Showing {scanResults.exactMatches} records with matching block/lot/qualifier and no field discrepancies</p>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Owner (Edmunds)</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Owner (Copilot)</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Address (Edmunds)</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Address (Copilot)</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Class</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {scanResults.detailedMatches.slice(0, 50).map((match, idx) => (
+                          <tr key={idx} className="border-t hover:bg-green-50">
+                            <td className="px-4 py-2 font-medium">{match.edmunds.block}/{match.edmunds.lot}</td>
+                            <td className="px-4 py-2 text-xs">{match.edmunds.owner || '—'}</td>
+                            <td className="px-4 py-2 text-xs">{match.copilot.owner_name || '—'}</td>
+                            <td className="px-4 py-2 text-xs">{match.edmunds.property_location || '—'}</td>
+                            <td className="px-4 py-2 text-xs">{match.copilot.property_location || '—'}</td>
+                            <td className="px-4 py-2 text-xs">{match.edmunds.property_m4_class || '—'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    {scanResults.detailedMatches.length > 50 && (
+                      <div className="text-center text-sm text-gray-500 py-4">
+                        Showing first 50 of {scanResults.detailedMatches.length} exact matches
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {activeResultTab === 'discrepancies' && (
+                <div>
+                  <p className="text-sm text-gray-600 mb-4">Records with matching block/lot/qualifier but field differences (owner, address, class, etc.)</p>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Field</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Edmunds Value</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Copilot Value</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Match %</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Severity</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {scanResults.detailedDiscrepancies.map((match, idx) =>
+                          match.discrepancies.map((d, didx) => (
+                            <tr key={`${idx}-${didx}`} className="border-t hover:bg-yellow-50">
+                              {didx === 0 && (
+                                <>
+                                  <td className="px-4 py-2 font-medium" rowSpan={match.discrepancies.length}>{match.edmunds.block}/{match.edmunds.lot}</td>
+                                </>
+                              )}
+                              <td className="px-4 py-2 text-xs font-medium">{d.field}</td>
+                              <td className="px-4 py-2 text-xs">{d.edmunds}</td>
+                              <td className="px-4 py-2 text-xs">{d.copilot}</td>
+                              <td className="px-4 py-2 text-xs">{(d.similarity * 100).toFixed(0)}%</td>
+                              {didx === 0 && (
+                                <td className="px-4 py-2" rowSpan={match.discrepancies.length}>
+                                  <span className={`px-2 py-1 rounded text-xs font-medium ${
+                                    match.severity === 'critical'
+                                      ? 'bg-red-100 text-red-800'
+                                      : 'bg-yellow-100 text-yellow-800'
+                                  }`}>
+                                    {match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
+                                  </span>
+                                </td>
+                              )}
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {activeResultTab === 'ghosts' && (
+                <div>
+                  <p className="text-sm text-gray-600 mb-4">Edmunds records with no match in Copilot system</p>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Category</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Owner (Edmunds)</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Class</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Address</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">City, State ZIP</th>
+                          <th className="px-4 py-2 text-left font-medium text-gray-700">Details</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {scanResults.detailedGhosts.map((ghost, idx) => (
+                          <tr key={idx} className="border-t hover:bg-red-50">
+                            <td className="px-4 py-2 font-medium">{ghost.edmunds.block}/{ghost.edmunds.lot}</td>
+                            <td className="px-4 py-2">
+                              <span className={`px-2 py-1 rounded text-xs font-medium ${
+                                ghost.category === 'Subdivided'
+                                  ? 'bg-blue-100 text-blue-800'
+                                  : ghost.category === 'Additional Lot'
+                                  ? 'bg-green-100 text-green-800'
+                                  : 'bg-red-100 text-red-800'
+                              }`}>
+                                {ghost.category}
+                              </span>
+                            </td>
+                            <td className="px-4 py-2 text-xs">{ghost.edmunds.owner || '—'}</td>
+                            <td className="px-4 py-2 text-xs">{ghost.edmunds.property_m4_class || '—'}</td>
+                            <td className="px-4 py-2 text-xs">{ghost.edmunds.property_location || '—'}</td>
+                            <td className="px-4 py-2 text-xs">
+                              {ghost.edmunds.owner_city && `${ghost.edmunds.owner_city}, ${ghost.edmunds.state} ${ghost.edmunds.zip}`}
+                              {!ghost.edmunds.owner_city && '—'}
+                            </td>
+                            <td className="px-4 py-2 text-xs text-gray-600">{ghost.details}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
             </div>
-          )}
+          </div>
 
           {/* Export Button */}
           <div className="flex justify-end">

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -562,44 +562,79 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     });
 
     const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
-    // Dynamic columns: 4 base + 2 per discrepancy field
+
+    // Set column widths
     const colWidths = [
       { wch: 10 },  // Block
       { wch: 10 },  // Lot
       { wch: 12 },  // Qualifier
       { wch: 12 }   // Status
     ];
-    // Add columns for each field (estimate max 10 fields, 2 cols each = 20 more cols)
     for (let i = 0; i < 20; i++) {
       colWidths.push({ wch: 30 });
     }
     discSheet['!cols'] = colWidths;
 
-    // Apply styling to discrepancy sheet
-    // First pass: identify MOD IV columns
+    // Apply styling using proper XLSX iteration (like ManagementChecklist)
+    const range = XLSX.utils.decode_range(discSheet['!ref']);
+
+    // First pass: identify MOD IV columns from header
     const modIvColumns = new Set();
-    Object.keys(discSheet).forEach(cell => {
-      if (cell.match(/^[A-Z]+1$/) && discSheet[cell]?.v?.includes('MOD IV')) {
-        modIvColumns.add(cell.replace(/1$/, ''));
+    for (let C = range.s.c; C <= range.e.c; ++C) {
+      const cellAddress = XLSX.utils.encode_cell({ r: 0, c: C });
+      if (discSheet[cellAddress]?.v?.includes('MOD IV')) {
+        modIvColumns.add(C);
       }
-    });
+    }
 
-    // Second pass: apply styles
-    Object.keys(discSheet).forEach(cell => {
-      if (cell.startsWith('!')) return;
+    // Second pass: apply styles to all cells
+    for (let R = range.s.r; R <= range.e.r; ++R) {
+      for (let C = range.s.c; C <= range.e.c; ++C) {
+        const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
+        if (!discSheet[cellAddress]) continue;
 
-      const colLetter = cell.replace(/\d+$/, '');
-      const isHeader = cell.match(/^[A-Z]+1$/);
-      const isMODIV = modIvColumns.has(colLetter);
+        if (!discSheet[cellAddress].s) discSheet[cellAddress].s = {};
 
-      if (isHeader) {
-        discSheet[cell].s = headerStyle;
-      } else if (isMODIV) {
-        discSheet[cell].s = modIvStyle;
-      } else {
-        discSheet[cell].s = cellStyle;
+        if (R === 0) {
+          // Header row
+          discSheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10, bold: true, color: { rgb: 'FFFFFF' } },
+            fill: { fgColor: { rgb: '1F2937' } },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: {
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+              top: { style: 'thin' },
+              bottom: { style: 'thin' }
+            }
+          };
+        } else if (modIvColumns.has(C)) {
+          // MOD IV columns - dark blue
+          discSheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10, color: { rgb: '1F2937' } },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: {
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+              top: { style: 'thin' },
+              bottom: { style: 'thin' }
+            }
+          };
+        } else {
+          // Regular data cells
+          discSheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10 },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: {
+              left: { style: 'thin' },
+              right: { style: 'thin' },
+              top: { style: 'thin' },
+              bottom: { style: 'thin' }
+            }
+          };
+        }
       }
-    });
+    }
 
     XLSX.utils.book_append_sheet(workbook, discSheet, 'Discrepancies');
 
@@ -633,14 +668,30 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     ];
 
     // Apply styling to phantom sheet
-    Object.keys(phantomSheet).forEach(cell => {
-      if (cell.startsWith('!')) return;
-      if (cell.match(/^[A-H]1$/)) {
-        phantomSheet[cell].s = headerStyle;
-      } else {
-        phantomSheet[cell].s = cellStyle;
+    const phantomRange = XLSX.utils.decode_range(phantomSheet['!ref']);
+    for (let R = phantomRange.s.r; R <= phantomRange.e.r; ++R) {
+      for (let C = phantomRange.s.c; C <= phantomRange.e.c; ++C) {
+        const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
+        if (!phantomSheet[cellAddress]) continue;
+
+        if (!phantomSheet[cellAddress].s) phantomSheet[cellAddress].s = {};
+
+        if (R === 0) {
+          phantomSheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10, bold: true, color: { rgb: 'FFFFFF' } },
+            fill: { fgColor: { rgb: '1F2937' } },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
+          };
+        } else {
+          phantomSheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10 },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
+          };
+        }
       }
-    });
+    }
 
     XLSX.utils.book_append_sheet(workbook, phantomSheet, 'Phantom Properties');
 
@@ -656,14 +707,30 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     summarySheet['!cols'] = [{ wch: 35 }, { wch: 20 }];
 
     // Apply styling to summary sheet
-    Object.keys(summarySheet).forEach(cell => {
-      if (cell.startsWith('!')) return;
-      if (cell.match(/^[A-B]1$/)) {
-        summarySheet[cell].s = headerStyle;
-      } else {
-        summarySheet[cell].s = cellStyle;
+    const summaryRange = XLSX.utils.decode_range(summarySheet['!ref']);
+    for (let R = summaryRange.s.r; R <= summaryRange.e.r; ++R) {
+      for (let C = summaryRange.s.c; C <= summaryRange.e.c; ++C) {
+        const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
+        if (!summarySheet[cellAddress]) continue;
+
+        if (!summarySheet[cellAddress].s) summarySheet[cellAddress].s = {};
+
+        if (R === 0) {
+          summarySheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10, bold: true, color: { rgb: 'FFFFFF' } },
+            fill: { fgColor: { rgb: '1F2937' } },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
+          };
+        } else {
+          summarySheet[cellAddress].s = {
+            font: { name: 'Leelawadee', sz: 10 },
+            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
+          };
+        }
       }
-    });
+    }
 
     XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary');
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -149,65 +149,54 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   };
 
   // Compare fields and find discrepancies — FLAG ANYTHING THAT ISN'T EXACT
+  // Fuzzy = minor differences (space, abbrev, typo) | Review/Critical = unrelated values
   const compareRecords = (edmundsRecord, copilotRecord) => {
     const discrepancies = [];
 
-    // Owner — flag if not exact match
+    // Helper: compare text fields with fuzzy detection
+    const compareTextField = (field, edmunds, copilot) => {
+      if (edmunds === copilot) return null; // Exact match, no discrepancy
+
+      const sim = stringSimilarity(edmunds, copilot);
+      const severity = sim >= 0.90 ? 'fuzzy' : 'critical'; // 90%+ = fuzzy, <90% = review needed
+
+      return {
+        field,
+        edmunds: edmunds || '(empty)',
+        copilot: copilot || '(empty)',
+        similarity: sim,
+        severity
+      };
+    };
+
+    // Owner
     const edmundsOwner = (edmundsRecord.owner || '').toString().trim();
     const copilotOwner = (copilotRecord.owner_name || '').toString().trim();
-    if (edmundsOwner !== copilotOwner) {
-      discrepancies.push({
-        field: 'owner',
-        edmunds: edmundsOwner || '(empty)',
-        copilot: copilotOwner || '(empty)',
-        similarity: 1,
-        severity: 'critical'
-      });
-    }
+    const ownerDisc = compareTextField('owner', edmundsOwner, copilotOwner);
+    if (ownerDisc) discrepancies.push(ownerDisc);
 
-    // Property Location — flag if not exact match
+    // Property Location
     const edmundsAddr = (edmundsRecord.property_location || '').toString().trim();
     const copilotAddr = (copilotRecord.property_location || '').toString().trim();
-    if (edmundsAddr !== copilotAddr) {
-      discrepancies.push({
-        field: 'property_location',
-        edmunds: edmundsAddr || '(empty)',
-        copilot: copilotAddr || '(empty)',
-        similarity: 1,
-        severity: 'critical'
-      });
-    }
+    const addrDisc = compareTextField('property_location', edmundsAddr, copilotAddr);
+    if (addrDisc) discrepancies.push(addrDisc);
 
-    // Owner Address — flag if not exact match
+    // Owner Address
     const edmundsOwnerAddr = (edmundsRecord.owner_street || '').toString().trim();
     const copilotOwnerAddr = (copilotRecord.owner_street || '').toString().trim();
-    if (edmundsOwnerAddr !== copilotOwnerAddr) {
-      discrepancies.push({
-        field: 'owner_address',
-        edmunds: edmundsOwnerAddr || '(empty)',
-        copilot: copilotOwnerAddr || '(empty)',
-        similarity: 1,
-        severity: 'critical'
-      });
-    }
+    const ownerAddrDisc = compareTextField('owner_address', edmundsOwnerAddr, copilotOwnerAddr);
+    if (ownerAddrDisc) discrepancies.push(ownerAddrDisc);
 
     // Parse Copilot owner_csz field
     const parsedCopilot = parseCsz(copilotRecord.owner_csz);
 
-    // Owner City — flag if not exact match
+    // Owner City
     const edmundsCity = (edmundsRecord.owner_city || '').toString().trim();
     const copilotCity = parsedCopilot.city;
-    if (edmundsCity !== copilotCity) {
-      discrepancies.push({
-        field: 'owner_city',
-        edmunds: edmundsCity || '(empty)',
-        copilot: copilotCity || '(empty)',
-        similarity: 1,
-        severity: 'critical'
-      });
-    }
+    const cityDisc = compareTextField('owner_city', edmundsCity, copilotCity);
+    if (cityDisc) discrepancies.push(cityDisc);
 
-    // State — normalize spaces and compare exactly
+    // State — normalize spaces then compare exactly (N J → NJ)
     const edmundsState = (edmundsRecord.state || '').toString().trim().toUpperCase().replace(/\s+/g, '');
     const copilotState = parsedCopilot.state;
     if (edmundsState !== copilotState) {
@@ -215,12 +204,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         field: 'state',
         edmunds: edmundsState || '(empty)',
         copilot: copilotState || '(empty)',
-        similarity: 1,
+        similarity: 0,
         severity: 'critical'
       });
     }
 
-    // ZIP — flag if not exact match
+    // ZIP — exact match only
     const edmundsZip = (edmundsRecord.zip || '').toString().trim();
     const copilotZip = parsedCopilot.zip;
     if (edmundsZip !== copilotZip) {
@@ -228,12 +217,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         field: 'zip',
         edmunds: edmundsZip || '(empty)',
         copilot: copilotZip || '(empty)',
-        similarity: 1,
+        similarity: 0,
         severity: 'critical'
       });
     }
 
-    // Property Class — flag if not exact match
+    // Property Class — exact match only
     const edmundsClass = (edmundsRecord.property_m4_class || '').toString().trim();
     const copilotClass = (copilotRecord.property_m4_class || '').toString().trim();
     if (edmundsClass !== copilotClass) {
@@ -241,7 +230,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         field: 'property_class',
         edmunds: edmundsClass || '(empty)',
         copilot: copilotClass || '(empty)',
-        similarity: 1,
+        similarity: 0,
         severity: 'critical'
       });
     }

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -148,128 +148,102 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { city, state, zip };
   };
 
-  // Compare fields and find discrepancies
+  // Compare fields and find discrepancies — FLAG ANYTHING THAT ISN'T EXACT
   const compareRecords = (edmundsRecord, copilotRecord) => {
     const discrepancies = [];
 
-    // Owner comparison — flag if different OR if one is missing
+    // Owner — flag if not exact match
     const edmundsOwner = (edmundsRecord.owner || '').toString().trim();
     const copilotOwner = (copilotRecord.owner_name || '').toString().trim();
-    if (edmundsOwner || copilotOwner) {
-      if (!edmundsOwner || !copilotOwner || edmundsOwner !== copilotOwner) {
-        const ownerSim = stringSimilarity(edmundsOwner, copilotOwner);
-        if (ownerSim < 0.92) { // Lowered from 0.95 to catch typos
-          discrepancies.push({
-            field: 'owner',
-            edmunds: edmundsOwner || '(empty)',
-            copilot: copilotOwner || '(empty)',
-            similarity: ownerSim,
-            severity: ownerSim < 0.7 ? 'critical' : 'fuzzy'
-          });
-        }
-      }
+    if (edmundsOwner !== copilotOwner) {
+      discrepancies.push({
+        field: 'owner',
+        edmunds: edmundsOwner || '(empty)',
+        copilot: copilotOwner || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
-    // Property Location comparison
+    // Property Location — flag if not exact match
     const edmundsAddr = (edmundsRecord.property_location || '').toString().trim();
     const copilotAddr = (copilotRecord.property_location || '').toString().trim();
-    if (edmundsAddr || copilotAddr) {
-      if (!edmundsAddr || !copilotAddr || edmundsAddr !== copilotAddr) {
-        const addrSim = stringSimilarity(edmundsAddr, copilotAddr);
-        if (addrSim < 0.92) {
-          discrepancies.push({
-            field: 'property_location',
-            edmunds: edmundsAddr || '(empty)',
-            copilot: copilotAddr || '(empty)',
-            similarity: addrSim,
-            severity: addrSim < 0.7 ? 'critical' : 'fuzzy'
-          });
-        }
-      }
+    if (edmundsAddr !== copilotAddr) {
+      discrepancies.push({
+        field: 'property_location',
+        edmunds: edmundsAddr || '(empty)',
+        copilot: copilotAddr || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
-    // Owner Address comparison
+    // Owner Address — flag if not exact match
     const edmundsOwnerAddr = (edmundsRecord.owner_street || '').toString().trim();
     const copilotOwnerAddr = (copilotRecord.owner_street || '').toString().trim();
-    if (edmundsOwnerAddr || copilotOwnerAddr) {
-      if (!edmundsOwnerAddr || !copilotOwnerAddr || edmundsOwnerAddr !== copilotOwnerAddr) {
-        const ownerAddrSim = stringSimilarity(edmundsOwnerAddr, copilotOwnerAddr);
-        if (ownerAddrSim < 0.92) {
-          discrepancies.push({
-            field: 'owner_address',
-            edmunds: edmundsOwnerAddr || '(empty)',
-            copilot: copilotOwnerAddr || '(empty)',
-            similarity: ownerAddrSim,
-            severity: ownerAddrSim < 0.7 ? 'critical' : 'fuzzy'
-          });
-        }
-      }
+    if (edmundsOwnerAddr !== copilotOwnerAddr) {
+      discrepancies.push({
+        field: 'owner_address',
+        edmunds: edmundsOwnerAddr || '(empty)',
+        copilot: copilotOwnerAddr || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
     // Parse Copilot owner_csz field
     const parsedCopilot = parseCsz(copilotRecord.owner_csz);
 
-    // Owner City comparison
+    // Owner City — flag if not exact match
     const edmundsCity = (edmundsRecord.owner_city || '').toString().trim();
     const copilotCity = parsedCopilot.city;
-    if (edmundsCity || copilotCity) {
-      if (!edmundsCity || !copilotCity || edmundsCity !== copilotCity) {
-        const citySim = stringSimilarity(edmundsCity, copilotCity);
-        if (citySim < 0.92) {
-          discrepancies.push({
-            field: 'owner_city',
-            edmunds: edmundsCity || '(empty)',
-            copilot: copilotCity || '(empty)',
-            similarity: citySim,
-            severity: citySim < 0.7 ? 'critical' : 'fuzzy'
-          });
-        }
-      }
+    if (edmundsCity !== copilotCity) {
+      discrepancies.push({
+        field: 'owner_city',
+        edmunds: edmundsCity || '(empty)',
+        copilot: copilotCity || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
-    // State comparison (normalize format: "NJ" vs "N J")
+    // State — normalize spaces and compare exactly
     const edmundsState = (edmundsRecord.state || '').toString().trim().toUpperCase().replace(/\s+/g, '');
     const copilotState = parsedCopilot.state;
-    if (edmundsState || copilotState) {
-      if (!edmundsState || !copilotState || edmundsState !== copilotState) {
-        discrepancies.push({
-          field: 'state',
-          edmunds: edmundsState || '(empty)',
-          copilot: copilotState || '(empty)',
-          similarity: edmundsState === copilotState ? 1 : 0,
-          severity: 'critical'
-        });
-      }
+    if (edmundsState !== copilotState) {
+      discrepancies.push({
+        field: 'state',
+        edmunds: edmundsState || '(empty)',
+        copilot: copilotState || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
-    // ZIP comparison
+    // ZIP — flag if not exact match
     const edmundsZip = (edmundsRecord.zip || '').toString().trim();
     const copilotZip = parsedCopilot.zip;
-    if (edmundsZip || copilotZip) {
-      if (!edmundsZip || !copilotZip || edmundsZip !== copilotZip) {
-        discrepancies.push({
-          field: 'zip',
-          edmunds: edmundsZip || '(empty)',
-          copilot: copilotZip || '(empty)',
-          similarity: edmundsZip === copilotZip ? 1 : 0,
-          severity: 'critical'
-        });
-      }
+    if (edmundsZip !== copilotZip) {
+      discrepancies.push({
+        field: 'zip',
+        edmunds: edmundsZip || '(empty)',
+        copilot: copilotZip || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
-    // Class comparison
+    // Property Class — flag if not exact match
     const edmundsClass = (edmundsRecord.property_m4_class || '').toString().trim();
     const copilotClass = (copilotRecord.property_m4_class || '').toString().trim();
-    if (edmundsClass || copilotClass) {
-      if (!edmundsClass || !copilotClass || edmundsClass !== copilotClass) {
-        discrepancies.push({
-          field: 'property_class',
-          edmunds: edmundsClass || '(empty)',
-          copilot: copilotClass || '(empty)',
-          similarity: edmundsClass === copilotClass ? 1 : 0,
-          severity: 'critical'
-        });
-      }
+    if (edmundsClass !== copilotClass) {
+      discrepancies.push({
+        field: 'property_class',
+        edmunds: edmundsClass || '(empty)',
+        copilot: copilotClass || '(empty)',
+        similarity: 1,
+        severity: 'critical'
+      });
     }
 
     return discrepancies;

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -509,39 +509,23 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
 
     const workbook = XLSX.utils.book_new();
 
-    // Discrepancies sheet
-    const discrepanciesData = scanResults.detailedDiscrepancies.map(match => ({
-      'Block': match.edmunds.block,
-      'Lot': match.edmunds.lot,
-      'Qualifier': match.edmunds.qualifier,
-      'Status': match.severity === 'critical' ? 'REVIEW' : 'FUZZY',
-      'Issue': match.discrepancies.map(d => `${d.field}`).join('; '),
-      'Your Value': match.discrepancies.map(d => `${d.field}: ${d.copilot}`).join(' | '),
-      'Edmunds Value': match.discrepancies.map(d => `${d.field}: ${d.edmunds}`).join(' | ')
-    }));
+    // Define styles for all sheets
+    const headerStyle = {
+      font: { name: 'Leelawadee', size: 10, bold: true, color: { rgb: 'FFFFFF' } },
+      fill: { fgColor: { rgb: '1F2937' } },
+      alignment: { horizontal: 'center', vertical: 'center', wrapText: true }
+    };
 
-    const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
-    XLSX.utils.book_append_sheet(workbook, discSheet, 'Discrepancies');
-
-    // Phantom Properties sheet
-    const phantomData = scanResults.detailedGhosts.map(ghost => ({
-      'Block': ghost.edmunds.block,
-      'Lot': ghost.edmunds.lot,
-      'Qualifier': ghost.edmunds.qualifier,
-      'Category': ghost.category,
-      'Details': ghost.details,
-      'Edmunds Owner': ghost.edmunds.owner,
-      'Edmunds Address': ghost.edmunds.property_location,
-      'Recommended Action':
-        ghost.category === 'Subdivided'
-          ? 'Update lot numbers to reflect subdivision'
-          : ghost.category === 'Additional Lot'
-          ? 'Already exists as additional card - no action needed'
-          : 'Review and delete if invalid'
-    }));
-
-    const phantomSheet = XLSX.utils.json_to_sheet(phantomData);
-    XLSX.utils.book_append_sheet(workbook, phantomSheet, 'Phantom Properties');
+    const cellStyle = {
+      font: { name: 'Leelawadee', size: 10 },
+      alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+      border: {
+        left: { style: 'thin', color: { rgb: 'CCCCCC' } },
+        right: { style: 'thin', color: { rgb: 'CCCCCC' } },
+        top: { style: 'thin', color: { rgb: 'CCCCCC' } },
+        bottom: { style: 'thin', color: { rgb: 'CCCCCC' } }
+      }
+    };
 
     // Summary sheet
     const summaryData = [
@@ -551,9 +535,84 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       { Metric: 'Ghost Records', Value: scanResults.ghosts },
       { Metric: 'Scan Date', Value: new Date(scanResults.timestamp).toLocaleString() }
     ];
-
     const summarySheet = XLSX.utils.json_to_sheet(summaryData);
+    summarySheet['!cols'] = [{ wch: 35 }, { wch: 20 }];
     XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary', 0);
+
+    // Discrepancies sheet
+    const discrepanciesData = scanResults.detailedDiscrepancies.map(match => ({
+      'Block': match.edmunds.block,
+      'Lot': match.edmunds.lot,
+      'Qualifier': match.edmunds.qualifier || '-',
+      'Status': match.severity === 'critical' ? 'REVIEW' : 'FUZZY',
+      'Issue': match.discrepancies.map(d => `${d.field}`).join('; '),
+      'Your Value': match.discrepancies.map(d => `${d.field}: ${d.copilot}`).join(' | '),
+      'Edmunds Value': match.discrepancies.map(d => `${d.field}: ${d.edmunds}`).join(' | ')
+    }));
+
+    const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
+    discSheet['!cols'] = [
+      { wch: 10 },  // Block
+      { wch: 10 },  // Lot
+      { wch: 12 },  // Qualifier
+      { wch: 12 },  // Status
+      { wch: 25 },  // Issue
+      { wch: 35 },  // Your Value
+      { wch: 35 }   // Edmunds Value
+    ];
+
+    // Apply styling to discrepancy sheet
+    Object.keys(discSheet).forEach(cell => {
+      if (cell.startsWith('!')) return;
+      if (cell.match(/^[A-G]1$/)) {
+        discSheet[cell].s = headerStyle;
+      } else {
+        discSheet[cell].s = cellStyle;
+      }
+    });
+
+    XLSX.utils.book_append_sheet(workbook, discSheet, 'Discrepancies');
+
+    // Phantom Properties sheet
+    const phantomData = scanResults.detailedGhosts.map(ghost => ({
+      'Block': ghost.edmunds.block,
+      'Lot': ghost.edmunds.lot,
+      'Qualifier': ghost.edmunds.qualifier || '-',
+      'Category': ghost.category,
+      'Edmunds Owner': ghost.edmunds.owner,
+      'Edmunds Address': ghost.edmunds.property_location,
+      'Details': ghost.details,
+      'Recommended Action':
+        ghost.category === 'Subdivided'
+          ? 'Update lot numbers to reflect subdivision'
+          : ghost.category === 'Additional Lot'
+          ? 'Already exists as additional card'
+          : 'Review and delete if invalid'
+    }));
+
+    const phantomSheet = XLSX.utils.json_to_sheet(phantomData);
+    phantomSheet['!cols'] = [
+      { wch: 10 },  // Block
+      { wch: 10 },  // Lot
+      { wch: 12 },  // Qualifier
+      { wch: 18 },  // Category
+      { wch: 35 },  // Owner
+      { wch: 35 },  // Address
+      { wch: 25 },  // Details
+      { wch: 30 }   // Recommended Action
+    ];
+
+    // Apply styling to phantom sheet
+    Object.keys(phantomSheet).forEach(cell => {
+      if (cell.startsWith('!')) return;
+      if (cell.match(/^[A-H]1$/)) {
+        phantomSheet[cell].s = headerStyle;
+      } else {
+        phantomSheet[cell].s = cellStyle;
+      }
+    });
+
+    XLSX.utils.book_append_sheet(workbook, phantomSheet, 'Phantom Properties');
 
     XLSX.writeFile(workbook, `Edmunds-Reconciliation-${jobData?.job_name || 'Job'}-${new Date().toISOString().split('T')[0]}.xlsx`);
   };

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -585,23 +585,33 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         modIvColumns.add(i);
       }
     });
+    console.log('[Edmunds Export] Disc headers:', discHeaders);
+    console.log('[Edmunds Export] MOD IV columns:', Array.from(modIvColumns));
 
     // Apply styling to all cells
     const range = XLSX.utils.decode_range(discSheet['!ref']);
+    console.log('[Edmunds Export] Disc sheet range:', range);
     for (let R = range.s.r; R <= range.e.r; ++R) {
       for (let C = range.s.c; C <= range.e.c; ++C) {
         const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
-        if (!discSheet[cellAddress]) continue;
+        if (!discSheet[cellAddress]) {
+          console.log('[Edmunds Export] Cell missing:', cellAddress);
+          continue;
+        }
+
+        // Initialize s if it doesn't exist
+        if (!discSheet[cellAddress].s) discSheet[cellAddress].s = {};
 
         if (R === 0) {
-          discSheet[cellAddress].s = headerStyle;
+          discSheet[cellAddress].s = JSON.parse(JSON.stringify(headerStyle));
         } else if (modIvColumns.has(C)) {
-          discSheet[cellAddress].s = modIvStyle;
+          discSheet[cellAddress].s = JSON.parse(JSON.stringify(modIvStyle));
         } else {
-          discSheet[cellAddress].s = baseStyle;
+          discSheet[cellAddress].s = JSON.parse(JSON.stringify(baseStyle));
         }
       }
     }
+    console.log('[Edmunds Export] Applied styles to discrepancies sheet');
 
     XLSX.utils.book_append_sheet(workbook, discSheet, 'Discrepancies');
 
@@ -640,9 +650,11 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       for (let C = phantomRange.s.c; C <= phantomRange.e.c; ++C) {
         const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
         if (!phantomSheet[cellAddress]) continue;
-        phantomSheet[cellAddress].s = R === 0 ? headerStyle : baseStyle;
+        if (!phantomSheet[cellAddress].s) phantomSheet[cellAddress].s = {};
+        phantomSheet[cellAddress].s = JSON.parse(JSON.stringify(R === 0 ? headerStyle : baseStyle));
       }
     }
+    console.log('[Edmunds Export] Applied styles to phantom sheet');
 
     XLSX.utils.book_append_sheet(workbook, phantomSheet, 'Phantom Properties');
 
@@ -664,9 +676,11 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       for (let C = summaryRange.s.c; C <= summaryRange.e.c; ++C) {
         const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
         if (!summarySheet[cellAddress]) continue;
-        summarySheet[cellAddress].s = R === 0 ? headerStyle : baseStyle;
+        if (!summarySheet[cellAddress].s) summarySheet[cellAddress].s = {};
+        summarySheet[cellAddress].s = JSON.parse(JSON.stringify(R === 0 ? headerStyle : baseStyle));
       }
     }
+    console.log('[Edmunds Export] Applied styles to summary sheet');
 
     XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary');
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -262,13 +262,20 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       }
 
       // Helper: fuzzy column matching (find columns by partial name match)
-      const findColumn = (row, searchTerms) => {
+      const findColumn = (row, searchTerms, isZip = false) => {
         const columnNames = Object.keys(row);
         for (const search of (Array.isArray(searchTerms) ? searchTerms : [searchTerms])) {
           const match = columnNames.find(col =>
             col.toLowerCase().includes(search.toLowerCase())
           );
-          if (match) return row[match];
+          if (match) {
+            let value = row[match];
+            // Preserve leading zeros for ZIP codes (Excel converts 07105 → 7105)
+            if (isZip && value) {
+              value = String(value).padStart(5, '0');
+            }
+            return value;
+          }
         }
         return '';
       };
@@ -283,7 +290,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         owner_street: findColumn(row, ['owner street', 'owner address']), // Only Street1, not Street2
         owner_city: findColumn(row, ['owner city']),
         state: findColumn(row, ['state']),
-        zip: findColumn(row, ['owner zip', 'zip']),
+        zip: findColumn(row, ['owner zip', 'zip'], true), // true = preserve leading zeros
         property_m4_class: findColumn(row, ['property class', 'class', 'm4 class'])
       })).filter(r => r.block && r.lot);
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -195,17 +195,54 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const ownerDisc = compareTextField('owner', edmundsOwner, copilotOwner);
     if (ownerDisc) discrepancies.push(ownerDisc);
 
-    // Property Location
+    // Helper: normalize numbers in addresses (7 vs 7th, 2 vs 02, etc.)
+    const normalizeAddressNumbers = (addr) => {
+      return addr.replace(/(\d+)(?:st|nd|rd|th)?/gi, (match, num) => num).replace(/\b0+(\d+)\b/g, '$1').toUpperCase();
+    };
+
+    // Property Location — allow numeric variations as fuzzy
     const edmundsAddr = (edmundsRecord.property_location || '').toString().trim();
     const copilotAddr = (copilotRecord.property_location || '').toString().trim();
-    const addrDisc = compareTextField('property_location', edmundsAddr, copilotAddr);
-    if (addrDisc) discrepancies.push(addrDisc);
+    if (edmundsAddr !== copilotAddr) {
+      const normalizedEdmunds = normalizeAddressNumbers(edmundsAddr);
+      const normalizedCopilot = normalizeAddressNumbers(copilotAddr);
+      if (normalizedEdmunds === normalizedCopilot) {
+        // Numeric variations only, count as fuzzy
+        discrepancies.push({
+          field: 'property_location',
+          edmunds: edmundsAddr,
+          copilot: copilotAddr,
+          similarity: 0.95,
+          severity: 'fuzzy'
+        });
+      } else {
+        // Real difference, use similarity scoring
+        const addrDisc = compareTextField('property_location', edmundsAddr, copilotAddr);
+        if (addrDisc) discrepancies.push(addrDisc);
+      }
+    }
 
-    // Owner Address
+    // Owner Address — allow numeric variations as fuzzy
     const edmundsOwnerAddr = (edmundsRecord.owner_street || '').toString().trim();
     const copilotOwnerAddr = (copilotRecord.owner_street || '').toString().trim();
-    const ownerAddrDisc = compareTextField('owner_address', edmundsOwnerAddr, copilotOwnerAddr);
-    if (ownerAddrDisc) discrepancies.push(ownerAddrDisc);
+    if (edmundsOwnerAddr !== copilotOwnerAddr) {
+      const normalizedEdmundsOwner = normalizeAddressNumbers(edmundsOwnerAddr);
+      const normalizedCopilotOwner = normalizeAddressNumbers(copilotOwnerAddr);
+      if (normalizedEdmundsOwner === normalizedCopilotOwner) {
+        // Numeric variations only, count as fuzzy
+        discrepancies.push({
+          field: 'owner_address',
+          edmunds: edmundsOwnerAddr,
+          copilot: copilotOwnerAddr,
+          similarity: 0.95,
+          severity: 'fuzzy'
+        });
+      } else {
+        // Real difference, use similarity scoring
+        const ownerAddrDisc = compareTextField('owner_address', edmundsOwnerAddr, copilotOwnerAddr);
+        if (ownerAddrDisc) discrepancies.push(ownerAddrDisc);
+      }
+    }
 
     // Extract city/state and zip from both sources
     // Edmunds: owner_city is "NEWARK, NJ" and zip is separate "07105"

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -505,8 +505,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   };
 
   const exportReport = () => {
-    if (!scanResults) return;
+    if (!scanResults) {
+      alert('No scan results to export. Please upload and scan Edmunds data first.');
+      return;
+    }
 
+    console.log('[Edmunds Export] Starting export with proper formatting...');
     const workbook = XLSX.utils.book_new();
 
     // Define styles (matching OverallAnalysisTab pattern)
@@ -526,17 +530,23 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     };
 
     // Discrepancies sheet - one row per Block/Lot/Qualifier, fields as columns
-    // Build headers first
+    // Build headers first - use array to preserve order
     const discHeaders = ['Block', 'Lot', 'Qualifier', 'Status'];
-    const fieldPairs = new Set();
+    const fieldPairs = [];
+    const seenFields = new Set();
+
+    // Collect unique fields in order they appear
     scanResults.detailedDiscrepancies.forEach(match => {
       match.discrepancies.forEach(disc => {
-        fieldPairs.add(disc.field);
+        if (!seenFields.has(disc.field)) {
+          seenFields.add(disc.field);
+          fieldPairs.push(disc.field);
+        }
       });
     });
 
     // Add field pairs to headers
-    Array.from(fieldPairs).forEach(field => {
+    fieldPairs.forEach(field => {
       discHeaders.push(`${field} - MOD IV`, `${field} - Edmunds`);
     });
 
@@ -550,7 +560,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       ];
 
       // Add field values in order
-      Array.from(fieldPairs).forEach(field => {
+      fieldPairs.forEach(field => {
         const disc = match.discrepancies.find(d => d.field === field);
         row.push(disc?.copilot || '');
         row.push(disc?.edmunds || '');
@@ -660,7 +670,11 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
 
     XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary');
 
-    XLSX.writeFile(workbook, `Edmunds-Reconciliation-${jobData?.job_name || 'Job'}-${new Date().toISOString().split('T')[0]}.xlsx`);
+    const filename = `Edmunds-Reconciliation-${jobData?.job_name || 'Job'}-${new Date().toISOString().split('T')[0]}.xlsx`;
+    console.log('[Edmunds Export] File being written:', filename);
+    console.log('[Edmunds Export] Workbook sheets:', workbook.SheetNames);
+    XLSX.writeFile(workbook, filename);
+    console.log('[Edmunds Export] Export complete');
   };
 
   return (

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -9,6 +9,9 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [successMessage, setSuccessMessage] = useState(null);
   const [activeResultTab, setActiveResultTab] = useState('matches'); // matches, discrepancies, ghosts
   const [selectedBreakdownField, setSelectedBreakdownField] = useState(null); // Filter by field
+  const [sortColumn, setSortColumn] = useState('block'); // Sorting
+  const [sortDirection, setSortDirection] = useState('asc');
+  const [severityFilter, setSeverityFilter] = useState(null); // null = all, 'critical', 'fuzzy'
 
   // Fuzzy string matching
   const stringSimilarity = (str1, str2) => {
@@ -189,11 +192,20 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       };
     };
 
-    // Owner
+    // Owner — 50% threshold for fuzzy
     const edmundsOwner = (edmundsRecord.owner || '').toString().trim();
     const copilotOwner = (copilotRecord.owner_name || '').toString().trim();
-    const ownerDisc = compareTextField('owner', edmundsOwner, copilotOwner);
-    if (ownerDisc) discrepancies.push(ownerDisc);
+    if (edmundsOwner !== copilotOwner) {
+      const sim = stringSimilarity(edmundsOwner, copilotOwner);
+      const severity = sim >= 0.50 ? 'fuzzy' : 'critical'; // 50%+ = fuzzy
+      discrepancies.push({
+        field: 'owner',
+        edmunds: edmundsOwner || '(empty)',
+        copilot: copilotOwner || '(empty)',
+        similarity: sim,
+        severity
+      });
+    }
 
     // Helper: normalize ordinals and numbers in addresses
     // "fourth" → "4", "4th" → "4", "03" → "3", etc.
@@ -307,6 +319,50 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       });
     }
 
+    // Sales Data (optional fields) — for recent sales tracking
+    const edmundsSalesDate = (edmundsRecord.sales_date || '').toString().trim();
+    const edmundsSalesPrice = (edmundsRecord.sales_price || '').toString().trim();
+    const edmundsSalesBook = (edmundsRecord.sales_book || '').toString().trim();
+    const edmundsSalesPage = (edmundsRecord.sales_page || '').toString().trim();
+
+    // Note: Copilot may not have these fields yet, so we include Edmunds values for reference
+    if (edmundsSalesDate) {
+      discrepancies.push({
+        field: 'sales_date',
+        edmunds: edmundsSalesDate,
+        copilot: '(not in Copilot)',
+        similarity: 0,
+        severity: 'fuzzy' // Info only, not a critical mismatch
+      });
+    }
+    if (edmundsSalesPrice) {
+      discrepancies.push({
+        field: 'sales_price',
+        edmunds: edmundsSalesPrice,
+        copilot: '(not in Copilot)',
+        similarity: 0,
+        severity: 'fuzzy'
+      });
+    }
+    if (edmundsSalesBook) {
+      discrepancies.push({
+        field: 'sales_book',
+        edmunds: edmundsSalesBook,
+        copilot: '(not in Copilot)',
+        similarity: 0,
+        severity: 'fuzzy'
+      });
+    }
+    if (edmundsSalesPage) {
+      discrepancies.push({
+        field: 'sales_page',
+        edmunds: edmundsSalesPage,
+        copilot: '(not in Copilot)',
+        similarity: 0,
+        severity: 'fuzzy'
+      });
+    }
+
     return discrepancies;
   };
 
@@ -360,7 +416,11 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         owner_city: findColumn(row, ['owner city']),
         state: findColumn(row, ['state']),
         zip: findColumn(row, ['owner zip', 'zip'], true), // true = preserve leading zeros
-        property_m4_class: findColumn(row, ['property class', 'class', 'm4 class'])
+        property_m4_class: findColumn(row, ['property class', 'class', 'm4 class']),
+        sales_date: findColumn(row, ['sales date', 'sale date']) || '',
+        sales_price: findColumn(row, ['sales price', 'sale price']) || '',
+        sales_book: findColumn(row, ['sales book', 'sale book']) || '',
+        sales_page: findColumn(row, ['sales page', 'sale page']) || ''
       })).filter(r => r.block && r.lot);
 
       const primaryCopilot = getPrimaryProperties();
@@ -674,6 +734,41 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                     ))}
                   </div>
 
+                  {/* Severity Filter Buttons */}
+                  <div className="flex gap-2 mb-4 items-center">
+                    <span className="text-xs font-medium text-gray-600">Filter Severity:</span>
+                    <button
+                      onClick={() => setSeverityFilter(null)}
+                      className={`text-xs px-3 py-1 rounded ${
+                        severityFilter === null
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                      }`}
+                    >
+                      All
+                    </button>
+                    <button
+                      onClick={() => setSeverityFilter('critical')}
+                      className={`text-xs px-3 py-1 rounded ${
+                        severityFilter === 'critical'
+                          ? 'bg-red-600 text-white'
+                          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                      }`}
+                    >
+                      🔴 Review
+                    </button>
+                    <button
+                      onClick={() => setSeverityFilter('fuzzy')}
+                      className={`text-xs px-3 py-1 rounded ${
+                        severityFilter === 'fuzzy'
+                          ? 'bg-yellow-600 text-white'
+                          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                      }`}
+                    >
+                      🟡 Fuzzy
+                    </button>
+                  </div>
+
                   {selectedBreakdownField && (
                     <div className="bg-blue-50 p-3 rounded mb-4 border border-blue-200 flex items-center justify-between">
                       <p className="text-sm text-gray-700">
@@ -683,7 +778,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                         onClick={() => setSelectedBreakdownField(null)}
                         className="text-xs px-3 py-1 bg-blue-200 hover:bg-blue-300 rounded"
                       >
-                        Show All
+                        Clear
                       </button>
                     </div>
                   )}
@@ -691,7 +786,25 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                       <table className="w-full text-sm">
                         <thead className="bg-gray-50">
                           <tr>
-                            <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
+                            <th
+                              className="px-4 py-2 text-left font-medium text-gray-700 cursor-pointer hover:bg-gray-100"
+                              onClick={() => {
+                                setSortColumn('block');
+                                setSortDirection(sortColumn === 'block' && sortDirection === 'asc' ? 'desc' : 'asc');
+                              }}
+                            >
+                              Block {sortColumn === 'block' && (sortDirection === 'asc' ? '↑' : '↓')}
+                            </th>
+                            <th
+                              className="px-4 py-2 text-left font-medium text-gray-700 cursor-pointer hover:bg-gray-100"
+                              onClick={() => {
+                                setSortColumn('lot');
+                                setSortDirection(sortColumn === 'lot' && sortDirection === 'asc' ? 'desc' : 'asc');
+                              }}
+                            >
+                              Lot {sortColumn === 'lot' && (sortDirection === 'asc' ? '↑' : '↓')}
+                            </th>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Qualifier</th>
                             <th className="px-4 py-2 text-left font-medium text-gray-700">Field</th>
                             <th className="px-4 py-2 text-left font-medium text-gray-700">Edmunds Value</th>
                             <th className="px-4 py-2 text-left font-medium text-gray-700">Copilot Value</th>
@@ -709,29 +822,37 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                                 : match.discrepancies
                             }))
                             .filter(item => item.filtered.length > 0)
+                            .filter(item => !severityFilter || item.filtered.some(d => d.severity === severityFilter))
+                            .sort((a, b) => {
+                              const aVal = Number(a.match.edmunds[sortColumn]) || 0;
+                              const bVal = Number(b.match.edmunds[sortColumn]) || 0;
+                              return sortDirection === 'asc' ? aVal - bVal : bVal - aVal;
+                            })
                             .map(item =>
-                              item.filtered.map((d, didx) => (
+                              item.filtered
+                                .filter(d => !severityFilter || d.severity === severityFilter)
+                                .map((d, didx) => (
                                 <tr key={`${item.idx}-${didx}`} className="border-t hover:bg-yellow-50">
                                 {didx === 0 && (
                                   <>
-                                    <td className="px-4 py-2 font-medium" rowSpan={item.filtered.length}>{item.match.edmunds.block}/{item.match.edmunds.lot}</td>
+                                    <td className="px-4 py-2 font-medium text-sm" rowSpan={item.filtered.filter(d => !severityFilter || d.severity === severityFilter).length}>{item.match.edmunds.block}</td>
+                                    <td className="px-4 py-2 font-medium text-sm" rowSpan={item.filtered.filter(d => !severityFilter || d.severity === severityFilter).length}>{item.match.edmunds.lot}</td>
+                                    <td className="px-4 py-2 font-medium text-sm" rowSpan={item.filtered.filter(d => !severityFilter || d.severity === severityFilter).length}>{item.match.edmunds.qualifier || '-'}</td>
                                   </>
                                 )}
                                 <td className="px-4 py-2 text-xs font-medium">{d.field}</td>
                                 <td className="px-4 py-2 text-xs">{d.edmunds}</td>
                                 <td className="px-4 py-2 text-xs">{d.copilot}</td>
                                 <td className="px-4 py-2 text-xs">{(d.similarity * 100).toFixed(0)}%</td>
-                                {didx === 0 && (
-                                  <td className="px-4 py-2" rowSpan={item.filtered.length}>
-                                    <span className={`px-2 py-1 rounded text-xs font-medium ${
-                                      item.match.severity === 'critical'
-                                        ? 'bg-red-100 text-red-800'
-                                        : 'bg-yellow-100 text-yellow-800'
-                                    }`}>
-                                      {item.match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
-                                    </span>
-                                  </td>
-                                )}
+                                <td className="px-4 py-2">
+                                  <span className={`px-2 py-1 rounded text-xs font-medium ${
+                                    d.severity === 'critical'
+                                      ? 'bg-red-100 text-red-800'
+                                      : 'bg-yellow-100 text-yellow-800'
+                                  }`}>
+                                    {d.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
+                                  </span>
+                                </td>
                               </tr>
                             ))
                           )}

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { Download, AlertCircle, CheckCircle, AlertTriangle, X } from 'lucide-react';
+import { Download, AlertCircle, CheckCircle, X } from 'lucide-react';
 import * as XLSX from 'xlsx';
-import { supabase } from '../../lib/supabaseClient';
 
 const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [isUploading, setIsUploading] = useState(false);
@@ -129,12 +128,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
-  // Parse owner_csz field (formats: "City, ST ZIP" or "City ST ZIP")
-  const parseCsz = (csz) => {
+  // Parse Copilot's owner_csz field (format: "City State Zip" or "City, State Zip")
+  const parseCszCopilot = (csz) => {
     if (!csz) return { city: '', state: '', zip: '' };
     const str = String(csz).trim();
 
-    // Try to match state and zip at the end: "XX ##### " or "XX-#### "
+    // Try to match state and zip at the end: "XX ##### " or "XX-#####"
     const stateZipMatch = str.match(/([A-Z]{2})\s+([\d\-]{5,10})\s*$/i);
 
     if (stateZipMatch) {
@@ -146,6 +145,22 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     }
 
     return { city: str, state: '', zip: '' };
+  };
+
+  // Parse Edmunds data: owner_city is "City, State" and zip is separate
+  const parseEdmundsCity = (ownerCity) => {
+    if (!ownerCity) return { city: '', state: '' };
+    const str = String(ownerCity).trim();
+
+    // Try to match "City, State" or "City State"
+    const match = str.match(/^(.+?)[,\s]+([A-Z]{2})\s*$/i);
+    if (match) {
+      const city = match[1].trim();
+      const state = match[2].toUpperCase().replace(/\s+/g, ''); // Normalize spaces in state
+      return { city, state };
+    }
+
+    return { city: str, state: '' };
   };
 
   // Compare fields and find discrepancies — FLAG ANYTHING THAT ISN'T EXACT
@@ -187,11 +202,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const ownerAddrDisc = compareTextField('owner_address', edmundsOwnerAddr, copilotOwnerAddr);
     if (ownerAddrDisc) discrepancies.push(ownerAddrDisc);
 
-    // Parse Copilot owner_csz field
-    const parsedCopilot = parseCsz(copilotRecord.owner_csz);
+    // Parse Copilot owner_csz field (has city, state, zip all together)
+    const parsedCopilot = parseCszCopilot(copilotRecord.owner_csz);
 
-    // Parse Edmunds owner_city field same way as Copilot (extracts city, state, zip)
-    const parsedEdmunds = parseCsz(edmundsRecord.owner_city);
+    // Parse Edmunds owner_city field (has city, state) and zip is separate column
+    const parsedEdmunds = parseEdmundsCity(edmundsRecord.owner_city);
+    const edmundsZip = (edmundsRecord.zip || '').toString().trim();
 
     // Owner City
     const edmundsCity = parsedEdmunds.city;
@@ -199,9 +215,9 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const cityDisc = compareTextField('owner_city', edmundsCity, copilotCity);
     if (cityDisc) discrepancies.push(cityDisc);
 
-    // State — normalize spaces then compare exactly (N J → NJ)
-    const edmundsState = (parsedEdmunds.state || edmundsRecord.state || '').toString().trim().toUpperCase().replace(/\s+/g, '');
-    const copilotState = parsedCopilot.state;
+    // State — compare directly (Edmunds state from "City, State" and Copilot from owner_csz)
+    const edmundsState = parsedEdmunds.state || '';
+    const copilotState = parsedCopilot.state || '';
     if (edmundsState !== copilotState) {
       discrepancies.push({
         field: 'state',
@@ -213,7 +229,6 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     }
 
     // ZIP — exact match, preserve leading zeros (treat as string)
-    const edmundsZip = (parsedEdmunds.zip || edmundsRecord.zip || '').toString().trim();
     const copilotZip = (parsedCopilot.zip || '').toString().trim();
     if (edmundsZip !== copilotZip) {
       discrepancies.push({

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -509,129 +509,86 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
 
     const workbook = XLSX.utils.book_new();
 
-    // Define styles
-    const headerStyle = {
-      font: { bold: true, color: { rgb: 'FFFFFF' }, sz: 10 },
-      fill: { fgColor: { rgb: '1F2937' } },
-      alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-      border: {
-        left: { style: 'thin' },
-        right: { style: 'thin' },
-        top: { style: 'thin' },
-        bottom: { style: 'thin' }
-      }
+    // Define styles (matching OverallAnalysisTab pattern)
+    const baseStyle = {
+      font: { name: 'Leelawadee', sz: 10 },
+      alignment: { horizontal: 'center', vertical: 'center' }
     };
 
-    const cellStyle = {
-      alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-      border: {
-        left: { style: 'thin' },
-        right: { style: 'thin' },
-        top: { style: 'thin' },
-        bottom: { style: 'thin' }
-      }
+    const headerStyle = {
+      font: { name: 'Leelawadee', sz: 10, bold: true },
+      alignment: { horizontal: 'center', vertical: 'center' }
     };
 
     const modIvStyle = {
-      font: { color: { rgb: '1F2937' }, sz: 10 }, // Dark blue color for MOD IV columns
-      alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-      border: {
-        left: { style: 'thin' },
-        right: { style: 'thin' },
-        top: { style: 'thin' },
-        bottom: { style: 'thin' }
-      }
+      font: { name: 'Leelawadee', sz: 10, color: { rgb: '00008B' } }, // Dark blue
+      alignment: { horizontal: 'center', vertical: 'center' }
     };
 
     // Discrepancies sheet - one row per Block/Lot/Qualifier, fields as columns
-    const discrepanciesData = scanResults.detailedDiscrepancies.map(match => {
-      const row = {
-        'Block': match.edmunds.block,
-        'Lot': match.edmunds.lot,
-        'Qualifier': match.edmunds.qualifier,
-        'Status': match.discrepancies[0]?.severity === 'critical' ? 'REVIEW' : 'FUZZY'
-      };
-
-      // Add columns for each field comparison
+    // Build headers first
+    const discHeaders = ['Block', 'Lot', 'Qualifier', 'Status'];
+    const fieldPairs = new Set();
+    scanResults.detailedDiscrepancies.forEach(match => {
       match.discrepancies.forEach(disc => {
-        row[`${disc.field} - MOD IV`] = disc.copilot;
-        row[`${disc.field} - Edmunds`] = disc.edmunds;
+        fieldPairs.add(disc.field);
+      });
+    });
+
+    // Add field pairs to headers
+    Array.from(fieldPairs).forEach(field => {
+      discHeaders.push(`${field} - MOD IV`, `${field} - Edmunds`);
+    });
+
+    // Build data rows
+    const discData = scanResults.detailedDiscrepancies.map(match => {
+      const row = [
+        match.edmunds.block,
+        match.edmunds.lot,
+        match.edmunds.qualifier || '',
+        match.discrepancies[0]?.severity === 'critical' ? 'REVIEW' : 'FUZZY'
+      ];
+
+      // Add field values in order
+      Array.from(fieldPairs).forEach(field => {
+        const disc = match.discrepancies.find(d => d.field === field);
+        row.push(disc?.copilot || '');
+        row.push(disc?.edmunds || '');
       });
 
       return row;
     });
 
-    const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
+    const discSheet = XLSX.utils.aoa_to_sheet([discHeaders, ...discData]);
 
     // Set column widths
-    const colWidths = [
-      { wch: 10 },  // Block
-      { wch: 10 },  // Lot
-      { wch: 12 },  // Qualifier
-      { wch: 12 }   // Status
-    ];
-    for (let i = 0; i < 20; i++) {
+    const colWidths = [{ wch: 10 }, { wch: 10 }, { wch: 12 }, { wch: 12 }];
+    for (let i = 0; i < (discHeaders.length - 4); i++) {
       colWidths.push({ wch: 30 });
     }
     discSheet['!cols'] = colWidths;
 
-    // Apply styling using proper XLSX iteration (like ManagementChecklist)
-    const range = XLSX.utils.decode_range(discSheet['!ref']);
-
-    // First pass: identify MOD IV columns from header
+    // Identify MOD IV columns
     const modIvColumns = new Set();
-    for (let C = range.s.c; C <= range.e.c; ++C) {
-      const cellAddress = XLSX.utils.encode_cell({ r: 0, c: C });
-      if (discSheet[cellAddress]?.v?.includes('MOD IV')) {
-        modIvColumns.add(C);
+    discHeaders.forEach((h, i) => {
+      if (h.includes('MOD IV')) {
+        modIvColumns.add(i);
       }
-    }
+    });
 
-    // Second pass: apply styles to all cells
+    // Apply styling to all cells
+    const range = XLSX.utils.decode_range(discSheet['!ref']);
     for (let R = range.s.r; R <= range.e.r; ++R) {
       for (let C = range.s.c; C <= range.e.c; ++C) {
         const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
         if (!discSheet[cellAddress]) continue;
 
-        if (!discSheet[cellAddress].s) discSheet[cellAddress].s = {};
-
         if (R === 0) {
-          // Header row
-          discSheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10, bold: true, color: { rgb: 'FFFFFF' } },
-            fill: { fgColor: { rgb: '1F2937' } },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: {
-              left: { style: 'thin' },
-              right: { style: 'thin' },
-              top: { style: 'thin' },
-              bottom: { style: 'thin' }
-            }
-          };
+          discSheet[cellAddress].s = headerStyle;
         } else if (modIvColumns.has(C)) {
-          // MOD IV columns - dark blue
-          discSheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10, color: { rgb: '1F2937' } },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: {
-              left: { style: 'thin' },
-              right: { style: 'thin' },
-              top: { style: 'thin' },
-              bottom: { style: 'thin' }
-            }
-          };
+          discSheet[cellAddress].s = modIvStyle;
         } else {
-          // Regular data cells
-          discSheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10 },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: {
-              left: { style: 'thin' },
-              right: { style: 'thin' },
-              top: { style: 'thin' },
-              bottom: { style: 'thin' }
-            }
-          };
+          discSheet[cellAddress].s = baseStyle;
         }
       }
     }
@@ -639,23 +596,23 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     XLSX.utils.book_append_sheet(workbook, discSheet, 'Discrepancies');
 
     // Phantom Properties sheet
-    const phantomData = scanResults.detailedGhosts.map(ghost => ({
-      'Block': ghost.edmunds.block,
-      'Lot': ghost.edmunds.lot,
-      'Qualifier': ghost.edmunds.qualifier,
-      'Category': ghost.category,
-      'Edmunds Owner': ghost.edmunds.owner,
-      'Edmunds Address': ghost.edmunds.property_location,
-      'Details': ghost.details,
-      'Recommended Action':
-        ghost.category === 'Subdivided'
-          ? 'Update lot numbers to reflect subdivision'
-          : ghost.category === 'Additional Lot'
-          ? 'Already exists as additional card'
-          : 'Review and delete if invalid'
-    }));
+    const phantomHeaders = ['Block', 'Lot', 'Qualifier', 'Category', 'Edmunds Owner', 'Edmunds Address', 'Details', 'Recommended Action'];
+    const phantomData = scanResults.detailedGhosts.map(ghost => [
+      ghost.edmunds.block,
+      ghost.edmunds.lot,
+      ghost.edmunds.qualifier || '',
+      ghost.category,
+      ghost.edmunds.owner,
+      ghost.edmunds.property_location,
+      ghost.details,
+      ghost.category === 'Subdivided'
+        ? 'Update lot numbers to reflect subdivision'
+        : ghost.category === 'Additional Lot'
+        ? 'Already exists as additional card'
+        : 'Review and delete if invalid'
+    ]);
 
-    const phantomSheet = XLSX.utils.json_to_sheet(phantomData);
+    const phantomSheet = XLSX.utils.aoa_to_sheet([phantomHeaders, ...phantomData]);
     phantomSheet['!cols'] = [
       { wch: 10 },  // Block
       { wch: 10 },  // Lot
@@ -673,23 +630,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       for (let C = phantomRange.s.c; C <= phantomRange.e.c; ++C) {
         const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
         if (!phantomSheet[cellAddress]) continue;
-
-        if (!phantomSheet[cellAddress].s) phantomSheet[cellAddress].s = {};
-
-        if (R === 0) {
-          phantomSheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10, bold: true, color: { rgb: 'FFFFFF' } },
-            fill: { fgColor: { rgb: '1F2937' } },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
-          };
-        } else {
-          phantomSheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10 },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
-          };
-        }
+        phantomSheet[cellAddress].s = R === 0 ? headerStyle : baseStyle;
       }
     }
 
@@ -697,13 +638,14 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
 
     // Summary sheet - added last
     const summaryData = [
-      { Metric: 'Total Edmunds Records', Value: scanResults.totalEdmunds },
-      { Metric: 'Exact Matches (No Issues)', Value: scanResults.exactMatches },
-      { Metric: 'Discrepancies Found', Value: scanResults.discrepancies },
-      { Metric: 'Ghost Records', Value: scanResults.ghosts },
-      { Metric: 'Scan Date', Value: new Date(scanResults.timestamp).toLocaleString() }
+      ['Metric', 'Value'],
+      ['Total Edmunds Records', scanResults.totalEdmunds],
+      ['Exact Matches (No Issues)', scanResults.exactMatches],
+      ['Discrepancies Found', scanResults.discrepancies],
+      ['Ghost Records', scanResults.ghosts],
+      ['Scan Date', new Date(scanResults.timestamp).toLocaleString()]
     ];
-    const summarySheet = XLSX.utils.json_to_sheet(summaryData);
+    const summarySheet = XLSX.utils.aoa_to_sheet(summaryData);
     summarySheet['!cols'] = [{ wch: 35 }, { wch: 20 }];
 
     // Apply styling to summary sheet
@@ -712,23 +654,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       for (let C = summaryRange.s.c; C <= summaryRange.e.c; ++C) {
         const cellAddress = XLSX.utils.encode_cell({ r: R, c: C });
         if (!summarySheet[cellAddress]) continue;
-
-        if (!summarySheet[cellAddress].s) summarySheet[cellAddress].s = {};
-
-        if (R === 0) {
-          summarySheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10, bold: true, color: { rgb: 'FFFFFF' } },
-            fill: { fgColor: { rgb: '1F2937' } },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
-          };
-        } else {
-          summarySheet[cellAddress].s = {
-            font: { name: 'Leelawadee', sz: 10 },
-            alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
-            border: { left: { style: 'thin' }, right: { style: 'thin' }, top: { style: 'thin' }, bottom: { style: 'thin' } }
-          };
-        }
+        summarySheet[cellAddress].s = R === 0 ? headerStyle : baseStyle;
       }
     }
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -527,36 +527,42 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       }
     };
 
-    // Discrepancies sheet - expanded with separate columns for each field
-    const discrepanciesData = scanResults.detailedDiscrepancies.flatMap(match =>
-      match.discrepancies.map(disc => ({
+    // Discrepancies sheet - one row per Block/Lot/Qualifier, fields as columns
+    const discrepanciesData = scanResults.detailedDiscrepancies.map(match => {
+      const row = {
         'Block': match.edmunds.block,
         'Lot': match.edmunds.lot,
         'Qualifier': match.edmunds.qualifier,
-        'Field': disc.field,
-        'Status': disc.severity === 'critical' ? 'REVIEW' : 'FUZZY',
-        'MOD IV Value': disc.copilot,
-        'Edmunds Value': disc.edmunds,
-        'Match %': `${(disc.similarity * 100).toFixed(0)}%`
-      }))
-    );
+        'Status': match.discrepancies[0]?.severity === 'critical' ? 'REVIEW' : 'FUZZY'
+      };
+
+      // Add columns for each field comparison
+      match.discrepancies.forEach(disc => {
+        row[`${disc.field} - MOD IV`] = disc.copilot;
+        row[`${disc.field} - Edmunds`] = disc.edmunds;
+      });
+
+      return row;
+    });
 
     const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
-    discSheet['!cols'] = [
+    // Dynamic columns: 4 base + 2 per discrepancy field
+    const colWidths = [
       { wch: 10 },  // Block
       { wch: 10 },  // Lot
       { wch: 12 },  // Qualifier
-      { wch: 20 },  // Field
-      { wch: 12 },  // Status
-      { wch: 35 },  // MOD IV Value
-      { wch: 35 },  // Edmunds Value
-      { wch: 10 }   // Match %
+      { wch: 12 }   // Status
     ];
+    // Add columns for each field (estimate max 10 fields, 2 cols each = 20 more cols)
+    for (let i = 0; i < 20; i++) {
+      colWidths.push({ wch: 30 });
+    }
+    discSheet['!cols'] = colWidths;
 
     // Apply styling to discrepancy sheet
     Object.keys(discSheet).forEach(cell => {
       if (cell.startsWith('!')) return;
-      if (cell.match(/^[A-H]1$/)) {
+      if (cell.match(/^[A-Z]+1$/)) {  // All header cells (row 1)
         discSheet[cell].s = headerStyle;
       } else {
         discSheet[cell].s = cellStyle;

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -195,9 +195,29 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const ownerDisc = compareTextField('owner', edmundsOwner, copilotOwner);
     if (ownerDisc) discrepancies.push(ownerDisc);
 
-    // Helper: normalize numbers in addresses (7 vs 7th, 2 vs 02, etc.)
+    // Helper: normalize ordinals and numbers in addresses
+    // "fourth" → "4", "4th" → "4", "03" → "3", etc.
     const normalizeAddressNumbers = (addr) => {
-      return addr.replace(/(\d+)(?:st|nd|rd|th)?/gi, (match, num) => num).replace(/\b0+(\d+)\b/g, '$1').toUpperCase();
+      const ordinals = {
+        'first': '1', 'second': '2', 'third': '3', 'fourth': '4', 'fifth': '5',
+        'sixth': '6', 'seventh': '7', 'eighth': '8', 'ninth': '9', 'tenth': '10',
+        'eleventh': '11', 'twelfth': '12', 'thirteenth': '13', 'fourteenth': '14',
+        'fifteenth': '15', 'sixteenth': '16', 'seventeenth': '17', 'eighteenth': '18',
+        'nineteenth': '19', 'twentieth': '20', 'thirtieth': '30', 'fortieth': '40',
+        'fiftieth': '50', 'sixtieth': '60', 'seventieth': '70', 'eightieth': '80',
+        'ninetieth': '90', 'hundredth': '100'
+      };
+
+      let result = addr.toUpperCase();
+      // Replace written ordinals with numeric equivalents
+      Object.entries(ordinals).forEach(([word, num]) => {
+        result = result.replace(new RegExp(`\\b${word}\\b`, 'gi'), num);
+      });
+      // Remove ordinal suffixes (st, nd, rd, th)
+      result = result.replace(/(\d+)(?:ST|ND|RD|TH)\b/g, '$1');
+      // Remove leading zeros (03 → 3)
+      result = result.replace(/\b0+(\d+)\b/g, '$1');
+      return result;
     };
 
     // Property Location — allow numeric variations as fuzzy

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -455,12 +455,12 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                     </tr>
                   </thead>
                   <tbody>
-                    {scanResults.detailedDiscrepancies.slice(0, 10).map((match, idx) => (
+                    {scanResults.detailedDiscrepancies.map((match, idx) => (
                       <tr key={idx} className="border-t hover:bg-gray-50">
                         <td className="px-4 py-2">{match.edmunds.block}</td>
                         <td className="px-4 py-2">{match.edmunds.lot}</td>
                         <td className="px-4 py-2 text-xs">
-                          {match.discrepancies.map(d => d.field).join(', ')}
+                          {match.discrepancies.map(d => `${d.field} (${(d.similarity * 100).toFixed(0)}%)`).join(', ')}
                         </td>
                         <td className="px-4 py-2">
                           <span className={`px-2 py-1 rounded text-xs font-medium ${
@@ -486,21 +486,46 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                 <AlertCircle className="w-5 h-5 text-red-600" />
                 Phantom Properties ({scanResults.ghosts})
               </h3>
-              <div className="space-y-3">
-                {scanResults.detailedGhosts.slice(0, 10).map((ghost, idx) => (
-                  <div key={idx} className="bg-red-50 rounded-lg p-3 border border-red-200">
-                    <div className="flex justify-between items-start">
-                      <div>
-                        <div className="font-medium text-gray-800">{ghost.edmunds.block}/{ghost.edmunds.lot}</div>
-                        <div className="text-sm text-gray-600 mt-1">{ghost.edmunds.owner}</div>
-                        <div className="text-xs text-gray-500 mt-1">{ghost.details}</div>
-                      </div>
-                      <span className="px-2 py-1 rounded text-xs font-medium bg-red-100 text-red-800">
-                        {ghost.category}
-                      </span>
-                    </div>
-                  </div>
-                ))}
+              <div className="overflow-x-auto mb-4">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Category</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Owner (Edmunds)</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Class (Edmunds)</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Address (Edmunds)</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">City, State ZIP</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Details</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {scanResults.detailedGhosts.map((ghost, idx) => (
+                      <tr key={idx} className="border-t hover:bg-red-50">
+                        <td className="px-4 py-2 font-medium">{ghost.edmunds.block}/{ghost.edmunds.lot}</td>
+                        <td className="px-4 py-2">
+                          <span className={`px-2 py-1 rounded text-xs font-medium ${
+                            ghost.category === 'Subdivided'
+                              ? 'bg-blue-100 text-blue-800'
+                              : ghost.category === 'Additional Lot'
+                              ? 'bg-green-100 text-green-800'
+                              : 'bg-red-100 text-red-800'
+                          }`}>
+                            {ghost.category}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 text-xs">{ghost.edmunds.owner || '—'}</td>
+                        <td className="px-4 py-2 text-xs">{ghost.edmunds.property_m4_class || '—'}</td>
+                        <td className="px-4 py-2 text-xs">{ghost.edmunds.property_location || '—'}</td>
+                        <td className="px-4 py-2 text-xs">
+                          {ghost.edmunds.owner_city && `${ghost.edmunds.owner_city}, ${ghost.edmunds.state} ${ghost.edmunds.zip}`}
+                          {!ghost.edmunds.owner_city && '—'}
+                        </td>
+                        <td className="px-4 py-2 text-xs text-gray-600">{ghost.details}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           )}

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -550,6 +550,10 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       discHeaders.push(`${field} - MOD IV`, `${field} - Edmunds`);
     });
 
+    // Append most-recent-sale columns from Copilot (Edmunds can't share sales)
+    const saleHeaders = ['Last Sale Date', 'Last Sale Price', 'Last Sale Book', 'Last Sale Page'];
+    saleHeaders.forEach(h => discHeaders.push(h));
+
     // Build data rows
     const discData = scanResults.detailedDiscrepancies.map(match => {
       const row = [
@@ -565,6 +569,16 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         row.push(disc?.copilot || '');
         row.push(disc?.edmunds || '');
       });
+
+      // Most-recent-sale info from the Copilot property record
+      const cp = match.copilot || {};
+      const salePrice = cp.sales_price != null && cp.sales_price !== ''
+        ? `$${Number(cp.sales_price).toLocaleString('en-US', { maximumFractionDigits: 0 })}`
+        : '';
+      row.push(cp.sales_date || '');
+      row.push(salePrice);
+      row.push(cp.sales_book || '');
+      row.push(cp.sales_page || '');
 
       return row;
     });
@@ -585,6 +599,10 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         modIvColumns.add(i);
       }
     });
+    // Sale columns are Copilot/MOD IV data too — style them dark blue
+    for (let i = discHeaders.length - saleHeaders.length; i < discHeaders.length; i++) {
+      modIvColumns.add(i);
+    }
     console.log('[Edmunds Export] Disc headers:', discHeaders);
     console.log('[Edmunds Export] MOD IV columns:', Array.from(modIvColumns));
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -279,13 +279,13 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         block: findColumn(row, ['block']),
         lot: findColumn(row, ['lot']),
         qualifier: findColumn(row, ['qualifier']) || '',
-        owner: findColumn(row, ['owner']),
+        owner: findColumn(row, ['owner name', 'owner']),
         property_location: findColumn(row, ['property location', 'address']),
-        owner_street: findColumn(row, ['owner address', 'owner street']),
-        owner_city: findColumn(row, ['owner city', 'city']),
+        owner_street: findColumn(row, ['owner street', 'owner address']), // Only Street1, not Street2
+        owner_city: findColumn(row, ['owner city']),
         state: findColumn(row, ['state']),
-        zip: findColumn(row, ['zip']),
-        property_m4_class: findColumn(row, ['class', 'm4 class'])
+        zip: findColumn(row, ['owner zip', 'zip']),
+        property_m4_class: findColumn(row, ['property class', 'class', 'm4 class'])
       })).filter(r => r.block && r.lot);
 
       const primaryCopilot = getPrimaryProperties();

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -130,18 +130,22 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
 
   // Extract ZIP from owner_csz: last space-separated token if it's numeric
   // "RIVERTON NJ 08077" → csz: "RIVERTON NJ", zip: "08077"
-  // "POINT PLEASANT, NJ 07756" → csz: "POINT PLEASANT, NJ", zip: "07756"
+  // "RIVERTON NJ 0807711110" → csz: "RIVERTON NJ", zip: "08077" (extract first 5 digits)
   const extractZipFromCsz = (csz) => {
     if (!csz) return { csz: '', zip: '' };
     const str = String(csz).trim();
     const parts = str.split(/\s+/);
 
-    // Check if last part is numeric (ZIP code)
+    // Check if last part starts with digits (ZIP code, may include +4)
     const lastPart = parts[parts.length - 1];
-    if (/^\d{5}(?:-\d{4})?$/.test(lastPart)) {
-      const zip = lastPart;
-      const csz = parts.slice(0, -1).join(' ');
-      return { csz, zip };
+    if (/^\d+/.test(lastPart)) {
+      // Extract the first 5 digits as the ZIP code (ignore +4 extension)
+      const zipMatch = lastPart.match(/^(\d{5})/);
+      if (zipMatch) {
+        const zip = zipMatch[1];
+        const csz = parts.slice(0, -1).join(' ');
+        return { csz, zip };
+      }
     }
 
     // No ZIP found, entire string is csz

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -9,6 +9,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [successMessage, setSuccessMessage] = useState(null);
   const [activeResultTab, setActiveResultTab] = useState('matches'); // matches, discrepancies, ghosts
   const [activeDiscrepancyView, setActiveDiscrepancyView] = useState('list'); // list, breakdown
+  const [selectedBreakdownField, setSelectedBreakdownField] = useState(null); // Filter breakdown by field
 
   // Fuzzy string matching
   const stringSimilarity = (str1, str2) => {
@@ -624,14 +625,38 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                   </div>
 
                   {activeDiscrepancyView === 'breakdown' && (
-                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
-                      {Object.entries(scanResults.fieldBreakdown || {}).map(([field, count]) => (
-                        <div key={field} className="bg-blue-50 rounded-lg p-4 border border-blue-200">
-                          <div className="text-2xl font-bold text-blue-600">{count}</div>
-                          <div className="text-sm text-gray-600 capitalize mt-1">{field.replace(/_/g, ' ')}</div>
+                    <>
+                      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+                        {Object.entries(scanResults.fieldBreakdown || {}).map(([field, count]) => (
+                          <div
+                            key={field}
+                            onClick={() => setSelectedBreakdownField(selectedBreakdownField === field ? null : field)}
+                            className={`rounded-lg p-4 border cursor-pointer transition ${
+                              selectedBreakdownField === field
+                                ? 'bg-blue-100 border-blue-500 ring-2 ring-blue-300'
+                                : 'bg-blue-50 border-blue-200 hover:bg-blue-75'
+                            }`}
+                          >
+                            <div className="text-2xl font-bold text-blue-600">{count}</div>
+                            <div className="text-sm text-gray-600 capitalize mt-1">{field.replace(/_/g, ' ')}</div>
+                          </div>
+                        ))}
+                      </div>
+
+                      {selectedBreakdownField && (
+                        <div className="bg-blue-50 p-4 rounded mb-4 border border-blue-200">
+                          <p className="text-sm text-gray-700">
+                            Showing discrepancies for: <span className="font-bold capitalize">{selectedBreakdownField.replace(/_/g, ' ')}</span>
+                            <button
+                              onClick={() => setSelectedBreakdownField(null)}
+                              className="ml-4 text-xs px-2 py-1 bg-blue-200 hover:bg-blue-300 rounded"
+                            >
+                              Clear Filter
+                            </button>
+                          </p>
                         </div>
-                      ))}
-                    </div>
+                      )}
+                    </>
                   )}
 
                   {activeDiscrepancyView === 'list' && (
@@ -648,12 +673,21 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                           </tr>
                         </thead>
                         <tbody>
-                          {scanResults.detailedDiscrepancies.map((match, idx) =>
-                            match.discrepancies.map((d, didx) => (
-                              <tr key={`${idx}-${didx}`} className="border-t hover:bg-yellow-50">
+                          {scanResults.detailedDiscrepancies
+                            .map((match, idx) => ({
+                              match,
+                              idx,
+                              filtered: selectedBreakdownField
+                                ? match.discrepancies.filter(d => d.field === selectedBreakdownField)
+                                : match.discrepancies
+                            }))
+                            .filter(item => item.filtered.length > 0)
+                            .map(item =>
+                              item.filtered.map((d, didx) => (
+                                <tr key={`${item.idx}-${didx}`} className="border-t hover:bg-yellow-50">
                                 {didx === 0 && (
                                   <>
-                                    <td className="px-4 py-2 font-medium" rowSpan={match.discrepancies.length}>{match.edmunds.block}/{match.edmunds.lot}</td>
+                                    <td className="px-4 py-2 font-medium" rowSpan={item.filtered.length}>{item.match.edmunds.block}/{item.match.edmunds.lot}</td>
                                   </>
                                 )}
                                 <td className="px-4 py-2 text-xs font-medium">{d.field}</td>
@@ -661,13 +695,13 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                                 <td className="px-4 py-2 text-xs">{d.copilot}</td>
                                 <td className="px-4 py-2 text-xs">{(d.similarity * 100).toFixed(0)}%</td>
                                 {didx === 0 && (
-                                  <td className="px-4 py-2" rowSpan={match.discrepancies.length}>
+                                  <td className="px-4 py-2" rowSpan={item.filtered.length}>
                                     <span className={`px-2 py-1 rounded text-xs font-medium ${
-                                      match.severity === 'critical'
+                                      item.match.severity === 'critical'
                                         ? 'bg-red-100 text-red-800'
                                         : 'bg-yellow-100 text-yellow-800'
                                     }`}>
-                                      {match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
+                                      {item.match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
                                     </span>
                                   </td>
                                 )}

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -7,7 +7,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [scanResults, setScanResults] = useState(null);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
-  const [activeResultTab, setActiveResultTab] = useState('matches'); // matches, discrepancies, ghosts
+  const [activeResultTab, setActiveResultTab] = useState('discrepancies'); // matches, discrepancies, ghosts
   const [selectedBreakdownField, setSelectedBreakdownField] = useState(null); // Filter by field
   const [sortColumn, setSortColumn] = useState('block'); // Sorting
   const [sortDirection, setSortDirection] = useState('asc');
@@ -527,44 +527,36 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       }
     };
 
-    // Summary sheet
-    const summaryData = [
-      { Metric: 'Total Edmunds Records', Value: scanResults.totalEdmunds },
-      { Metric: 'Exact Matches (No Issues)', Value: scanResults.exactMatches },
-      { Metric: 'Discrepancies Found', Value: scanResults.discrepancies },
-      { Metric: 'Ghost Records', Value: scanResults.ghosts },
-      { Metric: 'Scan Date', Value: new Date(scanResults.timestamp).toLocaleString() }
-    ];
-    const summarySheet = XLSX.utils.json_to_sheet(summaryData);
-    summarySheet['!cols'] = [{ wch: 35 }, { wch: 20 }];
-    XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary', 0);
-
-    // Discrepancies sheet
-    const discrepanciesData = scanResults.detailedDiscrepancies.map(match => ({
-      'Block': match.edmunds.block,
-      'Lot': match.edmunds.lot,
-      'Qualifier': match.edmunds.qualifier || '-',
-      'Status': match.severity === 'critical' ? 'REVIEW' : 'FUZZY',
-      'Issue': match.discrepancies.map(d => `${d.field}`).join('; '),
-      'Your Value': match.discrepancies.map(d => `${d.field}: ${d.copilot}`).join(' | '),
-      'Edmunds Value': match.discrepancies.map(d => `${d.field}: ${d.edmunds}`).join(' | ')
-    }));
+    // Discrepancies sheet - expanded with separate columns for each field
+    const discrepanciesData = scanResults.detailedDiscrepancies.flatMap(match =>
+      match.discrepancies.map(disc => ({
+        'Block': match.edmunds.block,
+        'Lot': match.edmunds.lot,
+        'Qualifier': match.edmunds.qualifier,
+        'Field': disc.field,
+        'Status': disc.severity === 'critical' ? 'REVIEW' : 'FUZZY',
+        'MOD IV Value': disc.copilot,
+        'Edmunds Value': disc.edmunds,
+        'Match %': `${(disc.similarity * 100).toFixed(0)}%`
+      }))
+    );
 
     const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
     discSheet['!cols'] = [
       { wch: 10 },  // Block
       { wch: 10 },  // Lot
       { wch: 12 },  // Qualifier
+      { wch: 20 },  // Field
       { wch: 12 },  // Status
-      { wch: 25 },  // Issue
-      { wch: 35 },  // Your Value
-      { wch: 35 }   // Edmunds Value
+      { wch: 35 },  // MOD IV Value
+      { wch: 35 },  // Edmunds Value
+      { wch: 10 }   // Match %
     ];
 
     // Apply styling to discrepancy sheet
     Object.keys(discSheet).forEach(cell => {
       if (cell.startsWith('!')) return;
-      if (cell.match(/^[A-G]1$/)) {
+      if (cell.match(/^[A-H]1$/)) {
         discSheet[cell].s = headerStyle;
       } else {
         discSheet[cell].s = cellStyle;
@@ -577,7 +569,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const phantomData = scanResults.detailedGhosts.map(ghost => ({
       'Block': ghost.edmunds.block,
       'Lot': ghost.edmunds.lot,
-      'Qualifier': ghost.edmunds.qualifier || '-',
+      'Qualifier': ghost.edmunds.qualifier,
       'Category': ghost.category,
       'Edmunds Owner': ghost.edmunds.owner,
       'Edmunds Address': ghost.edmunds.property_location,
@@ -613,6 +605,29 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     });
 
     XLSX.utils.book_append_sheet(workbook, phantomSheet, 'Phantom Properties');
+
+    // Summary sheet - added last
+    const summaryData = [
+      { Metric: 'Total Edmunds Records', Value: scanResults.totalEdmunds },
+      { Metric: 'Exact Matches (No Issues)', Value: scanResults.exactMatches },
+      { Metric: 'Discrepancies Found', Value: scanResults.discrepancies },
+      { Metric: 'Ghost Records', Value: scanResults.ghosts },
+      { Metric: 'Scan Date', Value: new Date(scanResults.timestamp).toLocaleString() }
+    ];
+    const summarySheet = XLSX.utils.json_to_sheet(summaryData);
+    summarySheet['!cols'] = [{ wch: 35 }, { wch: 20 }];
+
+    // Apply styling to summary sheet
+    Object.keys(summarySheet).forEach(cell => {
+      if (cell.startsWith('!')) return;
+      if (cell.match(/^[A-B]1$/)) {
+        summarySheet[cell].s = headerStyle;
+      } else {
+        summarySheet[cell].s = cellStyle;
+      }
+    });
+
+    XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary');
 
     XLSX.writeFile(workbook, `Edmunds-Reconciliation-${jobData?.job_name || 'Job'}-${new Date().toISOString().split('T')[0]}.xlsx`);
   };

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -1,0 +1,508 @@
+import React, { useState } from 'react';
+import { Download, AlertCircle, CheckCircle, AlertTriangle, X } from 'lucide-react';
+import * as XLSX from 'xlsx';
+import { supabase } from '../../lib/supabaseClient';
+
+const EdmundsSyncTab = ({ jobData, properties = [] }) => {
+  const [isUploading, setIsUploading] = useState(false);
+  const [scanResults, setScanResults] = useState(null);
+  const [error, setError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+
+  // Fuzzy string matching
+  const stringSimilarity = (str1, str2) => {
+    if (!str1 || !str2) return 0;
+    const s1 = String(str1).toUpperCase().trim();
+    const s2 = String(str2).toUpperCase().trim();
+    if (s1 === s2) return 1;
+
+    const longer = s1.length > s2.length ? s1 : s2;
+    const shorter = s1.length > s2.length ? s2 : s1;
+    if (longer.length === 0) return 1;
+
+    const editDistance = getEditDistance(longer, shorter);
+    return (longer.length - editDistance) / longer.length;
+  };
+
+  const getEditDistance = (s1, s2) => {
+    const costs = [];
+    for (let i = 0; i <= s1.length; i++) {
+      let lastValue = i;
+      for (let j = 0; j <= s2.length; j++) {
+        if (i === 0) {
+          costs[j] = j;
+        } else if (j > 0) {
+          let newValue = costs[j - 1];
+          if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
+            newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+          }
+          costs[j - 1] = lastValue;
+          lastValue = newValue;
+        }
+      }
+      if (i > 0) costs[s2.length] = lastValue;
+    }
+    return costs[s2.length];
+  };
+
+  // Get primary card indicator based on vendor
+  const getPrimaryCardIndicator = () => {
+    if (jobData?.vendor_type === 'Microsystems') return 'M';
+    return '1'; // BRT default
+  };
+
+  // Filter to primary cards only
+  const getPrimaryProperties = () => {
+    const primaryCard = getPrimaryCardIndicator();
+    return properties.filter(p => {
+      const card = (p.property_card || p.property_addl_card || '').toString().trim().toUpperCase();
+      return card === primaryCard || !card; // Include records with no card indicator
+    });
+  };
+
+  // Detect if lot is subdivided (e.g., lot "1" split into "1.01", "1.02")
+  const checkSubdivision = (edmundsBlock, edmundsLot, copilotProps) => {
+    const edmundsLotStr = String(edmundsLot).trim();
+    const matches = copilotProps.filter(p => {
+      const pBlock = String(p.property_block || '').trim();
+      const pLot = String(p.property_lot || '').trim();
+      return pBlock === edmundsBlock && pLot.startsWith(edmundsLotStr + '.');
+    });
+    return matches.length > 0 ? matches : null;
+  };
+
+  // Check if lot exists as additional card
+  const checkAdditionalCard = (edmundsBlock, edmundsLot, edmundsQual) => {
+    const allPropsForLot = properties.filter(p => {
+      const pBlock = String(p.property_block || '').trim();
+      const pLot = String(p.property_lot || '').trim();
+      return pBlock === edmundsBlock && pLot === edmundsLot;
+    });
+    return allPropsForLot.length > 0 ? allPropsForLot : null;
+  };
+
+  // Categorize ghost records
+  const categorizeGhost = (edmundsRecord, allProps, primaryProps) => {
+    const { block, lot, qualifier } = edmundsRecord;
+    const blockStr = String(block || '').trim();
+    const lotStr = String(lot || '').trim();
+
+    // Check for subdivisions
+    const subdivisions = checkSubdivision(blockStr, lotStr, primaryProps);
+    if (subdivisions) {
+      return {
+        category: 'Subdivided',
+        details: `Lot became: ${subdivisions.map(p => `${p.property_lot}.${p.property_qualifier || ''}`).join(', ')}`
+      };
+    }
+
+    // Check for additional cards
+    const additionalCards = checkAdditionalCard(blockStr, lotStr, qualifier);
+    if (additionalCards && additionalCards.length > 0) {
+      const nonPrimary = additionalCards.filter(p => {
+        const card = (p.property_card || p.property_addl_card || '').toString().trim();
+        const primaryCard = getPrimaryCardIndicator();
+        return card !== primaryCard && card;
+      });
+      if (nonPrimary.length > 0) {
+        return {
+          category: 'Additional Lot',
+          details: `Exists as additional card(s): ${nonPrimary.map(p => `${p.property_block}/${p.property_lot}.${p.property_qualifier || ''}`).join(', ')}`
+        };
+      }
+    }
+
+    // Check if bad block/lot
+    const similarLots = allProps.filter(p => {
+      const pBlock = String(p.property_block || '').trim();
+      const pLot = String(p.property_lot || '').trim();
+      return stringSimilarity(pBlock, blockStr) > 0.7 || stringSimilarity(pLot, lotStr) > 0.7;
+    });
+
+    if (similarLots.length > 0) {
+      return {
+        category: 'Potential Match',
+        details: `Similar lots exist: ${similarLots.slice(0, 2).map(p => `${p.property_block}/${p.property_lot}`).join(', ')}`
+      };
+    }
+
+    return { category: 'Bad Block/Lot', details: 'No matching or similar records found' };
+  };
+
+  // Compare fields and find discrepancies
+  const compareRecords = (edmundsRecord, copilotRecord) => {
+    const discrepancies = [];
+    const fieldMap = {
+      owner: ['owner', 'owner_name'],
+      address: ['property_location', 'owner_street'],
+      city: ['owner_csz'],
+      zip: ['owner_csz'],
+      class: ['property_m4_class']
+    };
+
+    // Owner comparison
+    const edmundsOwner = (edmundsRecord.owner || '').toString().trim();
+    const copilotOwner = (copilotRecord.owner_name || '').toString().trim();
+    const ownerSim = stringSimilarity(edmundsOwner, copilotOwner);
+    if (ownerSim < 0.95 && edmundsOwner && copilotOwner) {
+      discrepancies.push({
+        field: 'owner',
+        edmunds: edmundsOwner,
+        copilot: copilotOwner,
+        similarity: ownerSim,
+        severity: ownerSim < 0.7 ? 'critical' : 'fuzzy'
+      });
+    }
+
+    // Address comparison
+    const edmundsAddr = (edmundsRecord.property_location || '').toString().trim();
+    const copilotAddr = (copilotRecord.property_location || '').toString().trim();
+    const addrSim = stringSimilarity(edmundsAddr, copilotAddr);
+    if (addrSim < 0.95 && edmundsAddr && copilotAddr) {
+      discrepancies.push({
+        field: 'address',
+        edmunds: edmundsAddr,
+        copilot: copilotAddr,
+        similarity: addrSim,
+        severity: addrSim < 0.7 ? 'critical' : 'fuzzy'
+      });
+    }
+
+    // Class comparison
+    const edmundsClass = (edmundsRecord.property_m4_class || '').toString().trim();
+    const copilotClass = (copilotRecord.property_m4_class || '').toString().trim();
+    if (edmundsClass && copilotClass && edmundsClass !== copilotClass) {
+      discrepancies.push({
+        field: 'class',
+        edmunds: edmundsClass,
+        copilot: copilotClass,
+        similarity: 0,
+        severity: 'critical'
+      });
+    }
+
+    return discrepancies;
+  };
+
+  const handleFileUpload = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    setError(null);
+    setScanResults(null);
+
+    try {
+      const workbook = XLSX.read(await file.arrayBuffer());
+      const sheetName = workbook.SheetNames[0];
+      const worksheet = workbook.Sheets[sheetName];
+      const data = XLSX.utils.sheet_to_json(worksheet);
+
+      if (data.length === 0) {
+        setError('No data found in Excel file');
+        setIsUploading(false);
+        return;
+      }
+
+      // Parse Edmunds records
+      const edmundsRecords = data.map(row => ({
+        block: row['Block'] || row['block'] || row['BLOCK'],
+        lot: row['Lot'] || row['lot'] || row['LOT'],
+        qualifier: row['Qualifier'] || row['qualifier'] || row['QUALIFIER'] || '',
+        owner: row['Owner'] || row['owner'] || row['OWNER'],
+        property_location: row['Property Location'] || row['property_location'] || row['Address'] || row['address'],
+        owner_street: row['Owner Address'] || row['owner_address'] || row['owner street'],
+        owner_city: row['Owner City'] || row['owner_city'] || row['City'],
+        state: row['State'] || row['state'],
+        zip: row['Zip'] || row['zip'],
+        property_m4_class: row['Class'] || row['class'] || row['M4 Class']
+      })).filter(r => r.block && r.lot);
+
+      const primaryCopilot = getPrimaryProperties();
+      const allCopilot = properties;
+
+      // Build composite key map for Copilot
+      const copilotMap = new Map();
+      primaryCopilot.forEach(p => {
+        const key = `${p.property_block}_${p.property_lot}_${p.property_qualifier || ''}`.trim();
+        copilotMap.set(key, p);
+      });
+
+      // Match records
+      const exactMatches = [];
+      const fuzzyMatches = [];
+      const ghostRecords = [];
+
+      edmundsRecords.forEach(edmundsRec => {
+        const blockStr = String(edmundsRec.block || '').trim();
+        const lotStr = String(edmundsRec.lot || '').trim();
+        const qualStr = String(edmundsRec.qualifier || '').trim();
+        const key = `${blockStr}_${lotStr}_${qualStr}`;
+
+        const copilotRec = copilotMap.get(key);
+
+        if (copilotRec) {
+          // Exact match exists
+          const discrepancies = compareRecords(edmundsRec, copilotRec);
+          if (discrepancies.length === 0) {
+            exactMatches.push({
+              type: 'exact',
+              edmunds: edmundsRec,
+              copilot: copilotRec,
+              discrepancies: []
+            });
+          } else {
+            const hasCritical = discrepancies.some(d => d.severity === 'critical');
+            (hasCritical ? fuzzyMatches : fuzzyMatches).push({
+              type: 'discrepancy',
+              edmunds: edmundsRec,
+              copilot: copilotRec,
+              discrepancies,
+              severity: hasCritical ? 'critical' : 'fuzzy'
+            });
+          }
+        } else {
+          // Ghost record
+          const categorized = categorizeGhost(edmundsRec, allCopilot, primaryCopilot);
+          ghostRecords.push({
+            type: 'ghost',
+            edmunds: edmundsRec,
+            ...categorized
+          });
+        }
+      });
+
+      setScanResults({
+        totalEdmunds: edmundsRecords.length,
+        exactMatches: exactMatches.length,
+        discrepancies: fuzzyMatches.length,
+        ghosts: ghostRecords.length,
+        detailedMatches: exactMatches,
+        detailedDiscrepancies: fuzzyMatches,
+        detailedGhosts: ghostRecords,
+        timestamp: new Date().toISOString()
+      });
+
+      setSuccessMessage(`Scanned ${edmundsRecords.length} Edmunds records`);
+    } catch (err) {
+      console.error('Error parsing file:', err);
+      setError(`Failed to parse file: ${err.message}`);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const exportReport = () => {
+    if (!scanResults) return;
+
+    const workbook = XLSX.utils.book_new();
+
+    // Discrepancies sheet
+    const discrepanciesData = scanResults.detailedDiscrepancies.map(match => ({
+      'Block': match.edmunds.block,
+      'Lot': match.edmunds.lot,
+      'Qualifier': match.edmunds.qualifier,
+      'Status': match.severity === 'critical' ? 'REVIEW' : 'FUZZY',
+      'Issue': match.discrepancies.map(d => `${d.field}`).join('; '),
+      'Your Value': match.discrepancies.map(d => `${d.field}: ${d.copilot}`).join(' | '),
+      'Edmunds Value': match.discrepancies.map(d => `${d.field}: ${d.edmunds}`).join(' | ')
+    }));
+
+    const discSheet = XLSX.utils.json_to_sheet(discrepanciesData);
+    XLSX.utils.book_append_sheet(workbook, discSheet, 'Discrepancies');
+
+    // Phantom Properties sheet
+    const phantomData = scanResults.detailedGhosts.map(ghost => ({
+      'Block': ghost.edmunds.block,
+      'Lot': ghost.edmunds.lot,
+      'Qualifier': ghost.edmunds.qualifier,
+      'Category': ghost.category,
+      'Details': ghost.details,
+      'Edmunds Owner': ghost.edmunds.owner,
+      'Recommended Action': ghost.category === 'Subdivided' ? 'Update lot numbers' : ghost.category === 'Additional Lot' ? 'Already exists as additional card' : 'Review and delete if invalid'
+    }));
+
+    const phantomSheet = XLSX.utils.json_to_sheet(phantomData);
+    XLSX.utils.book_append_sheet(workbook, phantomSheet, 'Phantom Properties');
+
+    // Summary sheet
+    const summaryData = [
+      { Metric: 'Total Edmunds Records', Value: scanResults.totalEdmunds },
+      { Metric: 'Exact Matches (No Issues)', Value: scanResults.exactMatches },
+      { Metric: 'Discrepancies Found', Value: scanResults.discrepancies },
+      { Metric: 'Ghost Records', Value: scanResults.ghosts },
+      { Metric: 'Scan Date', Value: new Date(scanResults.timestamp).toLocaleString() }
+    ];
+
+    const summarySheet = XLSX.utils.json_to_sheet(summaryData);
+    XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary', 0);
+
+    XLSX.writeFile(workbook, `Edmunds-Reconciliation-${jobData?.job_name || 'Job'}-${new Date().toISOString().split('T')[0]}.xlsx`);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-blue-50 to-cyan-50 rounded-lg border-2 border-blue-200 p-6">
+        <div className="flex items-center mb-3">
+          <AlertCircle className="w-8 h-8 mr-3 text-blue-600" />
+          <h2 className="text-2xl font-bold text-gray-800">🔄 Edmunds Sync & Reconciliation</h2>
+        </div>
+        <p className="text-gray-600">Import Edmunds collector data and reconcile against your property records. Identify mismatches, ghost records, and data quality issues.</p>
+      </div>
+
+      {/* Error Messages */}
+      {error && (
+        <div className="bg-red-50 border border-red-300 rounded-lg p-4 flex items-start gap-3">
+          <X className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-semibold text-red-800">Error</h3>
+            <p className="text-red-700 text-sm">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Success Messages */}
+      {successMessage && (
+        <div className="bg-green-50 border border-green-300 rounded-lg p-4 flex items-start gap-3">
+          <CheckCircle className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-green-700 font-medium">{successMessage}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Upload Section */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">Step 1: Upload Edmunds Data</h3>
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Upload the Edmunds Excel file with columns: Block, Lot, Qualifier, Owner, Property Location, Owner Address, City, State, Zip, Class
+          </p>
+          <div className="flex items-center gap-4">
+            <input
+              type="file"
+              id="edmunds-file"
+              accept=".xlsx,.xls,.csv"
+              onChange={handleFileUpload}
+              disabled={isUploading}
+              className="block w-full text-sm text-gray-500
+                file:mr-4 file:py-2 file:px-4
+                file:rounded-lg file:border-0
+                file:text-sm file:font-medium
+                file:bg-blue-50 file:text-blue-700
+                hover:file:bg-blue-100"
+            />
+            {isUploading && <span className="text-gray-600">Processing...</span>}
+          </div>
+        </div>
+      </div>
+
+      {/* Results Section */}
+      {scanResults && (
+        <div className="space-y-6">
+          {/* Summary Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <div className="text-3xl font-bold text-blue-600">{scanResults.totalEdmunds}</div>
+              <div className="text-sm text-gray-600 mt-1">Total Edmunds Records</div>
+            </div>
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <div className="text-3xl font-bold text-green-600">{scanResults.exactMatches}</div>
+              <div className="text-sm text-gray-600 mt-1">Exact Matches</div>
+            </div>
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <div className="text-3xl font-bold text-yellow-600">{scanResults.discrepancies}</div>
+              <div className="text-sm text-gray-600 mt-1">Discrepancies</div>
+            </div>
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <div className="text-3xl font-bold text-red-600">{scanResults.ghosts}</div>
+              <div className="text-sm text-gray-600 mt-1">Ghost Records</div>
+            </div>
+          </div>
+
+          {/* Discrepancies */}
+          {scanResults.discrepancies > 0 && (
+            <div className="bg-white rounded-lg border border-gray-200 p-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
+                <AlertTriangle className="w-5 h-5 text-yellow-600" />
+                Discrepancies Found ({scanResults.discrepancies})
+              </h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Block</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Lot</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Issues</th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-700">Severity</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {scanResults.detailedDiscrepancies.slice(0, 10).map((match, idx) => (
+                      <tr key={idx} className="border-t hover:bg-gray-50">
+                        <td className="px-4 py-2">{match.edmunds.block}</td>
+                        <td className="px-4 py-2">{match.edmunds.lot}</td>
+                        <td className="px-4 py-2 text-xs">
+                          {match.discrepancies.map(d => d.field).join(', ')}
+                        </td>
+                        <td className="px-4 py-2">
+                          <span className={`px-2 py-1 rounded text-xs font-medium ${
+                            match.severity === 'critical'
+                              ? 'bg-red-100 text-red-800'
+                              : 'bg-yellow-100 text-yellow-800'
+                          }`}>
+                            {match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Ghost Records */}
+          {scanResults.ghosts > 0 && (
+            <div className="bg-white rounded-lg border border-gray-200 p-6">
+              <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
+                <AlertCircle className="w-5 h-5 text-red-600" />
+                Phantom Properties ({scanResults.ghosts})
+              </h3>
+              <div className="space-y-3">
+                {scanResults.detailedGhosts.slice(0, 10).map((ghost, idx) => (
+                  <div key={idx} className="bg-red-50 rounded-lg p-3 border border-red-200">
+                    <div className="flex justify-between items-start">
+                      <div>
+                        <div className="font-medium text-gray-800">{ghost.edmunds.block}/{ghost.edmunds.lot}</div>
+                        <div className="text-sm text-gray-600 mt-1">{ghost.edmunds.owner}</div>
+                        <div className="text-xs text-gray-500 mt-1">{ghost.details}</div>
+                      </div>
+                      <span className="px-2 py-1 rounded text-xs font-medium bg-red-100 text-red-800">
+                        {ghost.category}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Export Button */}
+          <div className="flex justify-end">
+            <button
+              onClick={exportReport}
+              className="flex items-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium transition-all"
+            >
+              <Download className="w-4 h-4" />
+              Export Report for Collector
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EdmundsSyncTab;

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Download, AlertCircle, CheckCircle, X } from 'lucide-react';
-import * as XLSX from 'xlsx';
+import * as XLSX from 'xlsx-js-style';
 
 const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [isUploading, setIsUploading] = useState(false);

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -129,24 +129,23 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
-  // Parse owner_csz field (format: "City, ST ZIP" but can vary)
+  // Parse owner_csz field (formats: "City, ST ZIP" or "City ST ZIP")
   const parseCsz = (csz) => {
     if (!csz) return { city: '', state: '', zip: '' };
     const str = String(csz).trim();
-    const parts = str.split(',').map(p => p.trim());
-    let city = parts[0] || '';
-    let stateZip = parts[1] || '';
 
-    // Parse state and zip from "ST ZIP" or "ST  ZIP" (with extra spaces)
-    const stateZipMatch = stateZip.match(/([A-Z]{2})\s+(\d{5})/i);
-    let state = '';
-    let zip = '';
+    // Try to match state and zip at the end: "XX ##### " or "XX-#### "
+    const stateZipMatch = str.match(/([A-Z]{2})\s+([\d\-]{5,10})\s*$/i);
+
     if (stateZipMatch) {
-      state = stateZipMatch[1].toUpperCase();
-      zip = stateZipMatch[2];
+      const state = stateZipMatch[1].toUpperCase();
+      const zip = stateZipMatch[2];
+      // Everything before state/zip is the city (remove trailing spaces and commas)
+      const city = str.substring(0, stateZipMatch.index).trim().replace(/,\s*$/, '').trim();
+      return { city, state, zip };
     }
 
-    return { city, state, zip };
+    return { city: str, state: '', zip: '' };
   };
 
   // Compare fields and find discrepancies — FLAG ANYTHING THAT ISN'T EXACT

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -128,103 +128,148 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
+  // Parse owner_csz field (format: "City, ST ZIP" but can vary)
+  const parseCsz = (csz) => {
+    if (!csz) return { city: '', state: '', zip: '' };
+    const str = String(csz).trim();
+    const parts = str.split(',').map(p => p.trim());
+    let city = parts[0] || '';
+    let stateZip = parts[1] || '';
+
+    // Parse state and zip from "ST ZIP" or "ST  ZIP" (with extra spaces)
+    const stateZipMatch = stateZip.match(/([A-Z]{2})\s+(\d{5})/i);
+    let state = '';
+    let zip = '';
+    if (stateZipMatch) {
+      state = stateZipMatch[1].toUpperCase();
+      zip = stateZipMatch[2];
+    }
+
+    return { city, state, zip };
+  };
+
   // Compare fields and find discrepancies
   const compareRecords = (edmundsRecord, copilotRecord) => {
     const discrepancies = [];
 
-    // Owner comparison
+    // Owner comparison — flag if different OR if one is missing
     const edmundsOwner = (edmundsRecord.owner || '').toString().trim();
     const copilotOwner = (copilotRecord.owner_name || '').toString().trim();
-    const ownerSim = stringSimilarity(edmundsOwner, copilotOwner);
-    if (ownerSim < 0.95 && edmundsOwner && copilotOwner) {
-      discrepancies.push({
-        field: 'owner',
-        edmunds: edmundsOwner,
-        copilot: copilotOwner,
-        similarity: ownerSim,
-        severity: ownerSim < 0.7 ? 'critical' : 'fuzzy'
-      });
+    if (edmundsOwner || copilotOwner) {
+      if (!edmundsOwner || !copilotOwner || edmundsOwner !== copilotOwner) {
+        const ownerSim = stringSimilarity(edmundsOwner, copilotOwner);
+        if (ownerSim < 0.92) { // Lowered from 0.95 to catch typos
+          discrepancies.push({
+            field: 'owner',
+            edmunds: edmundsOwner || '(empty)',
+            copilot: copilotOwner || '(empty)',
+            similarity: ownerSim,
+            severity: ownerSim < 0.7 ? 'critical' : 'fuzzy'
+          });
+        }
+      }
     }
 
     // Property Location comparison
     const edmundsAddr = (edmundsRecord.property_location || '').toString().trim();
     const copilotAddr = (copilotRecord.property_location || '').toString().trim();
-    const addrSim = stringSimilarity(edmundsAddr, copilotAddr);
-    if (addrSim < 0.95 && edmundsAddr && copilotAddr) {
-      discrepancies.push({
-        field: 'property_location',
-        edmunds: edmundsAddr,
-        copilot: copilotAddr,
-        similarity: addrSim,
-        severity: addrSim < 0.7 ? 'critical' : 'fuzzy'
-      });
+    if (edmundsAddr || copilotAddr) {
+      if (!edmundsAddr || !copilotAddr || edmundsAddr !== copilotAddr) {
+        const addrSim = stringSimilarity(edmundsAddr, copilotAddr);
+        if (addrSim < 0.92) {
+          discrepancies.push({
+            field: 'property_location',
+            edmunds: edmundsAddr || '(empty)',
+            copilot: copilotAddr || '(empty)',
+            similarity: addrSim,
+            severity: addrSim < 0.7 ? 'critical' : 'fuzzy'
+          });
+        }
+      }
     }
 
     // Owner Address comparison
     const edmundsOwnerAddr = (edmundsRecord.owner_street || '').toString().trim();
     const copilotOwnerAddr = (copilotRecord.owner_street || '').toString().trim();
-    const ownerAddrSim = stringSimilarity(edmundsOwnerAddr, copilotOwnerAddr);
-    if (ownerAddrSim < 0.95 && edmundsOwnerAddr && copilotOwnerAddr) {
-      discrepancies.push({
-        field: 'owner_address',
-        edmunds: edmundsOwnerAddr,
-        copilot: copilotOwnerAddr,
-        similarity: ownerAddrSim,
-        severity: ownerAddrSim < 0.7 ? 'critical' : 'fuzzy'
-      });
+    if (edmundsOwnerAddr || copilotOwnerAddr) {
+      if (!edmundsOwnerAddr || !copilotOwnerAddr || edmundsOwnerAddr !== copilotOwnerAddr) {
+        const ownerAddrSim = stringSimilarity(edmundsOwnerAddr, copilotOwnerAddr);
+        if (ownerAddrSim < 0.92) {
+          discrepancies.push({
+            field: 'owner_address',
+            edmunds: edmundsOwnerAddr || '(empty)',
+            copilot: copilotOwnerAddr || '(empty)',
+            similarity: ownerAddrSim,
+            severity: ownerAddrSim < 0.7 ? 'critical' : 'fuzzy'
+          });
+        }
+      }
     }
+
+    // Parse Copilot owner_csz field
+    const parsedCopilot = parseCsz(copilotRecord.owner_csz);
 
     // Owner City comparison
     const edmundsCity = (edmundsRecord.owner_city || '').toString().trim();
-    const copilotCity = (copilotRecord.owner_csz || '').toString().trim().split(',')[0] || ''; // Extract city from csz
-    const citySim = stringSimilarity(edmundsCity, copilotCity);
-    if (citySim < 0.95 && edmundsCity && copilotCity) {
-      discrepancies.push({
-        field: 'owner_city',
-        edmunds: edmundsCity,
-        copilot: copilotCity,
-        similarity: citySim,
-        severity: citySim < 0.7 ? 'critical' : 'fuzzy'
-      });
+    const copilotCity = parsedCopilot.city;
+    if (edmundsCity || copilotCity) {
+      if (!edmundsCity || !copilotCity || edmundsCity !== copilotCity) {
+        const citySim = stringSimilarity(edmundsCity, copilotCity);
+        if (citySim < 0.92) {
+          discrepancies.push({
+            field: 'owner_city',
+            edmunds: edmundsCity || '(empty)',
+            copilot: copilotCity || '(empty)',
+            similarity: citySim,
+            severity: citySim < 0.7 ? 'critical' : 'fuzzy'
+          });
+        }
+      }
     }
 
-    // State comparison
-    const edmundsState = (edmundsRecord.state || '').toString().trim();
-    const copilotState = (copilotRecord.owner_csz || '').toString().trim().split(',')[1]?.trim().split(' ')[0] || ''; // Extract state from csz
-    if (edmundsState && copilotState && edmundsState.toUpperCase() !== copilotState.toUpperCase()) {
-      discrepancies.push({
-        field: 'state',
-        edmunds: edmundsState,
-        copilot: copilotState,
-        similarity: 0,
-        severity: 'critical'
-      });
+    // State comparison (normalize format: "NJ" vs "N J")
+    const edmundsState = (edmundsRecord.state || '').toString().trim().toUpperCase().replace(/\s+/g, '');
+    const copilotState = parsedCopilot.state;
+    if (edmundsState || copilotState) {
+      if (!edmundsState || !copilotState || edmundsState !== copilotState) {
+        discrepancies.push({
+          field: 'state',
+          edmunds: edmundsState || '(empty)',
+          copilot: copilotState || '(empty)',
+          similarity: edmundsState === copilotState ? 1 : 0,
+          severity: 'critical'
+        });
+      }
     }
 
     // ZIP comparison
     const edmundsZip = (edmundsRecord.zip || '').toString().trim();
-    const copilotZip = (copilotRecord.owner_csz || '').toString().trim().split(' ').pop() || ''; // Extract zip from csz
-    if (edmundsZip && copilotZip && edmundsZip !== copilotZip) {
-      discrepancies.push({
-        field: 'zip',
-        edmunds: edmundsZip,
-        copilot: copilotZip,
-        similarity: 0,
-        severity: 'critical'
-      });
+    const copilotZip = parsedCopilot.zip;
+    if (edmundsZip || copilotZip) {
+      if (!edmundsZip || !copilotZip || edmundsZip !== copilotZip) {
+        discrepancies.push({
+          field: 'zip',
+          edmunds: edmundsZip || '(empty)',
+          copilot: copilotZip || '(empty)',
+          similarity: edmundsZip === copilotZip ? 1 : 0,
+          severity: 'critical'
+        });
+      }
     }
 
     // Class comparison
     const edmundsClass = (edmundsRecord.property_m4_class || '').toString().trim();
     const copilotClass = (copilotRecord.property_m4_class || '').toString().trim();
-    if (edmundsClass && copilotClass && edmundsClass !== copilotClass) {
-      discrepancies.push({
-        field: 'property_class',
-        edmunds: edmundsClass,
-        copilot: copilotClass,
-        similarity: 0,
-        severity: 'critical'
-      });
+    if (edmundsClass || copilotClass) {
+      if (!edmundsClass || !copilotClass || edmundsClass !== copilotClass) {
+        discrepancies.push({
+          field: 'property_class',
+          edmunds: edmundsClass || '(empty)',
+          copilot: copilotClass || '(empty)',
+          similarity: edmundsClass === copilotClass ? 1 : 0,
+          severity: 'critical'
+        });
+      }
     }
 
     return discrepancies;

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -128,23 +128,40 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
-  // Parse Copilot's owner_csz field (format: "City State Zip" or "City, State Zip")
+  // Parse Copilot's owner_csz field: split on comma or double space
+  // "RIVERTON, N J 08077" → city: "RIVERTON", state: "NJ", zip: "08077"
   const parseCszCopilot = (csz) => {
     if (!csz) return { city: '', state: '', zip: '' };
     const str = String(csz).trim();
 
-    // Try to match state and zip at the end: "XX ##### " or "XX-#####"
-    const stateZipMatch = str.match(/([A-Z]{2})\s+([\d\-]{5,10})\s*$/i);
+    let remainder = str;
+    let city = '';
 
-    if (stateZipMatch) {
-      const state = stateZipMatch[1].toUpperCase();
-      const zip = stateZipMatch[2];
-      // Everything before state/zip is the city (remove trailing spaces and commas)
-      const city = str.substring(0, stateZipMatch.index).trim().replace(/,\s*$/, '').trim();
+    // Split on comma first
+    if (str.includes(',')) {
+      const parts = str.split(',').map(p => p.trim());
+      city = parts[0];
+      remainder = parts[1] || '';
+    } else if (str.includes('  ')) {
+      // Split on double space
+      const parts = str.split(/\s{2,}/).map(p => p.trim());
+      city = parts[0];
+      remainder = parts[1] || '';
+    } else {
+      // No separator, whole thing is city
+      return { city: str, state: '', zip: '' };
+    }
+
+    // From remainder, extract ZIP (ends with digits) and state (before ZIP)
+    const zipMatch = remainder.match(/([A-Z\s]+?)\s+([\d\-]{5,10})\s*$/i);
+    if (zipMatch) {
+      const state = zipMatch[1].trim().replace(/\s+/g, ''); // Normalize spaces
+      const zip = zipMatch[2];
       return { city, state, zip };
     }
 
-    return { city: str, state: '', zip: '' };
+    // If no ZIP found, everything is state
+    return { city, state: remainder.replace(/\s+/g, ''), zip: '' };
   };
 
   // Parse Edmunds owner_city: split on comma or double space

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -128,40 +128,34 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
-  // Parse Copilot's owner_csz field: split on comma or double space
+  // Parse Copilot's owner_csz field: handle various formats
+  // "RIVERTON NJ 08077" → city: "RIVERTON", state: "NJ", zip: "08077"
   // "RIVERTON, N J 08077" → city: "RIVERTON", state: "NJ", zip: "08077"
   const parseCszCopilot = (csz) => {
     if (!csz) return { city: '', state: '', zip: '' };
     const str = String(csz).trim();
 
-    let remainder = str;
-    let city = '';
-
-    // Split on comma first
-    if (str.includes(',')) {
-      const parts = str.split(',').map(p => p.trim());
-      city = parts[0];
-      remainder = parts[1] || '';
-    } else if (str.includes('  ')) {
-      // Split on double space
-      const parts = str.split(/\s{2,}/).map(p => p.trim());
-      city = parts[0];
-      remainder = parts[1] || '';
-    } else {
-      // No separator, whole thing is city
+    // Try to extract ZIP from the end first (5 or 9 digits)
+    const zipMatch = str.match(/([\d\-]{5,10})\s*$/);
+    if (!zipMatch) {
+      // No ZIP, treat whole thing as city or return empty
       return { city: str, state: '', zip: '' };
     }
 
-    // From remainder, extract ZIP (ends with digits) and state (before ZIP)
-    const zipMatch = remainder.match(/([A-Z\s]+?)\s+([\d\-]{5,10})\s*$/i);
-    if (zipMatch) {
-      const state = zipMatch[1].trim().replace(/\s+/g, ''); // Normalize spaces
-      const zip = zipMatch[2];
+    const zip = zipMatch[1];
+    const beforeZip = str.substring(0, zipMatch.index).trim();
+
+    // Now extract state and city from beforeZip
+    // State is the last 1-2 letters (possibly with space like "N J")
+    const stateMatch = beforeZip.match(/([A-Z])(?:\s+([A-Z]))?\s*$/i);
+    if (stateMatch) {
+      const state = (stateMatch[1] + (stateMatch[2] ? stateMatch[2] : '')).toUpperCase();
+      const city = beforeZip.substring(0, stateMatch.index).trim().replace(/,\s*$/, '').trim();
       return { city, state, zip };
     }
 
-    // If no ZIP found, everything is state
-    return { city, state: remainder.replace(/\s+/g, ''), zip: '' };
+    // If can't parse state, everything before ZIP is city
+    return { city: beforeZip, state: '', zip };
   };
 
   // Parse Edmunds owner_city: split on comma or double space

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -664,7 +664,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       ['Total Edmunds Records', scanResults.totalEdmunds],
       ['Exact Matches (No Issues)', scanResults.exactMatches],
       ['Discrepancies Found', scanResults.discrepancies],
-      ['Ghost Records', scanResults.ghosts],
+      ['Phantom Properties', scanResults.ghosts],
       ['Scan Date', new Date(scanResults.timestamp).toLocaleString()]
     ];
     const summarySheet = XLSX.utils.aoa_to_sheet(summaryData);
@@ -697,7 +697,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       <div className="bg-gradient-to-r from-blue-50 to-cyan-50 rounded-lg border-2 border-blue-200 p-6">
         <div className="flex items-center mb-3">
           <AlertCircle className="w-8 h-8 mr-3 text-blue-600" />
-          <h2 className="text-2xl font-bold text-gray-800">🔄 Edmunds Sync & Reconciliation</h2>
+          <h2 className="text-2xl font-bold text-gray-800">🔄 Edmunds Audit</h2>
         </div>
         <p className="text-gray-600">Import Edmunds collector data and reconcile against your property records. Identify mismatches, ghost records, and data quality issues.</p>
       </div>
@@ -768,42 +768,51 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
             </div>
             <div className="bg-white rounded-lg border border-gray-200 p-4">
               <div className="text-3xl font-bold text-red-600">{scanResults.ghosts}</div>
-              <div className="text-sm text-gray-600 mt-1">Ghost Records</div>
+              <div className="text-sm text-gray-600 mt-1">Phantom Properties</div>
             </div>
           </div>
 
           {/* Results Tabs */}
           <div className="bg-white rounded-lg border border-gray-200">
-            <div className="border-b border-gray-200 flex">
+            <div className="border-b border-gray-200 flex items-center justify-between">
+              <div className="flex">
+                <button
+                  onClick={() => setActiveResultTab('matches')}
+                  className={`px-6 py-3 font-medium text-sm border-b-2 ${
+                    activeResultTab === 'matches'
+                      ? 'border-blue-500 text-blue-600'
+                      : 'border-transparent text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  ✓ Exact Matches ({scanResults.exactMatches})
+                </button>
+                <button
+                  onClick={() => setActiveResultTab('discrepancies')}
+                  className={`px-6 py-3 font-medium text-sm border-b-2 ${
+                    activeResultTab === 'discrepancies'
+                      ? 'border-blue-500 text-blue-600'
+                      : 'border-transparent text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  ⚠️ Discrepancies ({scanResults.discrepancies})
+                </button>
+                <button
+                  onClick={() => setActiveResultTab('ghosts')}
+                  className={`px-6 py-3 font-medium text-sm border-b-2 ${
+                    activeResultTab === 'ghosts'
+                      ? 'border-blue-500 text-blue-600'
+                      : 'border-transparent text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  👻 Phantom Properties ({scanResults.ghosts})
+                </button>
+              </div>
               <button
-                onClick={() => setActiveResultTab('matches')}
-                className={`px-6 py-3 font-medium text-sm border-b-2 ${
-                  activeResultTab === 'matches'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
-                }`}
+                onClick={exportReport}
+                className="flex items-center gap-2 px-4 py-2 mr-4 bg-green-600 text-white rounded hover:bg-green-700 font-medium text-sm transition-all"
               >
-                ✓ Exact Matches ({scanResults.exactMatches})
-              </button>
-              <button
-                onClick={() => setActiveResultTab('discrepancies')}
-                className={`px-6 py-3 font-medium text-sm border-b-2 ${
-                  activeResultTab === 'discrepancies'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                ⚠️ Discrepancies ({scanResults.discrepancies})
-              </button>
-              <button
-                onClick={() => setActiveResultTab('ghosts')}
-                className={`px-6 py-3 font-medium text-sm border-b-2 ${
-                  activeResultTab === 'ghosts'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
-                }`}
-              >
-                👻 Phantom Properties ({scanResults.ghosts})
+                <Download className="w-4 h-4" />
+                Export
               </button>
             </div>
 
@@ -1044,16 +1053,6 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
             </div>
           </div>
 
-          {/* Export Button */}
-          <div className="flex justify-end">
-            <button
-              onClick={exportReport}
-              className="flex items-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium transition-all"
-            >
-              <Download className="w-4 h-4" />
-              Export Report for Collector
-            </button>
-          </div>
         </div>
       )}
     </div>

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -131,13 +131,6 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   // Compare fields and find discrepancies
   const compareRecords = (edmundsRecord, copilotRecord) => {
     const discrepancies = [];
-    const fieldMap = {
-      owner: ['owner', 'owner_name'],
-      address: ['property_location', 'owner_street'],
-      city: ['owner_csz'],
-      zip: ['owner_csz'],
-      class: ['property_m4_class']
-    };
 
     // Owner comparison
     const edmundsOwner = (edmundsRecord.owner || '').toString().trim();
@@ -153,17 +146,71 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       });
     }
 
-    // Address comparison
+    // Property Location comparison
     const edmundsAddr = (edmundsRecord.property_location || '').toString().trim();
     const copilotAddr = (copilotRecord.property_location || '').toString().trim();
     const addrSim = stringSimilarity(edmundsAddr, copilotAddr);
     if (addrSim < 0.95 && edmundsAddr && copilotAddr) {
       discrepancies.push({
-        field: 'address',
+        field: 'property_location',
         edmunds: edmundsAddr,
         copilot: copilotAddr,
         similarity: addrSim,
         severity: addrSim < 0.7 ? 'critical' : 'fuzzy'
+      });
+    }
+
+    // Owner Address comparison
+    const edmundsOwnerAddr = (edmundsRecord.owner_street || '').toString().trim();
+    const copilotOwnerAddr = (copilotRecord.owner_street || '').toString().trim();
+    const ownerAddrSim = stringSimilarity(edmundsOwnerAddr, copilotOwnerAddr);
+    if (ownerAddrSim < 0.95 && edmundsOwnerAddr && copilotOwnerAddr) {
+      discrepancies.push({
+        field: 'owner_address',
+        edmunds: edmundsOwnerAddr,
+        copilot: copilotOwnerAddr,
+        similarity: ownerAddrSim,
+        severity: ownerAddrSim < 0.7 ? 'critical' : 'fuzzy'
+      });
+    }
+
+    // Owner City comparison
+    const edmundsCity = (edmundsRecord.owner_city || '').toString().trim();
+    const copilotCity = (copilotRecord.owner_csz || '').toString().trim().split(',')[0] || ''; // Extract city from csz
+    const citySim = stringSimilarity(edmundsCity, copilotCity);
+    if (citySim < 0.95 && edmundsCity && copilotCity) {
+      discrepancies.push({
+        field: 'owner_city',
+        edmunds: edmundsCity,
+        copilot: copilotCity,
+        similarity: citySim,
+        severity: citySim < 0.7 ? 'critical' : 'fuzzy'
+      });
+    }
+
+    // State comparison
+    const edmundsState = (edmundsRecord.state || '').toString().trim();
+    const copilotState = (copilotRecord.owner_csz || '').toString().trim().split(',')[1]?.trim().split(' ')[0] || ''; // Extract state from csz
+    if (edmundsState && copilotState && edmundsState.toUpperCase() !== copilotState.toUpperCase()) {
+      discrepancies.push({
+        field: 'state',
+        edmunds: edmundsState,
+        copilot: copilotState,
+        similarity: 0,
+        severity: 'critical'
+      });
+    }
+
+    // ZIP comparison
+    const edmundsZip = (edmundsRecord.zip || '').toString().trim();
+    const copilotZip = (copilotRecord.owner_csz || '').toString().trim().split(' ').pop() || ''; // Extract zip from csz
+    if (edmundsZip && copilotZip && edmundsZip !== copilotZip) {
+      discrepancies.push({
+        field: 'zip',
+        edmunds: edmundsZip,
+        copilot: copilotZip,
+        similarity: 0,
+        severity: 'critical'
       });
     }
 
@@ -172,7 +219,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const copilotClass = (copilotRecord.property_m4_class || '').toString().trim();
     if (edmundsClass && copilotClass && edmundsClass !== copilotClass) {
       discrepancies.push({
-        field: 'class',
+        field: 'property_class',
         edmunds: edmundsClass,
         copilot: copilotClass,
         similarity: 0,

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -8,8 +8,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
   const [activeResultTab, setActiveResultTab] = useState('matches'); // matches, discrepancies, ghosts
-  const [activeDiscrepancyView, setActiveDiscrepancyView] = useState('list'); // list, breakdown
-  const [selectedBreakdownField, setSelectedBreakdownField] = useState(null); // Filter breakdown by field
+  const [selectedBreakdownField, setSelectedBreakdownField] = useState(null); // Filter by field
 
   // Fuzzy string matching
   const stringSimilarity = (str1, str2) => {
@@ -600,66 +599,37 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                 <div>
                   <p className="text-sm text-gray-600 mb-4">Records with matching block/lot/qualifier but field differences (owner, address, class, etc.)</p>
 
-                  {/* Discrepancy View Switcher */}
-                  <div className="flex gap-2 mb-4">
-                    <button
-                      onClick={() => setActiveDiscrepancyView('list')}
-                      className={`px-4 py-2 rounded text-sm font-medium ${
-                        activeDiscrepancyView === 'list'
-                          ? 'bg-blue-100 text-blue-800'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                      }`}
-                    >
-                      📋 Full List ({scanResults.discrepancies})
-                    </button>
-                    <button
-                      onClick={() => setActiveDiscrepancyView('breakdown')}
-                      className={`px-4 py-2 rounded text-sm font-medium ${
-                        activeDiscrepancyView === 'breakdown'
-                          ? 'bg-blue-100 text-blue-800'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                      }`}
-                    >
-                      📊 Breakdown by Field
-                    </button>
+                  {/* Field Filter Tiles */}
+                  <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+                    {Object.entries(scanResults.fieldBreakdown || {}).map(([field, count]) => (
+                      <div
+                        key={field}
+                        onClick={() => setSelectedBreakdownField(selectedBreakdownField === field ? null : field)}
+                        className={`rounded-lg p-3 border cursor-pointer transition text-center ${
+                          selectedBreakdownField === field
+                            ? 'bg-blue-100 border-blue-500 ring-2 ring-blue-300'
+                            : 'bg-blue-50 border-blue-200 hover:bg-blue-75'
+                        }`}
+                      >
+                        <div className="text-xl font-bold text-blue-600">{count}</div>
+                        <div className="text-xs text-gray-600 capitalize mt-1">{field.replace(/_/g, ' ')}</div>
+                      </div>
+                    ))}
                   </div>
 
-                  {activeDiscrepancyView === 'breakdown' && (
-                    <>
-                      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
-                        {Object.entries(scanResults.fieldBreakdown || {}).map(([field, count]) => (
-                          <div
-                            key={field}
-                            onClick={() => setSelectedBreakdownField(selectedBreakdownField === field ? null : field)}
-                            className={`rounded-lg p-4 border cursor-pointer transition ${
-                              selectedBreakdownField === field
-                                ? 'bg-blue-100 border-blue-500 ring-2 ring-blue-300'
-                                : 'bg-blue-50 border-blue-200 hover:bg-blue-75'
-                            }`}
-                          >
-                            <div className="text-2xl font-bold text-blue-600">{count}</div>
-                            <div className="text-sm text-gray-600 capitalize mt-1">{field.replace(/_/g, ' ')}</div>
-                          </div>
-                        ))}
-                      </div>
-
-                      {selectedBreakdownField && (
-                        <div className="bg-blue-50 p-4 rounded mb-4 border border-blue-200">
-                          <p className="text-sm text-gray-700">
-                            Showing discrepancies for: <span className="font-bold capitalize">{selectedBreakdownField.replace(/_/g, ' ')}</span>
-                            <button
-                              onClick={() => setSelectedBreakdownField(null)}
-                              className="ml-4 text-xs px-2 py-1 bg-blue-200 hover:bg-blue-300 rounded"
-                            >
-                              Clear Filter
-                            </button>
-                          </p>
-                        </div>
-                      )}
-                    </>
+                  {selectedBreakdownField && (
+                    <div className="bg-blue-50 p-3 rounded mb-4 border border-blue-200 flex items-center justify-between">
+                      <p className="text-sm text-gray-700">
+                        Filtering by: <span className="font-bold capitalize">{selectedBreakdownField.replace(/_/g, ' ')}</span>
+                      </p>
+                      <button
+                        onClick={() => setSelectedBreakdownField(null)}
+                        className="text-xs px-3 py-1 bg-blue-200 hover:bg-blue-300 rounded"
+                      >
+                        Show All
+                      </button>
+                    </div>
                   )}
-
-                  {activeDiscrepancyView === 'list' && (
                     <div className="overflow-x-auto">
                       <table className="w-full text-sm">
                         <thead className="bg-gray-50">
@@ -711,7 +681,6 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
                         </tbody>
                       </table>
                     </div>
-                  )}
                 </div>
               )}
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -258,18 +258,30 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         return;
       }
 
-      // Parse Edmunds records
+      // Helper: fuzzy column matching (find columns by partial name match)
+      const findColumn = (row, searchTerms) => {
+        const columnNames = Object.keys(row);
+        for (const search of (Array.isArray(searchTerms) ? searchTerms : [searchTerms])) {
+          const match = columnNames.find(col =>
+            col.toLowerCase().includes(search.toLowerCase())
+          );
+          if (match) return row[match];
+        }
+        return '';
+      };
+
+      // Parse Edmunds records with flexible column matching
       const edmundsRecords = data.map(row => ({
-        block: row['Block'] || row['block'] || row['BLOCK'],
-        lot: row['Lot'] || row['lot'] || row['LOT'],
-        qualifier: row['Qualifier'] || row['qualifier'] || row['QUALIFIER'] || '',
-        owner: row['Owner'] || row['owner'] || row['OWNER'],
-        property_location: row['Property Location'] || row['property_location'] || row['Address'] || row['address'],
-        owner_street: row['Owner Address'] || row['owner_address'] || row['owner street'],
-        owner_city: row['Owner City'] || row['owner_city'] || row['City'],
-        state: row['State'] || row['state'],
-        zip: row['Zip'] || row['zip'],
-        property_m4_class: row['Class'] || row['class'] || row['M4 Class']
+        block: findColumn(row, ['block']),
+        lot: findColumn(row, ['lot']),
+        qualifier: findColumn(row, ['qualifier']) || '',
+        owner: findColumn(row, ['owner']),
+        property_location: findColumn(row, ['property location', 'address']),
+        owner_street: findColumn(row, ['owner address', 'owner street']),
+        owner_city: findColumn(row, ['owner city', 'city']),
+        state: findColumn(row, ['state']),
+        zip: findColumn(row, ['zip']),
+        property_m4_class: findColumn(row, ['class', 'm4 class'])
       })).filter(r => r.block && r.lot);
 
       const primaryCopilot = getPrimaryProperties();

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -128,61 +128,24 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
-  // Parse Copilot's owner_csz field: handle various formats
-  // "RIVERTON NJ 08077" → city: "RIVERTON", state: "NJ", zip: "08077"
-  // "RIVERTON, N J 08077" → city: "RIVERTON", state: "NJ", zip: "08077"
-  const parseCszCopilot = (csz) => {
-    if (!csz) return { city: '', state: '', zip: '' };
+  // Extract ZIP from owner_csz: last space-separated token if it's numeric
+  // "RIVERTON NJ 08077" → csz: "RIVERTON NJ", zip: "08077"
+  // "POINT PLEASANT, NJ 07756" → csz: "POINT PLEASANT, NJ", zip: "07756"
+  const extractZipFromCsz = (csz) => {
+    if (!csz) return { csz: '', zip: '' };
     const str = String(csz).trim();
+    const parts = str.split(/\s+/);
 
-    // Try to extract ZIP from the end first (5 or 9 digits)
-    const zipMatch = str.match(/([\d\-]{5,10})\s*$/);
-    if (!zipMatch) {
-      // No ZIP, treat whole thing as city or return empty
-      return { city: str, state: '', zip: '' };
+    // Check if last part is numeric (ZIP code)
+    const lastPart = parts[parts.length - 1];
+    if (/^\d{5}(?:-\d{4})?$/.test(lastPart)) {
+      const zip = lastPart;
+      const csz = parts.slice(0, -1).join(' ');
+      return { csz, zip };
     }
 
-    const zip = zipMatch[1];
-    const beforeZip = str.substring(0, zipMatch.index).trim();
-
-    // Now extract state and city from beforeZip
-    // State is the last 1-2 letters (possibly with space like "N J")
-    const stateMatch = beforeZip.match(/([A-Z])(?:\s+([A-Z]))?\s*$/i);
-    if (stateMatch) {
-      const state = (stateMatch[1] + (stateMatch[2] ? stateMatch[2] : '')).toUpperCase();
-      const city = beforeZip.substring(0, stateMatch.index).trim().replace(/,\s*$/, '').trim();
-      return { city, state, zip };
-    }
-
-    // If can't parse state, everything before ZIP is city
-    return { city: beforeZip, state: '', zip };
-  };
-
-  // Parse Edmunds owner_city: split on comma or double space
-  // "NEWARK, NJ" → city: "NEWARK", state: "NJ"
-  // "RIVERTON, N J" → city: "RIVERTON", state: "N J" → "NJ" (normalized)
-  const parseEdmundsCity = (ownerCity) => {
-    if (!ownerCity) return { city: '', state: '' };
-    const str = String(ownerCity).trim();
-
-    // Split on comma first
-    if (str.includes(',')) {
-      const parts = str.split(',').map(p => p.trim());
-      const city = parts[0];
-      const state = parts[1] ? parts[1].replace(/\s+/g, '') : ''; // Normalize spaces in state
-      return { city, state };
-    }
-
-    // Split on double space
-    if (str.includes('  ')) {
-      const parts = str.split(/\s{2,}/).map(p => p.trim());
-      const city = parts[0];
-      const state = parts[1] ? parts[1].replace(/\s+/g, '') : '';
-      return { city, state };
-    }
-
-    // No separator found, assume whole thing is city
-    return { city: str, state: '' };
+    // No ZIP found, entire string is csz
+    return { csz: str, zip: '' };
   };
 
   // Format ZIP code to standard format (XXXXX or XXXXX-XXXX)
@@ -190,7 +153,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     if (!zip) return '';
     const str = String(zip).trim();
     // Remove any non-digit/hyphen characters and extra spaces
-    const cleaned = str.replace(/[^\d\-]/g, '');
+    const cleaned = str.replace(/[^\d-]/g, '');
     // If 9 digits, format as XXXXX-XXXX; if 5 digits, format as XXXXX
     if (cleaned.length === 9) {
       return `${cleaned.substring(0, 5)}-${cleaned.substring(5)}`;
@@ -240,36 +203,26 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const ownerAddrDisc = compareTextField('owner_address', edmundsOwnerAddr, copilotOwnerAddr);
     if (ownerAddrDisc) discrepancies.push(ownerAddrDisc);
 
-    // Parse Copilot owner_csz field (has city, state, zip all together)
-    const parsedCopilot = parseCszCopilot(copilotRecord.owner_csz);
-
-    // Parse Edmunds owner_city field (has city, state) and zip is separate column
-    const parsedEdmunds = parseEdmundsCity(edmundsRecord.owner_city);
+    // Extract city/state and zip from both sources
+    // Edmunds: owner_city is "NEWARK, NJ" and zip is separate "07105"
+    const edmundsOwnerCsz = (edmundsRecord.owner_city || '').toString().trim();
     const edmundsZip = (edmundsRecord.zip || '').toString().trim();
+    const edmundsCszAndZip = edmundsOwnerCsz + (edmundsZip ? ' ' + edmundsZip : '');
 
-    // Owner City
-    const edmundsCity = parsedEdmunds.city;
-    const copilotCity = parsedCopilot.city;
-    const cityDisc = compareTextField('owner_city', edmundsCity, copilotCity);
-    if (cityDisc) discrepancies.push(cityDisc);
+    // Copilot: owner_csz is "RIVERTON NJ 08077"
+    const copilotCsz = (copilotRecord.owner_csz || '').toString().trim();
 
-    // State — compare directly (Edmunds state from "City, State" and Copilot from owner_csz)
-    const edmundsState = parsedEdmunds.state || '';
-    const copilotState = parsedCopilot.state || '';
-    if (edmundsState !== copilotState) {
-      discrepancies.push({
-        field: 'state',
-        edmunds: edmundsState || '(empty)',
-        copilot: copilotState || '(empty)',
-        similarity: 0,
-        severity: 'critical'
-      });
-    }
+    // Extract ZIP from both
+    const { csz: edmundsCszParsed, zip: edmundsZipParsed } = extractZipFromCsz(edmundsCszAndZip);
+    const { csz: copilotCszParsed, zip: copilotZipParsed } = extractZipFromCsz(copilotCsz);
+
+    // Compare owner_city/state combined (without ZIP)
+    const cszDisc = compareTextField('owner_city_state', edmundsCszParsed, copilotCszParsed);
+    if (cszDisc) discrepancies.push(cszDisc);
 
     // ZIP — exact match, format both to standard format (XXXXX or XXXXX-XXXX)
-    const copilotZip = (parsedCopilot.zip || '').toString().trim();
-    const edmundsZipFormatted = formatZip(edmundsZip);
-    const copilotZipFormatted = formatZip(copilotZip);
+    const edmundsZipFormatted = formatZip(edmundsZipParsed);
+    const copilotZipFormatted = formatZip(copilotZipParsed);
     if (edmundsZipFormatted !== copilotZipFormatted) {
       discrepancies.push({
         field: 'zip',

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -147,22 +147,30 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { city: str, state: '', zip: '' };
   };
 
-  // Parse Edmunds data: owner_city is "City, State" or "City State" or "City, S S" (like "RIVERTON, N J")
+  // Parse Edmunds owner_city: split on comma or double space
+  // "NEWARK, NJ" → city: "NEWARK", state: "NJ"
+  // "RIVERTON, N J" → city: "RIVERTON", state: "N J" → "NJ" (normalized)
   const parseEdmundsCity = (ownerCity) => {
     if (!ownerCity) return { city: '', state: '' };
     const str = String(ownerCity).trim();
 
-    // Try to match state at the end: "XX" or "X X" (with space)
-    // Pattern: city, then comma or spaces, then 1-2 letter state (possibly with space)
-    const match = str.match(/^(.+?)[,\s]+([A-Z])(?:\s+([A-Z]))?\s*$/i);
-    if (match) {
-      const city = match[1].trim();
-      // Handle both "NJ" and "N J" formats
-      const state = (match[2] + (match[3] ? match[3] : '')).toUpperCase();
+    // Split on comma first
+    if (str.includes(',')) {
+      const parts = str.split(',').map(p => p.trim());
+      const city = parts[0];
+      const state = parts[1] ? parts[1].replace(/\s+/g, '') : ''; // Normalize spaces in state
       return { city, state };
     }
 
-    // If no state found, assume whole thing is city
+    // Split on double space
+    if (str.includes('  ')) {
+      const parts = str.split(/\s{2,}/).map(p => p.trim());
+      const city = parts[0];
+      const state = parts[1] ? parts[1].replace(/\s+/g, '') : '';
+      return { city, state };
+    }
+
+    // No separator found, assume whole thing is city
     return { city: str, state: '' };
   };
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -9,6 +9,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
   const [activeResultTab, setActiveResultTab] = useState('matches'); // matches, discrepancies, ghosts
+  const [activeDiscrepancyView, setActiveDiscrepancyView] = useState('list'); // list, breakdown
 
   // Fuzzy string matching
   const stringSimilarity = (str1, str2) => {
@@ -190,14 +191,17 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     // Parse Copilot owner_csz field
     const parsedCopilot = parseCsz(copilotRecord.owner_csz);
 
+    // Parse Edmunds owner_city field same way as Copilot (extracts city, state, zip)
+    const parsedEdmunds = parseCsz(edmundsRecord.owner_city);
+
     // Owner City
-    const edmundsCity = (edmundsRecord.owner_city || '').toString().trim();
+    const edmundsCity = parsedEdmunds.city;
     const copilotCity = parsedCopilot.city;
     const cityDisc = compareTextField('owner_city', edmundsCity, copilotCity);
     if (cityDisc) discrepancies.push(cityDisc);
 
     // State — normalize spaces then compare exactly (N J → NJ)
-    const edmundsState = (edmundsRecord.state || '').toString().trim().toUpperCase().replace(/\s+/g, '');
+    const edmundsState = (parsedEdmunds.state || edmundsRecord.state || '').toString().trim().toUpperCase().replace(/\s+/g, '');
     const copilotState = parsedCopilot.state;
     if (edmundsState !== copilotState) {
       discrepancies.push({
@@ -209,9 +213,9 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       });
     }
 
-    // ZIP — exact match only
-    const edmundsZip = (edmundsRecord.zip || '').toString().trim();
-    const copilotZip = parsedCopilot.zip;
+    // ZIP — exact match, preserve leading zeros (treat as string)
+    const edmundsZip = (parsedEdmunds.zip || edmundsRecord.zip || '').toString().trim();
+    const copilotZip = (parsedCopilot.zip || '').toString().trim();
     if (edmundsZip !== copilotZip) {
       discrepancies.push({
         field: 'zip',
@@ -336,6 +340,14 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         }
       });
 
+      // Calculate discrepancy breakdown by field
+      const fieldBreakdown = {};
+      fuzzyMatches.forEach(match => {
+        match.discrepancies.forEach(disc => {
+          fieldBreakdown[disc.field] = (fieldBreakdown[disc.field] || 0) + 1;
+        });
+      });
+
       setScanResults({
         totalEdmunds: edmundsRecords.length,
         exactMatches: exactMatches.length,
@@ -344,6 +356,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
         detailedMatches: exactMatches,
         detailedDiscrepancies: fuzzyMatches,
         detailedGhosts: ghostRecords,
+        fieldBreakdown,
         timestamp: new Date().toISOString()
       });
 
@@ -567,48 +580,86 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
               {activeResultTab === 'discrepancies' && (
                 <div>
                   <p className="text-sm text-gray-600 mb-4">Records with matching block/lot/qualifier but field differences (owner, address, class, etc.)</p>
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead className="bg-gray-50">
-                        <tr>
-                          <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
-                          <th className="px-4 py-2 text-left font-medium text-gray-700">Field</th>
-                          <th className="px-4 py-2 text-left font-medium text-gray-700">Edmunds Value</th>
-                          <th className="px-4 py-2 text-left font-medium text-gray-700">Copilot Value</th>
-                          <th className="px-4 py-2 text-left font-medium text-gray-700">Match %</th>
-                          <th className="px-4 py-2 text-left font-medium text-gray-700">Severity</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {scanResults.detailedDiscrepancies.map((match, idx) =>
-                          match.discrepancies.map((d, didx) => (
-                            <tr key={`${idx}-${didx}`} className="border-t hover:bg-yellow-50">
-                              {didx === 0 && (
-                                <>
-                                  <td className="px-4 py-2 font-medium" rowSpan={match.discrepancies.length}>{match.edmunds.block}/{match.edmunds.lot}</td>
-                                </>
-                              )}
-                              <td className="px-4 py-2 text-xs font-medium">{d.field}</td>
-                              <td className="px-4 py-2 text-xs">{d.edmunds}</td>
-                              <td className="px-4 py-2 text-xs">{d.copilot}</td>
-                              <td className="px-4 py-2 text-xs">{(d.similarity * 100).toFixed(0)}%</td>
-                              {didx === 0 && (
-                                <td className="px-4 py-2" rowSpan={match.discrepancies.length}>
-                                  <span className={`px-2 py-1 rounded text-xs font-medium ${
-                                    match.severity === 'critical'
-                                      ? 'bg-red-100 text-red-800'
-                                      : 'bg-yellow-100 text-yellow-800'
-                                  }`}>
-                                    {match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
-                                  </span>
-                                </td>
-                              )}
-                            </tr>
-                          ))
-                        )}
-                      </tbody>
-                    </table>
+
+                  {/* Discrepancy View Switcher */}
+                  <div className="flex gap-2 mb-4">
+                    <button
+                      onClick={() => setActiveDiscrepancyView('list')}
+                      className={`px-4 py-2 rounded text-sm font-medium ${
+                        activeDiscrepancyView === 'list'
+                          ? 'bg-blue-100 text-blue-800'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      📋 Full List ({scanResults.discrepancies})
+                    </button>
+                    <button
+                      onClick={() => setActiveDiscrepancyView('breakdown')}
+                      className={`px-4 py-2 rounded text-sm font-medium ${
+                        activeDiscrepancyView === 'breakdown'
+                          ? 'bg-blue-100 text-blue-800'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      📊 Breakdown by Field
+                    </button>
                   </div>
+
+                  {activeDiscrepancyView === 'breakdown' && (
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+                      {Object.entries(scanResults.fieldBreakdown || {}).map(([field, count]) => (
+                        <div key={field} className="bg-blue-50 rounded-lg p-4 border border-blue-200">
+                          <div className="text-2xl font-bold text-blue-600">{count}</div>
+                          <div className="text-sm text-gray-600 capitalize mt-1">{field.replace(/_/g, ' ')}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {activeDiscrepancyView === 'list' && (
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <thead className="bg-gray-50">
+                          <tr>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Block/Lot</th>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Field</th>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Edmunds Value</th>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Copilot Value</th>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Match %</th>
+                            <th className="px-4 py-2 text-left font-medium text-gray-700">Severity</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {scanResults.detailedDiscrepancies.map((match, idx) =>
+                            match.discrepancies.map((d, didx) => (
+                              <tr key={`${idx}-${didx}`} className="border-t hover:bg-yellow-50">
+                                {didx === 0 && (
+                                  <>
+                                    <td className="px-4 py-2 font-medium" rowSpan={match.discrepancies.length}>{match.edmunds.block}/{match.edmunds.lot}</td>
+                                  </>
+                                )}
+                                <td className="px-4 py-2 text-xs font-medium">{d.field}</td>
+                                <td className="px-4 py-2 text-xs">{d.edmunds}</td>
+                                <td className="px-4 py-2 text-xs">{d.copilot}</td>
+                                <td className="px-4 py-2 text-xs">{(d.similarity * 100).toFixed(0)}%</td>
+                                {didx === 0 && (
+                                  <td className="px-4 py-2" rowSpan={match.discrepancies.length}>
+                                    <span className={`px-2 py-1 rounded text-xs font-medium ${
+                                      match.severity === 'critical'
+                                        ? 'bg-red-100 text-red-800'
+                                        : 'bg-yellow-100 text-yellow-800'
+                                    }`}>
+                                      {match.severity === 'critical' ? '🔴 Review' : '🟡 Fuzzy'}
+                                    </span>
+                                  </td>
+                                )}
+                              </tr>
+                            ))
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -699,7 +699,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
           <AlertCircle className="w-8 h-8 mr-3 text-blue-600" />
           <h2 className="text-2xl font-bold text-gray-800">🔄 Edmunds Audit</h2>
         </div>
-        <p className="text-gray-600">Import Edmunds collector data and reconcile against your property records. Identify mismatches, ghost records, and data quality issues.</p>
+        <p className="text-gray-600">Import Edmunds collector data and reconcile against your property records. Identify mismatches, phantom properties, and data quality issues.</p>
       </div>
 
       {/* Error Messages */}

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -60,23 +60,38 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     });
   };
 
+  // Build composite key like the rest of the system
+  const buildCompositeKey = (block, lot, qualifier = '', card = '', address = '') => {
+    const ccdd = jobData?.ccdd_code || jobData?.ccdd || '';
+    const year = jobData?.year_of_value || new Date().getFullYear();
+    const blockStr = String(block || '').trim();
+    const lotStr = String(lot || '').trim();
+    const qualStr = String(qualifier || '').trim();
+    const cardStr = String(card || '').trim();
+    const addrStr = String(address || '').trim().substring(0, 20); // Truncate for matching
+    return `${ccdd}_${year}_${blockStr}_${lotStr}_${qualStr}_${cardStr}_${addrStr}`.toUpperCase();
+  };
+
   // Detect if lot is subdivided (e.g., lot "1" split into "1.01", "1.02")
   const checkSubdivision = (edmundsBlock, edmundsLot, copilotProps) => {
     const edmundsLotStr = String(edmundsLot).trim();
+    const blockStr = String(edmundsBlock).trim();
     const matches = copilotProps.filter(p => {
       const pBlock = String(p.property_block || '').trim();
       const pLot = String(p.property_lot || '').trim();
-      return pBlock === edmundsBlock && pLot.startsWith(edmundsLotStr + '.');
+      return pBlock === blockStr && pLot.startsWith(edmundsLotStr + '.');
     });
     return matches.length > 0 ? matches : null;
   };
 
-  // Check if lot exists as additional card
+  // Check if lot exists as additional card (different card numbers for same block/lot)
   const checkAdditionalCard = (edmundsBlock, edmundsLot, edmundsQual) => {
+    const blockStr = String(edmundsBlock || '').trim();
+    const lotStr = String(edmundsLot || '').trim();
     const allPropsForLot = properties.filter(p => {
       const pBlock = String(p.property_block || '').trim();
       const pLot = String(p.property_lot || '').trim();
-      return pBlock === edmundsBlock && pLot === edmundsLot;
+      return pBlock === blockStr && pLot === lotStr;
     });
     return allPropsForLot.length > 0 ? allPropsForLot : null;
   };
@@ -87,7 +102,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     const blockStr = String(block || '').trim();
     const lotStr = String(lot || '').trim();
 
-    // Check for subdivisions
+    // Check for subdivisions first (lot 1 became 1.01, 1.02)
     const subdivisions = checkSubdivision(blockStr, lotStr, primaryProps);
     if (subdivisions) {
       return {
@@ -96,7 +111,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       };
     }
 
-    // Check for additional cards
+    // Check if exists as additional card (multiple cards for same lot)
     const additionalCards = checkAdditionalCard(blockStr, lotStr, qualifier);
     if (additionalCards && additionalCards.length > 0) {
       const nonPrimary = additionalCards.filter(p => {
@@ -112,21 +127,7 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       }
     }
 
-    // Check if bad block/lot
-    const similarLots = allProps.filter(p => {
-      const pBlock = String(p.property_block || '').trim();
-      const pLot = String(p.property_lot || '').trim();
-      return stringSimilarity(pBlock, blockStr) > 0.7 || stringSimilarity(pLot, lotStr) > 0.7;
-    });
-
-    if (similarLots.length > 0) {
-      return {
-        category: 'Potential Match',
-        details: `Similar lots exist: ${similarLots.slice(0, 2).map(p => `${p.property_block}/${p.property_lot}`).join(', ')}`
-      };
-    }
-
-    return { category: 'Bad Block/Lot', details: 'No matching or similar records found' };
+    return { category: 'Orphaned', details: 'No matching record in current system' };
   };
 
   // Compare fields and find discrepancies
@@ -221,11 +222,22 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       const primaryCopilot = getPrimaryProperties();
       const allCopilot = properties;
 
-      // Build composite key map for Copilot
+      // Build composite key map for Copilot using: ccdd_year_block_lot_qualifier_card_address
       const copilotMap = new Map();
       primaryCopilot.forEach(p => {
-        const key = `${p.property_block}_${p.property_lot}_${p.property_qualifier || ''}`.trim();
+        // Use abbreviated address for matching
+        const addr = String(p.property_location || '').trim().substring(0, 20).toUpperCase();
+        const card = getPrimaryCardIndicator(); // Primary card only
+        const key = buildCompositeKey(p.property_block, p.property_lot, p.property_qualifier, card, addr);
         copilotMap.set(key, p);
+      });
+
+      // Also build a block/lot only map for ghost detection
+      const blockLotMap = new Map();
+      primaryCopilot.forEach(p => {
+        const key = `${String(p.property_block || '').trim()}_${String(p.property_lot || '').trim()}_${String(p.property_qualifier || '').trim()}`;
+        if (!blockLotMap.has(key)) blockLotMap.set(key, []);
+        blockLotMap.get(key).push(p);
       });
 
       // Match records
@@ -234,10 +246,8 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       const ghostRecords = [];
 
       edmundsRecords.forEach(edmundsRec => {
-        const blockStr = String(edmundsRec.block || '').trim();
-        const lotStr = String(edmundsRec.lot || '').trim();
-        const qualStr = String(edmundsRec.qualifier || '').trim();
-        const key = `${blockStr}_${lotStr}_${qualStr}`;
+        const addr = String(edmundsRec.property_location || '').trim().substring(0, 20).toUpperCase();
+        const key = buildCompositeKey(edmundsRec.block, edmundsRec.lot, edmundsRec.qualifier, getPrimaryCardIndicator(), addr);
 
         const copilotRec = copilotMap.get(key);
 
@@ -319,7 +329,13 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       'Category': ghost.category,
       'Details': ghost.details,
       'Edmunds Owner': ghost.edmunds.owner,
-      'Recommended Action': ghost.category === 'Subdivided' ? 'Update lot numbers' : ghost.category === 'Additional Lot' ? 'Already exists as additional card' : 'Review and delete if invalid'
+      'Edmunds Address': ghost.edmunds.property_location,
+      'Recommended Action':
+        ghost.category === 'Subdivided'
+          ? 'Update lot numbers to reflect subdivision'
+          : ghost.category === 'Additional Lot'
+          ? 'Already exists as additional card - no action needed'
+          : 'Review and delete if invalid'
     }));
 
     const phantomSheet = XLSX.utils.json_to_sheet(phantomData);

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -147,20 +147,39 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     return { city: str, state: '', zip: '' };
   };
 
-  // Parse Edmunds data: owner_city is "City, State" and zip is separate
+  // Parse Edmunds data: owner_city is "City, State" or "City State" or "City, S S" (like "RIVERTON, N J")
   const parseEdmundsCity = (ownerCity) => {
     if (!ownerCity) return { city: '', state: '' };
     const str = String(ownerCity).trim();
 
-    // Try to match "City, State" or "City State"
-    const match = str.match(/^(.+?)[,\s]+([A-Z]{2})\s*$/i);
+    // Try to match state at the end: "XX" or "X X" (with space)
+    // Pattern: city, then comma or spaces, then 1-2 letter state (possibly with space)
+    const match = str.match(/^(.+?)[,\s]+([A-Z])(?:\s+([A-Z]))?\s*$/i);
     if (match) {
       const city = match[1].trim();
-      const state = match[2].toUpperCase().replace(/\s+/g, ''); // Normalize spaces in state
+      // Handle both "NJ" and "N J" formats
+      const state = (match[2] + (match[3] ? match[3] : '')).toUpperCase();
       return { city, state };
     }
 
+    // If no state found, assume whole thing is city
     return { city: str, state: '' };
+  };
+
+  // Format ZIP code to standard format (XXXXX or XXXXX-XXXX)
+  const formatZip = (zip) => {
+    if (!zip) return '';
+    const str = String(zip).trim();
+    // Remove any non-digit/hyphen characters and extra spaces
+    const cleaned = str.replace(/[^\d\-]/g, '');
+    // If 9 digits, format as XXXXX-XXXX; if 5 digits, format as XXXXX
+    if (cleaned.length === 9) {
+      return `${cleaned.substring(0, 5)}-${cleaned.substring(5)}`;
+    }
+    if (cleaned.length >= 5) {
+      return cleaned.substring(0, 5);
+    }
+    return str; // Return original if can't parse
   };
 
   // Compare fields and find discrepancies — FLAG ANYTHING THAT ISN'T EXACT
@@ -228,13 +247,15 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
       });
     }
 
-    // ZIP — exact match, preserve leading zeros (treat as string)
+    // ZIP — exact match, format both to standard format (XXXXX or XXXXX-XXXX)
     const copilotZip = (parsedCopilot.zip || '').toString().trim();
-    if (edmundsZip !== copilotZip) {
+    const edmundsZipFormatted = formatZip(edmundsZip);
+    const copilotZipFormatted = formatZip(copilotZip);
+    if (edmundsZipFormatted !== copilotZipFormatted) {
       discrepancies.push({
         field: 'zip',
-        edmunds: edmundsZip || '(empty)',
-        copilot: copilotZip || '(empty)',
+        edmunds: edmundsZipFormatted || '(empty)',
+        copilot: copilotZipFormatted || '(empty)',
         similarity: 0,
         severity: 'critical'
       });

--- a/src/components/job-modules/EdmundsSyncTab.jsx
+++ b/src/components/job-modules/EdmundsSyncTab.jsx
@@ -509,21 +509,37 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
 
     const workbook = XLSX.utils.book_new();
 
-    // Define styles for all sheets
+    // Define styles
     const headerStyle = {
-      font: { name: 'Leelawadee', size: 10, bold: true, color: { rgb: 'FFFFFF' } },
+      font: { bold: true, color: { rgb: 'FFFFFF' }, sz: 10 },
       fill: { fgColor: { rgb: '1F2937' } },
-      alignment: { horizontal: 'center', vertical: 'center', wrapText: true }
+      alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+      border: {
+        left: { style: 'thin' },
+        right: { style: 'thin' },
+        top: { style: 'thin' },
+        bottom: { style: 'thin' }
+      }
     };
 
     const cellStyle = {
-      font: { name: 'Leelawadee', size: 10 },
       alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
       border: {
-        left: { style: 'thin', color: { rgb: 'CCCCCC' } },
-        right: { style: 'thin', color: { rgb: 'CCCCCC' } },
-        top: { style: 'thin', color: { rgb: 'CCCCCC' } },
-        bottom: { style: 'thin', color: { rgb: 'CCCCCC' } }
+        left: { style: 'thin' },
+        right: { style: 'thin' },
+        top: { style: 'thin' },
+        bottom: { style: 'thin' }
+      }
+    };
+
+    const modIvStyle = {
+      font: { color: { rgb: '1F2937' }, sz: 10 }, // Dark blue color for MOD IV columns
+      alignment: { horizontal: 'center', vertical: 'center', wrapText: true },
+      border: {
+        left: { style: 'thin' },
+        right: { style: 'thin' },
+        top: { style: 'thin' },
+        bottom: { style: 'thin' }
       }
     };
 
@@ -560,10 +576,26 @@ const EdmundsSyncTab = ({ jobData, properties = [] }) => {
     discSheet['!cols'] = colWidths;
 
     // Apply styling to discrepancy sheet
+    // First pass: identify MOD IV columns
+    const modIvColumns = new Set();
+    Object.keys(discSheet).forEach(cell => {
+      if (cell.match(/^[A-Z]+1$/) && discSheet[cell]?.v?.includes('MOD IV')) {
+        modIvColumns.add(cell.replace(/1$/, ''));
+      }
+    });
+
+    // Second pass: apply styles
     Object.keys(discSheet).forEach(cell => {
       if (cell.startsWith('!')) return;
-      if (cell.match(/^[A-Z]+1$/)) {  // All header cells (row 1)
+
+      const colLetter = cell.replace(/\d+$/, '');
+      const isHeader = cell.match(/^[A-Z]+1$/);
+      const isMODIV = modIvColumns.has(colLetter);
+
+      if (isHeader) {
         discSheet[cell].s = headerStyle;
+      } else if (isMODIV) {
+        discSheet[cell].s = modIvStyle;
       } else {
         discSheet[cell].s = cellStyle;
       }

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -1375,7 +1375,7 @@ const JobContainer = ({
     },
     {
       id: 'edmunds-sync',
-      name: 'Edmunds Sync',
+      name: 'Edmunds Audit',
       icon: AlertCircle,
       component: EdmundsSyncTab,
       description: 'Reconcile with collector data',

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -6,6 +6,7 @@ import DataVisualizations from './DataVisualizations';
 import ManagementChecklist from './ManagementChecklist';
 import ProductionTracker from './ProductionTracker';
 import InspectionInfo from './InspectionInfo';
+import EdmundsSyncTab from './EdmundsSyncTab';
 import MarketAnalysis from './MarketAnalysis';
 import FinalValuation from './FinalValuation';
 import AppealLogTab from './final-valuation-tabs/AppealLogTab';
@@ -1371,6 +1372,14 @@ const JobContainer = ({
       component: InspectionInfo,
       description: 'Property inspection metrics and status',
       configKey: 'inspectionInfo'
+    },
+    {
+      id: 'edmunds-sync',
+      name: 'Edmunds Sync',
+      icon: AlertCircle,
+      component: EdmundsSyncTab,
+      description: 'Reconcile with collector data',
+      configKey: 'edmundsSync'
     },
     {
       id: 'market-analysis',

--- a/src/components/job-modules/ProductionTracker.jsx
+++ b/src/components/job-modules/ProductionTracker.jsx
@@ -536,9 +536,18 @@ const ProductionTracker = ({
     };
 
     try {
+      // Fetch existing workflow_stats to preserve checklist completion flags and other metadata
+      const { data: existingJob } = await supabase
+        .from('jobs')
+        .select('workflow_stats')
+        .eq('id', jobData.id)
+        .single();
+
+      const existingStats = existingJob?.workflow_stats || {};
+
       const { error } = await supabase
         .from('jobs')
-        .update({ 
+        .update({
           infoby_category_config: {
             ...configToSave,
             vendor_type: jobData.vendor_type,
@@ -547,6 +556,7 @@ const ProductionTracker = ({
           external_inspectors: externalInspectorsList,
           // Persist fresh analytics data for navigation survival
       workflow_stats: analyticsToSave.analytics ? {
+        ...existingStats,
         ...analyticsToSave.analytics,
         billingAnalytics: analyticsToSave.billingAnalytics,
         validationReport: analyticsToSave.validationReport,

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1763,6 +1763,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       const idxAddr      = col('Addl Contact Address');
       const idxCityState = col('Addl Contact City, State');
       const idxStatus    = col('Appeal Status');
+      const idxJudgCode  = col('Judg. Code 1');
+      const idxJudgTotal = col('Judg. Total');
 
       // Parse a CSV line respecting quoted fields
       const parseCSVLine = (line) => {
@@ -1812,15 +1814,17 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         return { block: blq, lot: '', qualifier: '' };
       };
 
-      // Fetch existing appeal numbers for this job to detect duplicates
+      // Fetch full existing rows so we can refresh judgment fields on re-import
+      // (rather than skipping) — MyNJAppeal now supplies judgment code/total.
       const { data: existingAppeals } = await supabase
         .from('appeal_log')
-        .select('appeal_number')
+        .select('id, appeal_number, current_assessment')
         .eq('job_id', jobData.id);
 
-      const existingNumbers = new Set(
-        (existingAppeals || []).map(a => a.appeal_number)
-      );
+      const existingByNumber = new Map();
+      (existingAppeals || []).forEach(a => {
+        if (a.appeal_number) existingByNumber.set(String(a.appeal_number).trim(), a);
+      });
 
       // Fetch DRAFT rows (no appeal_number yet) so we can merge proactive
       // appellant-evidence drafts into the official import instead of duplicating.
@@ -1835,11 +1839,12 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       });
 
       let imported = 0;
-      let skipped = 0;
+      let refreshed = 0;
       let unmatched = 0;
       let mergedDrafts = 0;
       const records = [];
       const draftUpdates = []; // { id, payload }
+      const refreshUpdates = []; // { id, payload } - judgment refresh on existing rows
 
       // Process data rows (skip header row 0)
       for (let i = 1; i < lines.length; i++) {
@@ -1854,12 +1859,6 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         const appealNumber = rawAppealNumber.startsWith('20@')
           ? rawAppealNumber.slice(3)
           : rawAppealNumber;
-
-        // Skip duplicates
-        if (existingNumbers.has(appealNumber)) {
-          skipped++;
-          continue;
-        }
 
         const blqRaw = getValue(idxBLQ);
         const { block, lot, qualifier } = parseBLQ(blqRaw);
@@ -1901,6 +1900,20 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         // Property class — stored as-is (2, 1, 6A, 15D etc.)
         const propertyClass = getValue(idxClass);
 
+        // Judgment fields — MyNJAppeal supplies "Judg. Code 1" and "Judg. Total"
+        const judgmentTotalRaw = getValue(idxJudgTotal).replace(/,/g, '');
+        const judgmentValue = judgmentTotalRaw !== '' && !isNaN(Number(judgmentTotalRaw))
+          ? Number(judgmentTotalRaw)
+          : null;
+        const judgmentCodeNJ = getValue(idxJudgCode) || null;
+        const baseAssessment = matchedProperty?.values_mod_total || currentAssessment || 0;
+        let loss = null;
+        let lossPct = null;
+        if (judgmentValue !== null && baseAssessment) {
+          loss = baseAssessment - judgmentValue;
+          lossPct = (loss / baseAssessment) * 100;
+        }
+
         const record = {
           job_id: jobData.id,
           appeal_number: appealNumber,
@@ -1915,6 +1928,10 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
           attorney_city_state: attorneyCityState,
           current_assessment: matchedProperty?.values_mod_total || currentAssessment || 0,
           requested_value: 0,
+          judgment_value: judgmentValue,
+          judgment_code_nj: judgmentCodeNJ,
+          loss,
+          loss_pct: lossPct,
           property_block: block,
           property_lot: lot,
           property_qualifier: qualifier,
@@ -1952,11 +1969,45 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
           continue;
         }
 
+        // Re-import path: row already exists for this appeal_number.
+        // Refresh judgment fields (code/value/loss) in place — leave user-managed
+        // fields (status, comments, appellant evidence, etc.) untouched.
+        const existingRow = existingByNumber.get(appealNumber);
+        if (existingRow) {
+          const refBase = baseAssessment || existingRow.current_assessment || 0;
+          let refLoss = null;
+          let refLossPct = null;
+          if (judgmentValue !== null && refBase) {
+            refLoss = refBase - judgmentValue;
+            refLossPct = (refLoss / refBase) * 100;
+          }
+          refreshUpdates.push({
+            id: existingRow.id,
+            payload: {
+              judgment_value: judgmentValue,
+              judgment_code_nj: judgmentCodeNJ,
+              loss: refLoss,
+              loss_pct: refLossPct
+            }
+          });
+          refreshed++;
+          continue;
+        }
+
         records.push(record);
       }
 
       // Apply draft merges (one update per draft to preserve evidence fields)
       for (const { id, payload } of draftUpdates) {
+        const { error } = await supabase
+          .from('appeal_log')
+          .update(payload)
+          .eq('id', id);
+        if (error) throw error;
+      }
+
+      // Apply judgment refreshes on existing appeal rows
+      for (const { id, payload } of refreshUpdates) {
         const { error } = await supabase
           .from('appeal_log')
           .update(payload)
@@ -2012,7 +2063,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       setAppeals(enrichedAppeals);
       computeAndEmitStats(enrichedAppeals);
       saveSnapshot(enrichedAppeals);
-      setImportResult({ imported, skipped, unmatched, mergedDrafts });
+      setImportResult({ imported, refreshed, unmatched, mergedDrafts });
       setImportFile(null);
 
       // Stamp last-import timestamp for the MyNJAppeal source
@@ -5241,8 +5292,9 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
 
             <div className="space-y-4">
               <p className="text-sm text-gray-600">
-                Supports the BRT online appeal system CSV export format.
-                Duplicate appeal numbers will be skipped automatically.
+                Supports the MyNJAppeal CSV export format. Re-importing an existing
+                appeal refreshes its <strong>judgment code</strong> and <strong>judgment total</strong> in
+                place — no manual entry needed for bulk judgment loads.
               </p>
 
               <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
@@ -5265,8 +5317,8 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
                 <div className="bg-gray-50 rounded-lg p-4 space-y-1 text-sm">
                   <p className="font-semibold text-gray-800">Import Complete</p>
                   <p className="text-green-700">✓ {importResult.imported} records imported</p>
-                  {importResult.skipped > 0 && (
-                    <p className="text-amber-700">⚠ {importResult.skipped} skipped (duplicates)</p>
+                  {importResult.refreshed > 0 && (
+                    <p className="text-emerald-700">✓ {importResult.refreshed} existing appeal{importResult.refreshed === 1 ? '' : 's'} refreshed (judgment code / total updated)</p>
                   )}
                   {importResult.unmatched > 0 && (
                     <p className="text-blue-700">ℹ {importResult.unmatched} unmatched to property records</p>

--- a/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppealLogTab.jsx
@@ -1744,29 +1744,7 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
       const text = await importFile.text();
       const lines = text.split('\n');
 
-      // Parse header row — strip BOM if present
-      const rawHeader = lines[0].replace(/^\uFEFF/, '');
-      const headers = rawHeader.split(',').map(h => h.trim().replace(/^"|"$/g, ''));
-
-      // Column index helpers
-      const col = (name) => headers.findIndex(h => h === name);
-
-      const idxBLQ       = col('BLQ');
-      const idxAppealNum = col('Appeal #');
-      const idxName      = col('Name');
-      const idxLocation  = col('Location');
-      const idxClass     = col('Class.');
-      const idxAssess    = col('Assessment');
-      const idxTaxCrt    = col('Tax Crt?');
-      const idxEntry     = col('Entry');
-      const idxContact   = col('Adtl. Contact');
-      const idxAddr      = col('Addl Contact Address');
-      const idxCityState = col('Addl Contact City, State');
-      const idxStatus    = col('Appeal Status');
-      const idxJudgCode  = col('Judg. Code 1');
-      const idxJudgTotal = col('Judg. Total');
-
-      // Parse a CSV line respecting quoted fields
+      // Parse a CSV line respecting quoted fields (e.g. "Owner City, State")
       const parseCSVLine = (line) => {
         const result = [];
         let current = '';
@@ -1785,6 +1763,30 @@ const AppealLogTab = ({ jobData, properties = [], inspectionData = [], marketLan
         result.push(current.trim());
         return result;
       };
+
+      // Parse header row with the SAME quote-aware parser so quoted headers
+      // ("Owner City, State") don't shift downstream column indices. Collapse
+      // internal whitespace so "Judg. Code  1" (double space) matches "Judg. Code 1".
+      const normalizeHeader = (h) => h.replace(/^\uFEFF/, '').replace(/\s+/g, ' ').trim();
+      const headers = parseCSVLine(lines[0].replace(/^\uFEFF/, '')).map(normalizeHeader);
+
+      // Column index helpers
+      const col = (name) => headers.findIndex(h => h === normalizeHeader(name));
+
+      const idxBLQ       = col('BLQ');
+      const idxAppealNum = col('Appeal #');
+      const idxName      = col('Name');
+      const idxLocation  = col('Location');
+      const idxClass     = col('Class.');
+      const idxAssess    = col('Assessment');
+      const idxTaxCrt    = col('Tax Crt?');
+      const idxEntry     = col('Entry');
+      const idxContact   = col('Adtl. Contact');
+      const idxAddr      = col('Addl Contact Address');
+      const idxCityState = col('Addl Contact City, State');
+      const idxStatus    = col('Appeal Status');
+      const idxJudgCode  = col('Judg. Code 1');
+      const idxJudgTotal = col('Judg. Total');
 
       // Parse BLQ — format: "188-26", "155-7.01", "96-4-C0102"
       const parseBLQ = (blq) => {

--- a/src/components/job-modules/final-valuation-tabs/ManageResultSetsTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ManageResultSetsTab.jsx
@@ -141,6 +141,19 @@ const ManageResultSetsTab = ({ jobData }) => {
     });
   };
 
+  const allFilteredSelected =
+    filteredSets.length > 0 && filteredSets.every(rs => selectedIds.has(rs.id));
+
+  const toggleSelectAllFiltered = () => {
+    const ids = filteredSets.map(rs => rs.id);
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (allFilteredSelected) ids.forEach(id => next.delete(id));
+      else ids.forEach(id => next.add(id));
+      return next;
+    });
+  };
+
   const toggleSelectAllInGroup = (rows) => {
     const rowIds = rows.map(r => r.id);
     const allSelected = rowIds.every(id => selectedIds.has(id));
@@ -350,6 +363,13 @@ const ManageResultSetsTab = ({ jobData }) => {
       </div>
 
       <div className="action-bar flex flex-wrap items-center gap-2">
+        <button
+          onClick={toggleSelectAllFiltered}
+          disabled={filteredSets.length === 0 || busy}
+          className="action-btn select-all-btn px-3 py-2 border border-gray-300 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          {allFilteredSelected ? 'Deselect All' : `Select All (${filteredSets.length})`}
+        </button>
         <button
           onClick={handleArchiveSelected}
           disabled={selectedActiveCount === 0 || busy}

--- a/src/lib/tenantConfig.js
+++ b/src/lib/tenantConfig.js
@@ -34,6 +34,7 @@ const TENANT_CONFIGS = {
       checklist: true,
       production: true,         // Full ProductionTracker with employee DB
       inspectionInfo: false,
+      edmundsSync: true,        // Edmunds reconciliation
       dataVisualizations: true,
       marketAnalysis: true,
       finalValuation: true,
@@ -75,6 +76,7 @@ const TENANT_CONFIGS = {
       checklist: false,                // Internal PPA workflow - not visible to assessor clients
       production: true,                // Enable for assessor clients (e.g., Rich's reassessments)
       inspectionInfo: true,            // Simplified inspection view with staff hints
+      edmundsSync: true,               // Edmunds reconciliation (available to assessor clients too)
       dataVisualizations: true,
       marketAnalysis: true,
       finalValuation: true,


### PR DESCRIPTION
### Summary
Adds a new Edmunds reconciliation tab for auditing collector data against property records, enables in-place judgment refresh on MyNJAppeal re-imports, and adds a "select all" convenience action to Manage Result Sets.

### Problem
There was no way to compare Edmunds collector exports against Copilot property records to catch owner, address, or classification mismatches. Separately, re-importing an updated MyNJAppeal CSV (with judgment code/value added after the original filing) skipped existing appeal rows entirely instead of updating them, forcing manual entry of judgment data. Manage Result Sets also lacked a quick way to select every filtered result set at once.

### Solution
- Built a new `EdmundsSyncTab` component that parses Edmunds exports, builds composite keys from block/lot/qualifier/card, filters to primary cards, and compares owner, address, city/state/zip, and classification fields with fuzzy-vs-critical severity scoring.
- Updated the appeal log import logic to detect existing appeal rows by appeal number and refresh their judgment code/value/loss fields in place rather than skipping them as duplicates.
- Added a "Select All" / "Deselect All" toggle for filtered result sets in `ManageResultSetsTab`.
- Exposed the new Edmunds sync feature via tenant configuration flags.

### Key Changes
- **New `src/components/job-modules/EdmundsSyncTab.jsx`**: fuzzy string matching (Levenshtein-based similarity), composite key building, primary-card filtering, subdivision/additional-card detection for phantom/ghost records, ZIP extraction and formatting from combined city/state/zip strings, address number/ordinal normalization, and field-level discrepancy comparison with fuzzy/critical severity classification.
- **`AppealLogTab.jsx`**: 
  - Fetches existing appeal rows by `appeal_number` (with `current_assessment`) instead of just checking for duplicates.
  - Parses `Judg. Code 1` and `Judg. Total` columns from MyNJAppeal CSVs, computing `judgment_value`, `judgment_code_nj`, `loss`, and `loss_pct`.
  - On re-import, existing rows are updated with refreshed judgment fields (`refreshUpdates`) instead of being skipped; new rows are inserted as before.
  - Updated import summary UI and help text to reflect the "refreshed" count and MyNJAppeal-specific behavior instead of "skipped (duplicates)".
- **`ManageResultSetsTab.jsx`**: added `toggleSelectAllFiltered` handler and a "Select All (n)" / "Deselect All" button in the action bar.
- **`tenantConfig.js`**: added `edmundsSync: true` feature flag for both tenant configs to enable the new Edmunds reconciliation tab.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/alpine-puzzle-e5eyfjvz"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-alpine-puzzle-e5eyfjvz.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 241`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>alpine-puzzle-e5eyfjvz</branchName>-->