### PR TITLE
Update age analysis categories to use fixed year ranges

### DIFF
--- a/src/components/job-modules/market-tabs/OverallAnalysisTab.jsx
+++ b/src/components/job-modules/market-tabs/OverallAnalysisTab.jsx
@@ -273,8 +273,8 @@ const OverallAnalysisTab = ({
     
     if (age <= 10) return 'New';
     if (age <= 20) return 'Newer';
-    if (age <= 35) return 'Moderate';
-    if (age <= 50) return 'Older';
+    if (yearBuilt >= 1990) return 'Moderate';
+    if (yearBuilt >= 1950) return 'Older';
     return 'Historic';
   };
 
@@ -673,8 +673,8 @@ const OverallAnalysisTab = ({
         isBaseline: false
       },
       'Moderate': {
-        label: 'Moderate (21-35 years)',
-        minYear: currentYear - 35,
+        label: `Moderate (1990-${currentYear - 21})`,
+        minYear: 1990,
         maxYear: currentYear - 21,
         allProperties: [],
         salesProperties: [],
@@ -694,9 +694,9 @@ const OverallAnalysisTab = ({
         isBaseline: false
       },
       'Older': {
-        label: 'Older (36-50 years)',
-        minYear: currentYear - 50,
-        maxYear: currentYear - 36,
+        label: 'Older (1950-1989)',
+        minYear: 1950,
+        maxYear: 1989,
         allProperties: [],
         salesProperties: [],
         totalSizeAll: 0,
@@ -715,8 +715,8 @@ const OverallAnalysisTab = ({
         isBaseline: false
       },
       'Historic': {
-        label: 'Historic (50+ years)',
-        maxYear: currentYear - 51,
+        label: 'Historic (pre-1950)',
+        maxYear: 1949,
         allProperties: [],
         salesProperties: [],
         totalSizeAll: 0,


### PR DESCRIPTION
### Summary
Updates the age classification logic in the Overall Analysis tab to use fixed calendar year thresholds instead of rolling age-based ranges for the "Moderate", "Older", and "Historic" categories.

### Problem
The previous age analysis defined "Moderate", "Older", and "Historic" categories using relative age offsets (e.g. 21-35 years, 36-50 years, 50+ years) from the current year. This made the boundaries shift every year and didn't align with how age categories should be anchored to specific construction eras.

### Solution
Replaced the relative age-offset calculations for "Moderate", "Older", and "Historic" with fixed year comparisons based on `yearBuilt`, anchoring boundaries to specific calendar years (1990 and 1950) rather than a sliding age window.

### Key Changes
- `getPropertyAgeCategory` now checks `yearBuilt >= 1990` for "Moderate" and `yearBuilt >= 1950` for "Older", instead of computing age ranges of 21-35 and 36-50 years.
- Updated the `Moderate` category config to use `minYear: 1990` and a dynamic label showing the range from 1990 to the current "Newer" cutoff.
- Updated the `Older` category config to use fixed `minYear: 1950` / `maxYear: 1989` with a static label "Older (1950-1989)".
- Updated the `Historic` category config to use `maxYear: 1949` with a static label "Historic (pre-1950)".

---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/crucial-claw-jduilzwk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-crucial-claw-jduilzwk.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 259`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>crucial-claw-jduilzwk</branchName>-->