### PR TITLE
Fix assignment key mismatch and contract modal overflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,6 +43,25 @@
   overflow-x: auto;
 }
 
+/* Contract setup modal — same Tailwind v2 CDN limitation as the CSV export
+   modal above: arbitrary values like max-h-[90vh] are ignored, so the shell
+   grows past the viewport and hides the footer buttons. Constrain it here with
+   a fixed-size flex shell + scrollable body (both axes). */
+.contract-modal-box {
+  width: 100%;
+  max-width: 42rem;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.contract-modal-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: auto;
+  overflow-y: auto;
+}
+
 /* Management OS Color Variables */
 :root {
   /* Primary Blues from Management OS */

--- a/src/components/AdminJobManagement.jsx
+++ b/src/components/AdminJobManagement.jsx
@@ -438,9 +438,25 @@ const AdminJobManagement = ({
 
       // Parse CSV and create composite keys
       const assignments = [];
-      // Use job's year_created instead of current year
-      const year = job.year_created || new Date().getFullYear();
-      const ccdd = job.ccdd || job.ccddCode;
+      // Derive the year+ccdd prefix from an actual property record so assignment
+      // keys always match how the source file was processed. The previous
+      // `job.year_created` fallback resolved to the current calendar year (the
+      // column doesn't exist), silently breaking the match on off-year jobs.
+      let keyPrefix = null;
+      const { data: sampleProp } = await supabase
+        .from('property_records')
+        .select('property_composite_key')
+        .eq('job_id', job.id)
+        .limit(1)
+        .maybeSingle();
+      if (sampleProp?.property_composite_key) {
+        keyPrefix = sampleProp.property_composite_key.split('-')[0];
+      }
+      if (!keyPrefix) {
+        const year = job.year_created || new Date().getFullYear();
+        const ccdd = job.ccdd || job.ccddCode;
+        keyPrefix = `${year}${ccdd}`;
+      }
 
       for (let i = 1; i < lines.length; i++) {
         const values = lines[i].split(delimiter).map(v => v.trim());
@@ -466,7 +482,7 @@ const AdminJobManagement = ({
         if (!block && !lot) continue;
        
         // Ensure consistent composite key format matching processors
-        const compositeKey = `${year}${ccdd}-${block}-${lot}_${qual || 'NONE'}-${card || 'NONE'}-${location || 'NONE'}`;
+        const compositeKey = `${keyPrefix}-${block}-${lot}_${qual || 'NONE'}-${card || 'NONE'}-${location || 'NONE'}`;
         
         assignments.push({
           property_composite_key: compositeKey,

--- a/src/components/BillingManagement.jsx
+++ b/src/components/BillingManagement.jsx
@@ -3540,14 +3540,14 @@ const calculateDistributionMetrics = async () => {
       {/* Contract Setup Modal */}
       {showContractSetup && selectedJob && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg w-full max-w-2xl max-h-[90vh] flex flex-col">
+          <div className="bg-white rounded-lg contract-modal-box">
             <div className="p-6 pb-4 flex-shrink-0">
               <h3 className="text-lg font-semibold">
                 {selectedJob.job_contracts && selectedJob.job_contracts.length > 0 ? 'Edit' : 'Setup'} Contract: {selectedJob.job_name}
               </h3>
             </div>
 
-            <div className="px-6 overflow-y-auto flex-1 min-h-0">
+            <div className="px-6 contract-modal-scroll">
               <div className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
### Summary
Fixes two bugs: assignment CSV imports failing to match property records on off-year jobs, and the contract setup modal expanding past the viewport, hiding its footer buttons.

### Problem
When uploading an assignment-only CSV for a job, the composite key was built using `job.year_created` (a column that doesn't exist) falling back to the current calendar year. For jobs from a different year, this generated composite keys that never matched the actual property records, causing exports (like the initial mailer) to come back empty. Separately, the Contract Setup modal in Billing Management used Tailwind arbitrary values (`max-h-[90vh]`) that are ignored under the Tailwind v2 CDN build, causing the modal to grow full-screen and hide its action buttons — a known issue already worked around elsewhere (CSV export modal).

### Solution
- Derive the composite key prefix (year + ccdd) directly from an existing `property_records` row for the job instead of relying on the missing `year_created` field, with the old logic kept only as a fallback.
- Apply the same fixed-size flex shell + scrollable body CSS pattern used for the CSV export modal to the Contract Setup modal, constraining its size and adding scroll bars instead of letting it grow past the viewport.

### Key Changes
- `AdminJobManagement.jsx`: Query a sample `property_composite_key` from `property_records` for the job to derive the correct `keyPrefix`, falling back to `year_created`/`ccdd` only if no property record is found. Composite key construction now uses `keyPrefix` instead of raw `year`/`ccdd`.
- `App.css`: Added `.contract-modal-box` and `.contract-modal-scroll` classes implementing a fixed max-width/max-height flex container with scrollable content area.
- `BillingManagement.jsx`: Replaced inline Tailwind arbitrary-value classes on the Contract Setup modal with the new `.contract-modal-box` / `.contract-modal-scroll` classes.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/multi-lab-dag3zxdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-multi-lab-dag3zxdd.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 243`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>multi-lab-dag3zxdd</branchName>-->