### PR TITLE
Fix BRT lot size calculation priority and precision

### DIFF
--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -574,7 +574,10 @@ const JobContainer = ({
                   calculated_lot_acre: (() => {
                     try {
                       const vendor = (jobData && (jobData.vendor_source || jobData.vendor)) || 'BRT';
-                      const val = interpretCodes.getCalculatedAcreage(propertyData, vendor);
+                      const val = interpretCodes.getCalculatedAcreage(
+                        { ...propertyData, property_market_analysis: marketAnalysis },
+                        vendor
+                      );
                       const num = parseFloat(val);
                       return !isNaN(num) && num > 0 ? num : null;
                     } catch (e) {

--- a/src/components/job-modules/market-tabs/LandValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/LandValuationTab.jsx
@@ -994,7 +994,14 @@ useEffect(() => {
 
   // ========== CALCULATE ACREAGE HELPER - ENHANCED ==========
   const calculateAcreage = useCallback((property) => {
-    // Always return acres - don't convert here
+    // Always return acres - don't convert here.
+    // Unit Rate Config writes the exact total for the VCS's configured method and a
+    // rounded companion in the other unit, so derive from SF when it's present —
+    // market_manual_lot_acre is rounded to 2 decimals and loses ~4,356 SF of
+    // resolution, which shows up as wrong lot sizes on small lots in SF mode.
+    const manualSf = parseFloat(property?.market_manual_lot_sf);
+    if (manualSf > 0) return manualSf / 43560;
+
     const acres = interpretCodes.getCalculatedAcreage(property, vendorType);
     return parseFloat(acres);
   }, [vendorType]);

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -2260,44 +2260,39 @@ getTotalLotSize: async function(property, vendorType, codeDefinitions) {
 
     // ===== NEW CORRECT WORKFLOW FOR BRT =====
     if (vendorType === 'BRT') {
-      // 1. FIRST: Check for lot dimensions (frontage × depth)
-      const frontage = marketAnalysis?.asset_lot_frontage ?? property.asset_lot_frontage;
-      const depth = marketAnalysis?.asset_lot_depth ?? property.asset_lot_depth;
+      // BRT source files ship only frontage/depth. Acre and SF come from the
+      // Unit Rate Config tool, so the manual values are authoritative and
+      // frontage × depth is the last resort for jobs where it hasn't been run.
 
-      if (frontage && depth && parseFloat(frontage) > 0 && parseFloat(depth) > 0) {
-        const sf = parseFloat(frontage) * parseFloat(depth);
-        const acres = (sf / 43560).toFixed(2);
-        // Calculated from frontage × depth
-        return acres;
-      }
-
-      // 2. FALLBACK: Use Unit Rate Config results (market_manual_lot_acre)
+      // 1. Unit Rate Config results (market_manual_lot_acre)
       const manualAcre = marketAnalysis?.market_manual_lot_acre ?? property.market_manual_lot_acre;
       if (manualAcre && parseFloat(manualAcre) > 0) {
-        // Using Unit Rate Config manual acres
         return parseFloat(manualAcre).toFixed(2);
       }
 
-      // 3. Check if we can derive from market_manual_lot_sf
+      // 2. Unit Rate Config results (market_manual_lot_sf)
       const manualSf = marketAnalysis?.market_manual_lot_sf ?? property.market_manual_lot_sf;
       if (manualSf && parseFloat(manualSf) > 0) {
-        const acres = (parseFloat(manualSf) / 43560).toFixed(2);
-        // Calculated from Unit Rate Config SF
-        return acres;
+        return (parseFloat(manualSf) / 43560).toFixed(2);
       }
 
-      // 4. Final fallback: Check for pre-calculated fields (unlikely for BRT but just in case)
+      // 3. Pre-calculated asset fields (unlikely for BRT but just in case)
       const acreField = marketAnalysis?.asset_lot_acre ?? property.asset_lot_acre;
       if (acreField && parseFloat(acreField) > 0) {
-        // Using pre-calculated asset_lot_acre field
         return parseFloat(acreField).toFixed(2);
       }
 
       const sfField = marketAnalysis?.asset_lot_sf ?? property.asset_lot_sf;
       if (sfField && parseFloat(sfField) > 0) {
-        const acres = (parseFloat(sfField) / 43560).toFixed(2);
-        // Calculated from asset_lot_sf field
-        return acres;
+        return (parseFloat(sfField) / 43560).toFixed(2);
+      }
+
+      // 4. Last resort: lot dimensions (frontage × depth)
+      const frontage = marketAnalysis?.asset_lot_frontage ?? property.asset_lot_frontage;
+      const depth = marketAnalysis?.asset_lot_depth ?? property.asset_lot_depth;
+      if (frontage && depth && parseFloat(frontage) > 0 && parseFloat(depth) > 0) {
+        const sf = parseFloat(frontage) * parseFloat(depth);
+        return (sf / 43560).toFixed(2);
       }
 
       // BRT: No more LANDUR summation - that was the old incorrect way


### PR DESCRIPTION
### Summary
Fixes the lot acreage/SF calculation for BRT jobs so Unit Rate Config results take priority over raw frontage × depth, and preserves square-foot precision when deriving acreage.

### Problem
For BRT jobs, lot size on the Land Valuation tab was being calculated from raw `asset_lot_frontage` × `asset_lot_depth` before checking the Unit Rate Config manual values (`market_manual_lot_acre` / `market_manual_lot_sf`). Since BRT source files only provide frontage/depth, and acre/SF totals are actually derived via the Unit Rate Config tool, this caused incorrect lot sizes (e.g., Barnegat Light properties showing values like 6098 instead of the correct 6250). Additionally, converting from the 2-decimal-rounded `market_manual_lot_acre` back to square feet lost resolution (~4,356 SF), producing wrong results for small lots when SF is the configured unit.

### Solution
Reordered the BRT lot size fallback chain so Unit Rate Config manual values are checked first, with frontage × depth demoted to a last-resort fallback. Also updated the acreage helper to derive from `market_manual_lot_sf` directly when present, avoiding lossy round-trip conversion through the rounded acre value.

### Key Changes
- `supabaseClient.js` (`getTotalLotSize`): Reordered BRT workflow priority to check `market_manual_lot_acre` → `market_manual_lot_sf` → `asset_lot_acre` → `asset_lot_sf` → frontage × depth (last resort), replacing the previous order where frontage × depth was checked first.
- `LandValuationTab.jsx` (`calculateAcreage`): Now derives acreage directly from `market_manual_lot_sf` when available, avoiding precision loss from the rounded `market_manual_lot_acre` value.
- `JobContainer.jsx`: Passes `property_market_analysis` (marketAnalysis) into `getCalculatedAcreage` calls so market-level manual values are considered in the calculation.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/thick-moon-y0crgell"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-thick-moon-y0crgell.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 257`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>thick-moon-y0crgell</branchName>-->