### PR TITLE
Add Building Class column to VCS Analyzer

### DIFF
--- a/src/components/job-modules/market-tabs/VcsAnalyzerSubTab.jsx
+++ b/src/components/job-modules/market-tabs/VcsAnalyzerSubTab.jsx
@@ -209,6 +209,29 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
           }
         }
 
+        // building class variability - raw numeric grade code + parcel count,
+        // dominant when one code covers >=80% (mirrors the Style/Mix pattern).
+        const classCounts = {};
+        for (const p of tProps) {
+          const raw = (p.asset_building_class || '').toString().trim() || '-';
+          classCounts[raw] = (classCounts[raw] || 0) + 1;
+        }
+        const classSorted = Object.entries(classCounts).sort((a, b) => b[1] - a[1]);
+        let classMix = '-';
+        if (classSorted.length) {
+          const topPct = Math.round((classSorted[0][1] / tProps.length) * 100);
+          if (topPct >= 80) {
+            classMix = `${classSorted[0][0]} (${classSorted[0][1]})`;
+          } else {
+            classMix =
+              'Mixed: ' +
+              classSorted
+                .slice(0, 3)
+                .map(([code, n]) => `${code}:${n}`)
+                .join('/');
+          }
+        }
+
         types.push({
           typeLabel:
             codeToType[tLabel] && codeToType[tLabel] !== tLabel
@@ -223,6 +246,7 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
           yrMin: years.length ? Math.min(...years) : null,
           yrMax: years.length ? Math.max(...years) : null,
           ageGap: years.length ? Math.max(...years) - Math.min(...years) : null,
+          classMix,
           styleMix,
         });
       }
@@ -434,6 +458,7 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
     const resHeaders = [
       'VCS',
       'Type',
+      'Bldg Class',
       'Parcels',
       'Usable Sales',
       'Norm Time',
@@ -461,6 +486,7 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
         resAoa.push([
           idx === 0 ? row.vcs : '',
           t.typeLabel,
+          t.classMix,
           t.parcels,
           t.usableSales,
           t.avgNormTime ? Math.round(t.avgNormTime) : '',
@@ -480,20 +506,20 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
       if (endRow > startRow) {
         // merge VCS / Commentary / Merge? cells across the type rows
         resMerges.push({ s: { r: startRow, c: 0 }, e: { r: endRow, c: 0 } });
-        resMerges.push({ s: { r: startRow, c: 12 }, e: { r: endRow, c: 12 } });
         resMerges.push({ s: { r: startRow, c: 13 }, e: { r: endRow, c: 13 } });
+        resMerges.push({ s: { r: startRow, c: 14 }, e: { r: endRow, c: 14 } });
       }
     }
     const resWs = XLSX.utils.aoa_to_sheet(resAoa);
     resWs['!merges'] = resMerges;
     resWs['!cols'] = [
-      { wch: 8 }, { wch: 22 }, { wch: 8 }, { wch: 11 }, { wch: 11 },
+      { wch: 8 }, { wch: 22 }, { wch: 14 }, { wch: 8 }, { wch: 11 }, { wch: 11 },
       { wch: 11 }, { wch: 10 }, { wch: 9 }, { wch: 8 }, { wch: 8 },
       { wch: 8 }, { wch: 22 }, { wch: 40 }, { wch: 9 },
     ];
     styleSheet(resWs, resAoa, {
-      2: NUM, 3: NUM, 4: CURRENCY, 5: CURRENCY, 6: NUM, 7: NUM,
-      8: YEAR, 9: YEAR, 10: NUM,
+      3: NUM, 4: NUM, 5: CURRENCY, 6: CURRENCY, 7: NUM, 8: NUM,
+      9: YEAR, 10: YEAR, 11: NUM,
     });
     XLSX.utils.book_append_sheet(wb, resWs, 'Class 2 Residential');
 
@@ -584,7 +610,7 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
           <thead className="bg-gray-100 text-gray-700">
             <tr>
               {[
-                'VCS', 'Type', 'Parcels', 'Usable Sales', 'Norm Time', 'Norm Size',
+                'VCS', 'Type', 'Bldg Class', 'Parcels', 'Usable Sales', 'Norm Time', 'Norm Size',
                 'Avg SFLA', 'SFLA Gap', 'Yr Min', 'Yr Max', 'Age Gap', 'Style/Mix',
                 'Commentary', 'Merge?',
               ].map((h) => (
@@ -615,6 +641,7 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
                     </td>
                   )}
                   <td className="px-2 py-1.5 whitespace-nowrap">{t.typeLabel}</td>
+                  <td className="px-2 py-1.5 whitespace-nowrap">{t.classMix}</td>
                   <td className="px-2 py-1.5 text-right">{t.parcels}</td>
                   <td className="px-2 py-1.5 text-right">{t.usableSales}</td>
                   <td className="px-2 py-1.5 text-right">{fmtMoney(t.avgNormTime)}</td>
@@ -666,7 +693,7 @@ const VcsAnalyzerSubTab = ({ jobData, properties, vendorType, codeDefinitions })
             })}
             {residential.length === 0 && (
               <tr>
-                <td colSpan={14} className="px-4 py-6 text-center text-gray-400">
+                <td colSpan={15} className="px-4 py-6 text-center text-gray-400">
                   No Class 2 residential parcels found for this job.
                 </td>
               </tr>


### PR DESCRIPTION
### Summary
Adds a dedicated "Bldg Class" column to the VCS Analyzer's Class 2 Residential table and its Excel export, showing building class variability per VCS/type group.

### Problem
The VCS Analyzer displayed style/type mix but had no way to see building class distribution per VCS type, making it harder to assess class variability at a glance.

### Solution
Compute a building class mix for each VCS/type group using the same dominant-vs-mixed logic already used for style mix (single code shown if it covers ≥80% of parcels, otherwise a "Mixed" breakdown of the top codes), then surface it as a new column in both the on-screen table and the Excel export.

### Key Changes
- Calculate `classMix` from `asset_building_class` per type group, mirroring the existing Style/Mix logic
- Insert a new "Bldg Class" column in the UI table (after Type) and update `colSpan` for the empty-state row
- Add "Bldg Class" header and `classMix` value to the Excel export rows
- Adjust Excel column widths, cell styling map, and merge ranges to account for the new column


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/asteroid-reward-0sjnsngf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-asteroid-reward-0sjnsngf.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 250`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>asteroid-reward-0sjnsngf</branchName>-->