### PR TITLE
Fix security holes in auth, password storage, and login flow

### DIFF
--- a/SECURITY-REMEDIATION-STATUS.md
+++ b/SECURITY-REMEDIATION-STATUS.md
@@ -1,0 +1,191 @@
+# Security Remediation — Status & Next Steps
+
+Session date: 2026-08-02. Supabase project `zxvavttfvpsagzluqqwn`.
+Companion to `SUPABASE_RESOURCE_FIX.md` (the original RLS plan, still accurate
+on the advisor inventory).
+
+Everything below is committed to the branch but **not yet deployed**. Nothing in
+the RLS project has started.
+
+---
+
+## 1. Shipped in this branch (code)
+
+### 1.1 Dev auto-login no longer bypasses authentication
+
+`src/App.js` (`checkSession`)
+
+Was: auto-login as the primary owner when the hostname matched any of a list
+(`production-black-seven`, `preview`, `builder.io`, …) **or** when the URL
+carried `?dev=true`. That made `<any-deployed-url>/?dev=true` a full admin
+session for anyone, with no password.
+
+Now: gated on `process.env.NODE_ENV !== 'production'` only, and the query-string
+escape hatch is explicitly refused.
+
+- Builder preview and localhost still auto-login (they run `npm start`).
+- Any Vercel production build now requires a real sign-in. **This includes
+  black-seven**, which previously relied on the hostname match.
+
+### 1.2 Login resolves identity by auth ID, then email
+
+`src/components/LandingPage.jsx`, `src/App.js`, `src/lib/supabaseClient.js`
+(`authHelpers.getCurrentUser`)
+
+All three did `.eq('email', …).single()` against `employees`. The admin account's
+auth email is `dudj23@gmail.com` but its employee row is `ppalead1@gmail.com`, so
+a real sign-in authenticated and then failed with "Employee record not found."
+
+Now: `.or('auth_user_id.eq.<uid>,email.eq.<email>').limit(1).maybeSingle()`.
+
+Verified in SQL that this resolves to the Jim Duda row. The other 20 users have
+a null `auth_user_id`, so they still match on email — no behavior change.
+
+### 1.3 Self-service password recovery
+
+- `src/components/ResetPassword.jsx` (new) — set-new-password screen, min 8
+  chars, signs out afterward so the new password is used on next sign-in.
+- `src/components/LandingPage.jsx` — "Forgot password?" calls
+  `resetPasswordForEmail` with `redirectTo: window.location.origin`.
+- `src/App.js` — `recoveryMode` state, set from a `#type=recovery` hash or the
+  `PASSWORD_RECOVERY` auth event, rendered ahead of everything else.
+- `src/components/LandingPage.css` — `.forgot-password-link`,
+  `.reset-sent-message`.
+
+Previously no recovery handling existed at all, which is why recovery links
+silently signed people in and never offered a password field (Dawn's bug).
+
+**Never executed end to end.** Compiles only.
+
+### 1.4 Plaintext passwords removed
+
+Three write sites deleted (`App.js` change-password, `UserManagement` create user
+and reset password). No read sites existed — nothing in the UI displayed it.
+
+### 1.5 Landing page
+
+Removed the "For Professional Property Appraisers" tagline. The `.tagline` and
+`.title-group` CSS rules are now unused but left in place.
+
+---
+
+## 2. Shipped already (live, not gated on deploy)
+
+### 2.1 `update-user-password` edge function — v4
+
+Source now tracked at `supabase/functions/update-user-password/index.ts`.
+
+The deployed v3 accepted the **publishable/anon key as authorization** and then
+used `service_role` to set any user's password by email. Anyone who read the key
+out of the JS bundle could take over any account, unauthenticated.
+
+v4: `verify_jwt` on, anon-key branch removed, caller must be a signed-in user
+whose `profiles.role = 'admin'`, minimum 8 characters, resets logged.
+
+Verified after deploy:
+
+| Request | Result |
+|---|---|
+| No auth header | 401 `UNAUTHORIZED_NO_AUTH_HEADER` |
+| Garbage bearer token | 401 `UNAUTHORIZED_INVALID_JWT_FORMAT` |
+| Publishable key (the real attack) | 401 `Unauthorized` |
+
+Side effect: the Users-tab reset button will not work from the Builder preview
+(dev mode has no real session). It works from a deployed build when signed in.
+
+### 2.2 Migration `remove_plaintext_employee_passwords`
+
+Nulled 74 stored cleartext passwords, then dropped `employees.initial_password`.
+All 81 employee rows otherwise intact.
+
+### 2.3 Deleted stale auth user
+
+`richard.carabelli@franklinnj.gov` — never signed in, never confirmed, retired.
+
+---
+
+## 3. Blocking next step — deploy and verify login
+
+1. Push, merge to main, let Vercel build **black-seven**.
+2. Get a password onto `dudj23@gmail.com`: Supabase dashboard →
+   Authentication → Users → row menu. If it only offers "send recovery email",
+   that works too *once the code above is live* (not before — the old build has
+   no set-password screen).
+3. Sign into black-seven. Expect: admin, full nav incl. Billing/Payroll, all 31
+   jobs.
+
+If it fails with "Employee record not found", the `.or()` lookup is the suspect.
+
+**Rollback:** restore the old condition in `App.js:checkSession` and redeploy.
+The Builder dev environment keeps auto-logging in as admin regardless, so there
+is no lock-out scenario.
+
+---
+
+## 4. Supabase dashboard items (manual)
+
+- [x] Site URL → `https://lojikre.com`; added to Redirect URLs.
+      (`www` handled by a GoDaddy redirect. `production-black-seven.vercel.app`
+      stays in the list — it is the main-branch deployment, not dead.)
+- [ ] Email OTP expiration → 3600s or less (`auth_otp_long_expiry`)
+- [ ] Leaked password protection → on (`auth_leaked_password_protection`)
+- [ ] Postgres security upgrade — has downtime, schedule deliberately
+
+---
+
+## 5. Next: RLS
+
+### Phase A — enable everywhere, authenticated-only
+
+One tracked migration: RLS on across all public tables with an
+authenticated-only policy each. Clears every ERROR-level advisor and shuts off
+anon access. Signed-in behavior is unchanged because the app already scopes its
+own queries. Reversible per table.
+
+Current advisor state: 40 tables with RLS disabled, 8 more with policies written
+but RLS never enabled (dead weight — the source of the resource warning), 1
+SECURITY DEFINER view (`job_assignments_with_employee`), 10 functions with
+mutable `search_path`, and `delete_organization_cascade` executable by `anon`.
+
+### Phase B — org scoping
+
+Backfill `employees.auth_user_id` (only Jim's is set today), add a
+`SECURITY DEFINER` helper resolving `auth.uid()` → org set + admin flag, then
+scope the tenant tables. Test each with JWT impersonation
+(`set local role authenticated` + `request.jwt.claims`) before committing.
+
+### Access model (confirmed with Jim)
+
+| Who | Data access |
+|---|---|
+| Jim (`5df85ca3…`, `profiles.role = 'admin'`) | Everything |
+| PPA internal staff (8, all `viewer`) | All jobs, employees, appeals. **No** billing/payroll/revenue |
+| Assessor clients (12) | Only their linked org(s) |
+
+Billing/payroll stay admin-only — Brian Schneider last signed in 2025-09-16 and
+Tom Davis has no account, so a separate "owner" tier isn't worth building.
+
+### Things that will bite
+
+- **Multi-org clients are real.** `employee_organizations` is the junction
+  `AssessorDashboard.jsx:72-76` reads. Dawn Guttschall → Dunellen + Middlesex.
+  Rich Buscemi → Runnemede + Springfield + Waterford. Policies must honor it,
+  not just `profiles.organization_id`.
+- `job_access_grants` (2 rows, Ron Breining) has `grantee_employee_id` with a
+  null `auth_user_id` — unusable as a policy basis until backfilled.
+- Admin is a **hardcoded UUID** in the frontend (`PRIMARY_OWNER_ID`, `App.js`).
+  RLS should key off `profiles.role` instead so there's one source of truth.
+- Each assessor org owns exactly one job; PPA Inc owns 41. Some towns exist
+  twice (PPA's "Dunellen" and Dawn's "Dunellen" are different job rows).
+
+---
+
+## 6. Unrelated data work completed this session
+
+- **Atlantic City** appeal log: bulk-applied judgment-code → status mapping for
+  2026 (6B/6A → AWP, 3 → S, 7 → W, 5A → NA, 2B → H). 1,268 rows. Zero `D`
+  remaining.
+- **Raritan** 36/7 card 1: `inspection_info_by` `00` → `01`.
+- **Raritan** phantom validation flags diagnosed as a stale source file
+  (re-uploaded a 7/14-vintage export twice), not a code bug. Resolved by
+  re-exporting from BRT.

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import PayrollManagement from './components/PayrollManagement';
 import JobContainer from './components/job-modules/JobContainer';
 import FileUploadButton from './components/job-modules/FileUploadButton';
 import LandingPage from './components/LandingPage';
+import ResetPassword from './components/ResetPassword';
 import UserManagement from './components/UserManagement';
 import OrganizationManagement from './components/OrganizationManagement';
 import RevenueManagement from './components/RevenueManagement';
@@ -207,6 +208,13 @@ const App = () => {
   // Dev mode: "View As" impersonation state
   const [viewingAs, setViewingAs] = useState(null);
 
+  // Supabase recovery links land on the app with a #type=recovery hash and an
+  // active session. Without this the user is silently signed in and never gets
+  // the chance to set a new password.
+  const [recoveryMode, setRecoveryMode] = useState(
+    () => typeof window !== 'undefined' && window.location.hash.includes('type=recovery')
+  );
+
   // Help modal state
   const [showHelp, setShowHelp] = useState(false);
   const [helpTab, setHelpTab] = useState('navigating-os');
@@ -289,14 +297,6 @@ const App = () => {
         password: cpNewPwd,
       });
       if (updateError) throw updateError;
-
-      // Update stored password on employee record for admin visibility
-      if (user.employeeData?.id) {
-        await supabase
-          .from('employees')
-          .update({ initial_password: cpNewPwd })
-          .eq('id', user.employeeData.id);
-      }
 
       setCpSuccess('Password updated successfully');
       setCpCurrentPwd('');
@@ -1136,9 +1136,17 @@ const App = () => {
     };
   };
 
+  // Session bootstrap
   // Check for existing session or dev mode on mount
   useEffect(() => {
     checkSession();
+  }, []);
+
+  useEffect(() => {
+    const { data: sub } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'PASSWORD_RECOVERY') setRecoveryMode(true);
+    });
+    return () => sub?.subscription?.unsubscribe();
   }, []);
 
   const checkSession = async () => {
@@ -1280,6 +1288,7 @@ const App = () => {
   // ==========================================
   // RENDER UI
   // ==========================================
+  if (recoveryMode) return <ResetPassword />;
   
   // Show loading state
   if (loading) {

--- a/src/App.js
+++ b/src/App.js
@@ -1177,8 +1177,9 @@ const App = () => {
         const { data: employee } = await supabase
           .from('employees')
           .select('*')
-          .eq('email', session.user.email.toLowerCase())
-          .single();
+          .or(`auth_user_id.eq.${session.user.id},email.eq.${session.user.email.toLowerCase()}`)
+          .limit(1)
+          .maybeSingle();
 
         if (employee) {
           setUser({

--- a/src/App.js
+++ b/src/App.js
@@ -1151,18 +1151,11 @@ const App = () => {
 
   const checkSession = async () => {
     try {
-      // Development auto-login - expanded conditions
-      if (process.env.NODE_ENV === 'development' ||
-          window.location.hostname.includes('production-black-seven') ||
-          window.location.hostname === 'localhost' ||
-          window.location.hostname.includes('github.dev') ||
-          window.location.hostname.includes('preview') ||
-          window.location.hostname.includes('fly.dev') ||
-          window.location.hostname.includes('builder.io') ||
-          window.location.hostname.includes('0.0.0.0') ||
-          window.location.hostname.includes('127.0.0.1') ||
-          window.location.port === '3001' ||
-          window.location.search.includes('dev=true')) {
+      // Development auto-login. Gated on the build type rather than hostname,
+      // so a deployed production build can never be entered without real
+      // credentials, and the query-string escape hatch is explicitly refused.
+      if (process.env.NODE_ENV !== 'production' &&
+          !window.location.search.includes('dev=true')) {
         setUser({
           id: '5df85ca3-7a54-4798-a665-c31da8d9caad', // Primary owner ID for dev mode
           email: 'dev@lojik.com',

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -267,6 +267,40 @@
   background: linear-gradient(135deg, #94a3b8 0%, #cbd5e1 100%);
 }
 
+.forgot-password-link {
+  display: block;
+  width: 100%;
+  margin-top: 1rem;
+  padding: 0;
+  background: none;
+  border: none;
+  color: #2563eb;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  cursor: pointer;
+}
+
+.forgot-password-link:hover:not(:disabled) {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+.forgot-password-link:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.reset-sent-message {
+  background-color: #f0fdf4;
+  color: #166534;
+  padding: 0.875rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  border: 1px solid #bbf7d0;
+}
+
 /* Login Footer */
 .login-footer {
   text-align: center;

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -7,6 +7,31 @@ const LandingPage = ({ onLogin }) => {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [resetSent, setResetSent] = useState(false);
+
+  const handleForgotPassword = async () => {
+    setError('');
+    setResetSent(false);
+
+    if (!email) {
+      setError('Enter your email address first, then click Forgot password.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const target = email.trim().toLowerCase();
+      const { error: resetError } = await supabase.auth.resetPasswordForEmail(target, {
+        redirectTo: window.location.origin
+      });
+      if (resetError) throw resetError;
+      setResetSent(true);
+    } catch (err) {
+      setError(err.message || 'Could not send the reset email. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -105,11 +130,25 @@ const LandingPage = ({ onLogin }) => {
               </div>
 
               {error && <div className="error-message">{error}</div>}
+              {resetSent && (
+                <div className="reset-sent-message">
+                  Check your email for a link to set a new password.
+                </div>
+              )}
 
               <button type="submit" className="login-button" disabled={loading}>
                 {loading ? 'Signing in...' : 'Sign In'}
               </button>
             </form>
+
+            <button
+              type="button"
+              className="forgot-password-link"
+              onClick={handleForgotPassword}
+              disabled={loading}
+            >
+              Forgot password?
+            </button>
 
             <div className="login-footer">
               <p>Need help? Contact your system administrator</p>

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -49,8 +49,9 @@ const LandingPage = ({ onLogin }) => {
       const { data: employee, error: empError } = await supabase
         .from('employees')
         .select('*')
-        .eq('email', email.toLowerCase())
-        .single();
+        .or(`auth_user_id.eq.${authData.user.id},email.eq.${email.toLowerCase()}`)
+        .limit(1)
+        .maybeSingle();
 
       if (empError || !employee) {
         throw new Error('Employee record not found. Please contact your administrator.');

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -84,9 +84,6 @@ const LandingPage = ({ onLogin }) => {
         <div className="header-content">
           <div className="logo-title-group">
             <LogoImage />
-            <div className="title-group">
-              <p className="tagline">For<br />Professional Property Appraisers</p>
-            </div>
           </div>
         </div>
       </header>

--- a/src/components/ResetPassword.jsx
+++ b/src/components/ResetPassword.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import './LandingPage.css';
+
+const ResetPassword = () => {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({ password });
+      if (updateError) throw updateError;
+
+      setSuccess(true);
+      // Drop the recovery session so the new password is used on the next sign-in.
+      await supabase.auth.signOut();
+      setTimeout(() => window.location.replace(window.location.origin), 2500);
+    } catch (err) {
+      setError(err.message || 'Could not update password. The link may have expired.');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="landing-container">
+      <main className="landing-main">
+        <div className="content-wrapper">
+          <div className="login-card">
+            <h3>Choose a New Password</h3>
+
+            {success ? (
+              <div className="reset-sent-message">
+                Password updated. Taking you back to sign in...
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit}>
+                <div className="form-group">
+                  <label htmlFor="new-password">New Password</label>
+                  <input
+                    type="password"
+                    id="new-password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="At least 8 characters"
+                    required
+                    disabled={loading}
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="confirm-password">Confirm New Password</label>
+                  <input
+                    type="password"
+                    id="confirm-password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    placeholder="Re-enter your new password"
+                    required
+                    disabled={loading}
+                  />
+                </div>
+
+                {error && <div className="error-message">{error}</div>}
+
+                <button type="submit" className="login-button" disabled={loading}>
+                  {loading ? 'Updating...' : 'Update Password'}
+                </button>
+              </form>
+            )}
+
+            <div className="login-footer">
+              <p>Need help? Contact your system administrator</p>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/src/components/UserManagement.jsx
+++ b/src/components/UserManagement.jsx
@@ -262,12 +262,6 @@ const UserManagement = ({ onViewAs }) => {
       });
       if (authError) throw authError;
 
-      // Store the initial password on the employee record for admin reference
-      await supabase
-        .from('employees')
-        .update({ initial_password: newUser.password })
-        .eq('id', employeeId);
-
       // Save all organization links in junction table
       const orgIdsToLink = isPpaUser ? [] : lojikOrgIds;
       if (orgIdsToLink.length > 0) {
@@ -329,12 +323,6 @@ const UserManagement = ({ onViewAs }) => {
       });
       const result = await res.json();
       if (!res.ok) throw new Error(result.error || 'Failed to update password');
-
-      // Store the new password on the employee record
-      await supabase
-        .from('employees')
-        .update({ initial_password: resetPassword })
-        .eq('id', selectedUser.id);
 
       setSuccessMessage(`Password updated for ${selectedUser.first_name} ${selectedUser.last_name}`);
       setShowResetModal(false);

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -4891,8 +4891,9 @@ export const authHelpers = {
       const { data: employee } = await supabase
         .from('employees')
         .select('*')
-        .eq('email', session.user.email.toLowerCase())
-        .single();
+        .or(`auth_user_id.eq.${session.user.id},email.eq.${session.user.email.toLowerCase()}`)
+        .limit(1)
+        .maybeSingle();
 
       return {
         ...session.user,

--- a/supabase/functions/update-user-password/index.ts
+++ b/supabase/functions/update-user-password/index.ts
@@ -1,0 +1,84 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+  });
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+    const token = authHeader.replace('Bearer ', '');
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const anonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+
+    // The caller must present a real user session. The anon key is published in
+    // the browser bundle, so it is never sufficient on its own.
+    const verifyClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: `Bearer ${token}` } },
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const { data: { user: caller } } = await verifyClient.auth.getUser();
+    if (!caller) {
+      return json({ error: 'Unauthorized' }, 401);
+    }
+
+    const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: callerProfile } = await supabaseAdmin
+      .from('profiles')
+      .select('role')
+      .eq('id', caller.id)
+      .single();
+
+    if (callerProfile?.role !== 'admin') {
+      return json({ error: 'Forbidden' }, 403);
+    }
+
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return json({ error: 'Email and password are required' }, 400);
+    }
+    if (typeof password !== 'string' || password.length < 8) {
+      return json({ error: 'Password must be at least 8 characters' }, 400);
+    }
+
+    const { data: { users }, error: listError } = await supabaseAdmin.auth.admin.listUsers();
+    if (listError) throw listError;
+
+    const target = users.find((u: any) => u.email?.toLowerCase() === String(email).toLowerCase());
+    if (!target) {
+      return json({ error: 'User not found in auth system' }, 404);
+    }
+
+    const { error: updateError } = await supabaseAdmin.auth.admin.updateUserById(target.id, {
+      password,
+    });
+    if (updateError) throw updateError;
+
+    console.log(`password reset for ${target.id} by admin ${caller.id}`);
+
+    return json({ success: true });
+  } catch (err) {
+    return json({ error: (err as Error).message || 'Failed to update password' }, 500);
+  }
+});


### PR DESCRIPTION
### Summary
Closes several security gaps found during a security review: an unauthenticated admin-login bypass, plaintext password storage, a broken employee lookup on real sign-in, and an unauthenticated password-reset edge function. Adds self-service password recovery and removes a stale marketing tagline from the landing page.

### Problem
The app had multiple auth vulnerabilities: any deployed URL with `?dev=true` (or matching hostnames like `production-black-seven`) granted a full admin session with no password, the `update-user-password` edge function accepted the public anon key to reset any user's password via `service_role`, and employee/initial passwords were being written in plaintext to the `employees` table. Separately, real sign-in failed for the admin account because the employee lookup only matched on email while the auth email and employee record email differed, and there was no way for a user to recover a forgotten password.

### Solution
Gated dev auto-login strictly to non-production environments, removed the query-string bypass, switched the employee lookup to match on `auth_user_id` or email, added a proper password-recovery flow (reset screen + forgot-password link + recovery-mode routing), stopped writing plaintext passwords, hardened the password-reset edge function to require an authenticated admin session, and removed the outdated landing page tagline.

### Key Changes
- `src/App.js`: dev auto-login now requires `NODE_ENV !== 'production'`; removed the `?dev=true`/hostname bypass; added `recoveryMode` state driven by a `#type=recovery` hash to route users into the reset-password screen; removed the write of `initial_password` on change-password.
- `src/lib/supabaseClient.js` (`authHelpers.getCurrentUser`) and `LandingPage.jsx`: employee lookup now uses `.or('auth_user_id.eq.<uid>,email.eq.<email>').maybeSingle()` instead of a strict email-only match.
- `src/components/ResetPassword.jsx` (new): set-new-password screen with minimum length/confirmation validation, signs the user out after updating so the new password takes effect on next login.
- `src/components/LandingPage.jsx` / `.css`: added "Forgot password?" link calling `resetPasswordForEmail`, a reset-sent confirmation message, and removed the "For Professional Property Appraisers" tagline block.
- `src/components/UserManagement.jsx`: removed writes of `initial_password` on user creation and password reset.
- `supabase/functions/update-user-password/index.ts` (new/tracked): edge function now requires a valid bearer JWT, verifies the caller via the anon-key client, checks `profiles.role = 'admin'` before using `service_role` to update the target user's password, enforces an 8-character minimum, and logs resets.
- `SECURITY-REMEDIATION-STATUS.md` (new): documents what's shipped in this branch vs. already live, remaining Supabase dashboard toggles, and the planned RLS rollout.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/twisted-prize-rfos5bi0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-twisted-prize-rfos5bi0.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 252`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>twisted-prize-rfos5bi0</branchName>-->