### PR TITLE
Rework masked sales as DB-backed promotions instead of overlays

### DIFF
--- a/copilot-os.md
+++ b/copilot-os.md
@@ -8,7 +8,9 @@
 > scoping helpers (§ RLS), storage buckets made private, direct local-folder
 > photo workflow replacing the PowerComp print-time merge (§ 11), geocoder +
 > appeal map + distance filter, Coordinates cleanup sub-tab, sales-pool chip
-> filter w/ Lojik year adjustment, AppealLog→CME bracket label parity.
+> filter w/ Lojik year adjustment, AppealLog→CME bracket label parity,
+> masked sales reworked from display-time overlay to `sales_override` promotion
+> with DB-backed skip decisions (§ 13).
 
 ---
 
@@ -917,14 +919,44 @@ This codebase has been built iteratively over the course of a year. Every patter
 
 15. **Sales-pool window math is shared and Lojik-aware** — `SalesComparisonTab.getCSPDateRange`, `AppellantEvidencePanel.sampleRange`, `DetailedAppraisalGrid` (inline in the comps prep), the admin Geocoder's `csvSalesWindow`, and `CoordinatesSubTab.salesWindow` all anchor on `jobs.end_date` and all subtract one from the year when `organizations.org_type === 'assessor'` (Lojik). Don't fork this convention. If the window definition needs to change, change all five usages together — and confirm with the user, because that math is the basis for sales review, sales pool inclusion, comp date ranges, and the coordinate cleanup queue.
 
-## 13. Masked Sales (BRT-only) — feature + pending test
+## 13. Masked Sales (BRT-only)
 
 BRT ships up to ~4 prior sales per parcel in `property_records.prev_sales`. A "masked" sale is a good older sale that got overwritten by a later **junk dollar-sale** (e.g. a $1 deed-of-correction), so it disappears from Sales Review (keys off the current sale's normalized value) and the Sales Pool (shows the most recent sampling).
 
-Pieces:
-- `src/lib/unmaskedSales.js` — detection (`detectMaskedCandidates`, gates on **current sale price ≤ $1,000**; NU codes are intentionally NOT used because BRT withholds them), HPI time-normalization, singular persistence to `property_market_analysis.unmasked_sale` (one JSONB per parcel — idempotent, overwrite-only), and `recheckMaskedAfterUpload` (post-upload classifier).
-- `ScanMaskedSalesModal.jsx` — fixed-size modal (uses `.csv-export-modal-box` CSS, NOT arbitrary Tailwind `max-h-[..]` which the v2 CDN ignores). Per-row **Unmask / Skip** decisions, progress bar, "Hide reviewed" filter. Skips persist per job in `localStorage` (`masked-skip-<jobId>`); unmasks persist in the DB.
-- Surfaced in **Sales Review** (wide window, `fromYear: 2012`) and **Sales Pool** (tight, user-selected `compFilters.salesDateStart/End`). Sales Pool injects the unmasked prior as the effective pool sale only when the current sale is junk (≤ $100), so a newer valid sale auto-supersedes it.
-- Post-upload re-check lives in `FileUploadButton.jsx` right after `computeTargetNormalization` (the pre-load spot, since normalization clearing was moved there to avoid the heavy job load). It auto-clears **stale** unmasks (a recent valid sale superseded them) and **flags** new masks (a junk dollar-sale kept over a healthy prior) — flags only, never auto-applies, since new masks still need BRT NU verification.
+### An unmask is a promotion, not an overlay
 
-**⏳ PENDING TEST (not yet validated end-to-end):** the post-upload re-check has only been verified to compile. The whole loop only matters **IF the user actually runs Scan Masked Sales + unmasks first, THEN does a file update** — only then is there an `unmasked_sale` for the re-check to clear/supersede. Cedar Grove (`be01c481-...`) was already fully unmasked, so it can't exercise the "new incoming sale clears a stale unmask" path without a fresh BRT update. Next time a BRT job has unmasked sales and receives a source-file update, watch the batch log for `🔓 Cleared N stale unmasked sale(s)` and `⚠️ N new masked sale(s)`. ✅
+**This is the thing to understand before touching any of it.** Unmasking writes
+the recovered prior into `property_records.sales_date/price/nu/book/page` and
+sets `sales_override = true` — the *same* operation as
+`DetailedAppraisalGrid`'s swap-hidden-sale and the updater's "Keep Old"
+(`FileUploadButton.jsx:1717`). Once promoted it is simply the parcel's sale, so
+normalization, the sales-period gate, Land Valuation and CME all consume it
+without knowing unmasking exists. **Do not re-add render-time substitution.**
+An earlier revision injected the sale at display time in Sales Review and the
+Sales Pool; that was replaced precisely because every downstream consumer had to
+learn about it individually, and most never did.
+
+`sales_override_meta` carries `promoted_from: 'masked_scan'`, which is what
+distinguishes our promotion from a Detailed-grid swap — reversal only touches
+our own. `original_sale` holds the displaced junk deed. Re-unmasking an
+already-promoted parcel deliberately keeps the *original* `original_sale` rather
+than overwriting it with the last promoted prior, or the real file sale would be
+lost on the second pass.
+
+Pieces:
+- `src/lib/unmaskedSales.js` — detection (`detectMaskedCandidates`, gates on **current sale price ≤ $1,000**; NU codes are intentionally NOT used because BRT withholds them), HPI time-normalization, promotion + reversal in `saveUnmaskedSales`, and `recheckMaskedAfterUpload` (post-upload classifier). `property_market_analysis.unmasked_sale` still exists but is now only a **marker + audit record** (source, multiplier, who/when) — it is not a data source for any surface.
+- `saveUnmaskedSales` also writes `values_norm_time` at save time, so **no normalization re-run is needed**. This is safe because the unmask HPI math (`loadHpiMultiplier`) is identical to `targetNormalization.getHPIMultiplier` — same table, same year clamping, same `Math.round(price × multiplier)`. It must be passed the **job's** `normalization_config.normalizeToYear` (threaded from both parents); the `MASKED_DEFAULTS.normalizeToYear` constant is a fallback only. `values_norm_size` is deliberately NOT written — size normalization is a separate PreValuation pass.
+- `ScanMaskedSalesModal.jsx` — fixed-size modal (uses `.csv-export-modal-box` CSS, NOT arbitrary Tailwind `max-h-[..]` which the v2 CDN ignores). Per-row **Unmask / Skip** decisions, progress bar, "Hide reviewed" filter. Both decisions persist in the DB: unmasks as promotions, skips in `property_market_analysis.masked_review_skipped`. Skips were briefly kept in `localStorage` — they are parcel-level team truth and belong in the DB, so a manager doesn't redo a colleague's BRT verification.
+- Dates render through `parseDateLocal`. `new Date('2020-09-11')` is UTC midnight and displays as the 10th anywhere behind UTC; the whole modal was a day early until this was fixed.
+- Surfaced in **Sales Review** (wide window, `fromYear: 2012`) and **Sales Pool** (tight, user-selected `compFilters.salesDateStart/End`). Both show one row per parcel carrying the promoted sale; the junk deed is never displayed. `_isUnmasked` (amber badge) derives from the override marker.
+- Post-upload re-check lives in `FileUploadButton.jsx` right after `computeTargetNormalization`. **The supersede rule now lives in the DB trigger `respect_sales_override`, not in JS** — it drops the override when the incoming sale is newer, over $100, and carries a usable NU code, otherwise it restores the promoted sale field by field. `recheckMaskedAfterUpload` no longer decides; it reads whether the override survived and syncs the marker to match. Don't reimplement that rule in application code.
+- `patchPropertiesWithMarketAnalysis` re-reads the sale fields from `property_records` as well as the market-analysis columns. Without that, a promotion lands in the DB but the stale $1 stays in memory and Sales Review's `sales_price <= 100` filter makes the parcel vanish.
+
+### Patterns here that look wrong but are correct
+
+| Pattern | Why |
+|---------|-----|
+| Unmasked sales get a `values_norm_time` but no CSP/PSP/HSP period code | Period windows only reach back ~3 years. An unmasked sale is by definition old — a recent sale wouldn't have years of junk deeds stacked on it. They feed Land Valuation and the `Avg Price (t)` columns; they were never meant to drive effective age. |
+| `unmasked_sale` is kept even though nothing reads it for data | It is the audit trail and the scan's `alreadyUnmasked` marker. Dropping it loses provenance and the ability to review a past decision. |
+| A promoted parcel still appears in the scan list | `detectMaskedCandidates` keeps it via `alreadyUnmasked` so the decision can be reversed. Its `current` now shows the promoted sale, which is correct post-promotion. |
+| `prev_sales` can contain a sale BRT's Mod IV panel doesn't show | `extractPrevSales` reads `PREV_SALE{1..5}DATE/AMT` verbatim from the export. Confirmed BRT-side bug (Barnegat Light 38/14 carries a 2016-07-29 $535,000 in slot 1 that the Mod IV Sales History omits). Don't "fix" the parser — verify against the file. |

--- a/copilot-os.md
+++ b/copilot-os.md
@@ -187,6 +187,28 @@ Note: `SET search_path` blocks SQL-function inlining, so these run as a
 Worth it — keeping `search_path` pinned avoids a security advisory, and one
 650 ms call still beats 165 round trips by a wide margin.
 
+### Agent DB access under RLS — never use a `.env` file
+
+RLS blocks the anon/publishable key from most tables, so agent-side helper
+scripts (`scripts/lv-query.js`, `scripts/job-cols.js`) need the Supabase
+**secret** key. That key lives **only as a platform environment variable**
+(`SUPABASE_SECRET_KEY`), injected into the process at runtime. There is no
+`.env` file on disk and there must never be one.
+
+- To add or change it, use the environment-variable settings (Fusion:
+  `ProposeEnvVariable`). Do **not** write it into `.env`, a script, or a doc.
+- Scripts read `process.env.SUPABASE_SECRET_KEY` and
+  `process.env.SUPABASE_URL || process.env.REACT_APP_SUPABASE_URL`. Only
+  `REACT_APP_SUPABASE_URL` is actually set, so keep that fallback.
+- The frontend gets `REACT_APP_SUPABASE_URL` + `REACT_APP_SUPABASE_ANON_KEY`
+  (the `sb_publishable_...` key — the legacy `anon` JWT is disabled). Those are
+  public by design and stay subject to RLS.
+- `.env` is gitignored **and untracked**. It was tracked until `05ded38a`
+  deleted it; while tracked, gitignore did nothing and the auto-commit bot kept
+  committing it, which is what tripped GitHub push protection. If a `.env` ever
+  reappears in `git ls-files`, that is the bug — remove it from the index, don't
+  work around the push block.
+
 ### Core Tables
 
 #### `organizations`

--- a/src/components/job-modules/JobContainer.jsx
+++ b/src/components/job-modules/JobContainer.jsx
@@ -442,6 +442,7 @@ const JobContainer = ({
                   values_norm_time,
                   sales_history,
                   unmasked_sale,
+                  masked_review_skipped,
                   market_manual_lot_acre,
                   market_manual_lot_sf
                 )
@@ -559,6 +560,7 @@ const JobContainer = ({
                   values_norm_time: marketAnalysis.values_norm_time || null,
                   sales_history: marketAnalysis.sales_history || null,
                   unmasked_sale: marketAnalysis.unmasked_sale || null,
+                  masked_review_skipped: marketAnalysis.masked_review_skipped === true,
                   // Ensure manual/calculated lot acreage and applied unit codes are available to UI
                   market_manual_lot_acre: marketAnalysis.market_manual_lot_acre ?? property.market_manual_lot_acre ?? null,
                   market_manual_lot_sf: marketAnalysis.market_manual_lot_sf ?? property.market_manual_lot_sf ?? null,

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -8307,8 +8307,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         surfaceLabel="Sales Pool"
         onSaved={(res) => {
           // Surgical patch: update only the changed properties in memory
-          if (patchPropertiesWithMarketAnalysis && res?.saved > 0) {
-            console.log(`🔧 Surgical patch: unmasked ${res.saved} sales`);
+          if (patchPropertiesWithMarketAnalysis && res?.changed > 0) {
+            console.log(`🔧 Surgical patch: unmasked ${res.saved}, skipped ${res.skipped}`);
             setPatchToast({ type: 'loading', message: '🔧 Updating CME data...' });
             patchPropertiesWithMarketAnalysis().then(() => {
               setPatchToast({ type: 'success', message: '✅ CME data refreshed instantly!' });

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1472,21 +1472,11 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
           };
         }
 
-        // SECOND: Apply BRT masked sales unmask (only if no manual override)
-        // BRT masked sales: when the current sale is a junk dollar-sale (≤ $100,
-        // which the filter below would drop anyway) and the user has unmasked a
-        // healthy prior, swap that prior in as the parcel's effective pool sale.
-        // Raw price/date are used here (the pool keys off sale price + window),
-        // not the HPI-normalized value (that's the Sales Review surface).
-        const currentJunk = !p.sales_price || Number(p.sales_price) <= 100;
-        if (currentJunk && p.unmasked_sale && p.unmasked_sale.sales_price) {
-          return {
-            ...p,
-            sales_price: p.unmasked_sale.sales_price,
-            sales_date: p.unmasked_sale.sales_date,
-            sales_nu: p.unmasked_sale.sales_nu ?? null,
-            _isUnmasked: true,
-          };
+        // BRT masked sales are promoted into property_records at unmask time,
+        // so the recovered prior is already this parcel's sale — the pool needs
+        // no substitution, just the marker for display.
+        if (p.sales_override === true && p.sales_override_meta?.promoted_from === 'masked_scan') {
+          return { ...p, _isUnmasked: true };
         }
         return p;
       })
@@ -8304,6 +8294,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
             : undefined,
           toDate: compFilters.salesDateEnd || null,
         }}
+        normalizeToYear={marketLandData?.normalization_config?.normalizeToYear || 2025}
         surfaceLabel="Sales Pool"
         onSaved={(res) => {
           // Surgical patch: update only the changed properties in memory

--- a/src/components/job-modules/final-valuation-tabs/SalesReviewTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesReviewTab.jsx
@@ -1690,8 +1690,8 @@ const SalesReviewTab = ({
         surfaceLabel="Sales Review"
         onSaved={(res) => {
           // Surgical patch: update only the changed properties in memory
-          if (patchPropertiesWithMarketAnalysis && res?.saved > 0) {
-            console.log(`🔧 Surgical patch: unmasked ${res.saved} sales`);
+          if (patchPropertiesWithMarketAnalysis && res?.changed > 0) {
+            console.log(`🔧 Surgical patch: unmasked ${res.saved}, skipped ${res.skipped}`);
             setPatchToast({ type: 'loading', message: '🔧 Updating data...' });
             patchPropertiesWithMarketAnalysis().then(() => {
               setPatchToast({ type: 'success', message: '✅ Data refreshed instantly!' });

--- a/src/components/job-modules/final-valuation-tabs/SalesReviewTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesReviewTab.jsx
@@ -236,24 +236,10 @@ const SalesReviewTab = ({
       prop._isMainCard === undefined ? true : prop._isMainCard
     );
 
-    // Inject unmasked sales as their own synthetic rows. Each carries the
-    // unmasked prior sale's price/date/norm-time while keeping the parcel's
-    // physical attributes, so it sorts/filters alongside real sales. Flagged
-    // with _isUnmasked for badge rendering and a distinct id to avoid key
-    // collisions with the current-sale row.
-    const unmaskedRows = mainCardProps
-      .filter(prop => prop.unmasked_sale && prop.unmasked_sale.sales_price)
-      .map(prop => ({
-        ...prop,
-        id: `${prop.id}_unmasked`,
-        _isUnmasked: true,
-        sales_price: prop.unmasked_sale.sales_price,
-        sales_date: prop.unmasked_sale.sales_date,
-        sales_nu: prop.unmasked_sale.sales_nu || null,
-        values_norm_time: prop.unmasked_sale.values_norm_time || null,
-      }));
-
-    return [...mainCardProps, ...unmaskedRows].map(prop => {
+    // Unmasked sales are promoted into property_records, so the parcel's own
+    // row already carries the recovered sale — no synthetic row, and the junk
+    // deed it displaced stays hidden in sales_override_meta.
+    return mainCardProps.map(prop => {
       // Package detection using centralized _pkg (computed once in JobContainer)
       const pkgInfo = prop._pkg;
       const isPackage = !!pkgInfo;
@@ -317,6 +303,8 @@ const SalesReviewTab = ({
 
       return {
         ...prop,
+        _isUnmasked: prop.sales_override === true
+          && prop.sales_override_meta?.promoted_from === 'masked_scan',
         periodCode,
         isPackage,
         isFarmSale,
@@ -1687,6 +1675,7 @@ const SalesReviewTab = ({
         properties={properties}
         jobData={jobData}
         dateRange={{ fromYear: 2012 }}
+        normalizeToYear={marketLandData?.normalization_config?.normalizeToYear || 2025}
         surfaceLabel="Sales Review"
         onSaved={(res) => {
           // Surgical patch: update only the changed properties in memory

--- a/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
@@ -47,14 +47,9 @@ const ScanMaskedSalesModal = ({
   const [saveResult, setSaveResult] = useState(null);
 
   // "Skip" decisions (reviewed in BRT, decided not to unmask) are parcel-level
-  // truth, so they persist per job in localStorage — survives reopen/surface
-  // switch without a DB column. Unmask decisions persist in the DB itself.
-  const skipStorageKey = jobData?.id ? `masked-skip-${jobData.id}` : null;
-  const loadSkipSet = useCallback(() => {
-    if (!skipStorageKey) return new Set();
-    try { return new Set(JSON.parse(localStorage.getItem(skipStorageKey) || '[]')); }
-    catch { return new Set(); }
-  }, [skipStorageKey]);
+  // truth shared by the whole team, so they live in
+  // property_market_analysis.masked_review_skipped next to unmasked_sale —
+  // a skip survives across users, browsers and machines.
 
   const candidates = useMemo(() => {
     if (!isOpen) return [];
@@ -79,18 +74,17 @@ const ScanMaskedSalesModal = ({
   // must deliberately review each one (verify the NU in BRT first).
   useEffect(() => {
     if (!isOpen) return;
-    const skipped = loadSkipSet();
     const seed = {};
     candidates.forEach(c => {
       const key = c.property_composite_key;
       let decision = 'pending';
       if (c.alreadyUnmasked) decision = 'unmask';
-      else if (skipped.has(key)) decision = 'skip';
+      else if (c.alreadySkipped) decision = 'skip';
       seed[key] = { decision, chosenSource: c.best?.source || null };
     });
     setRows(seed);
     setSaveResult(null);
-  }, [isOpen, candidates, loadSkipSet]);
+  }, [isOpen, candidates]);
 
   const setDecision = useCallback((key, decision) => {
     setRows(prev => ({ ...prev, [key]: { ...prev[key], decision } }));
@@ -127,16 +121,22 @@ const ScanMaskedSalesModal = ({
       const r = rows[c.property_composite_key];
       const decision = r?.decision || 'pending';
       if (decision !== 'unmask') {
-        // skip/pending → clear any existing unmask (only if previously set).
-        return c.alreadyUnmasked
-          ? { property_composite_key: c.property_composite_key, sale: null }
-          : null;
+        // skip/pending → clear any existing unmask (only if previously set) and
+        // record the skip state. Nothing to write when neither changed.
+        const skipped = decision === 'skip';
+        if (!c.alreadyUnmasked && skipped === c.alreadySkipped) return null;
+        return {
+          property_composite_key: c.property_composite_key,
+          sale: null,
+          skipped,
+        };
       }
       const chosen = c.candidates.find(s => s.source === r.chosenSource) || c.best;
       const norm = timeNormalizeUnmasked(chosen, hpiFn, MASKED_DEFAULTS.normalizeToYear);
       return {
         property_composite_key: c.property_composite_key,
         userId,
+        skipped: false,
         sale: {
           sales_price: chosen.sales_price,
           sales_date: chosen.sales_date,
@@ -148,18 +148,6 @@ const ScanMaskedSalesModal = ({
       };
     }).filter(Boolean);
 
-    // Persist the skip set: clear current-scope keys, re-add current skips.
-    if (skipStorageKey) {
-      const set = loadSkipSet();
-      candidates.forEach(c => set.delete(c.property_composite_key));
-      candidates.forEach(c => {
-        if ((rows[c.property_composite_key]?.decision || 'pending') === 'skip') {
-          set.add(c.property_composite_key);
-        }
-      });
-      try { localStorage.setItem(skipStorageKey, JSON.stringify([...set])); } catch { /* ignore quota */ }
-    }
-
     try {
       const res = await saveUnmaskedSales(jobData.id, decisions);
       setSaveResult(res);
@@ -170,7 +158,7 @@ const ScanMaskedSalesModal = ({
     } finally {
       setSaving(false);
     }
-  }, [candidates, rows, hpiFn, jobData?.id, userId, onSaved, skipStorageKey, loadSkipSet]);
+  }, [candidates, rows, hpiFn, jobData?.id, userId, onSaved]);
 
   if (!isOpen) return null;
 

--- a/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
@@ -7,6 +7,7 @@ import {
   saveUnmaskedSales,
   MASKED_DEFAULTS,
 } from '../../../lib/unmaskedSales';
+import { parseDateLocal } from '../../../lib/supabaseClient';
 
 /**
  * Scan Masked Sales modal. Mounted in both Sales Review (wide window) and Sales
@@ -168,7 +169,12 @@ const ScanMaskedSalesModal = ({
   if (!isOpen) return null;
 
   const fmt = (n) => (n || n === 0) ? `$${Math.round(Number(n)).toLocaleString()}` : '—';
-  const fmtDate = (d) => d ? new Date(d).toLocaleDateString('en-US') : '—';
+  // new Date('2020-09-11') is UTC midnight, which renders as the 10th in any
+  // timezone behind UTC. parseDateLocal keeps date-only values on their day.
+  const fmtDate = (d) => {
+    const parsed = parseDateLocal(d);
+    return parsed ? parsed.toLocaleDateString('en-US') : '—';
+  };
 
   return createPortal((
     <div className="csv-export-modal-overlay fixed inset-0 bg-black/50 flex items-center justify-center p-4">

--- a/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
@@ -319,7 +319,7 @@ const ScanMaskedSalesModal = ({
             {counts.total} candidate{counts.total === 1 ? '' : 's'} · {counts.unmask} to unmask · {counts.pending} still pending
             {saveResult && !saveResult.error && (
               <span className="ml-2 text-green-600">
-                ✓ Saved {saveResult.saved} · cleared {saveResult.cleared} — 🔧 CME data ready
+                ✓ Saved {saveResult.saved} · skipped {saveResult.skipped} · cleared {saveResult.cleared} — 🔧 CME data ready
               </span>
             )}
             {saveResult?.error && <span className="ml-2 text-red-600">Error: {saveResult.error}</span>}

--- a/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
+++ b/src/components/job-modules/final-valuation-tabs/ScanMaskedSalesModal.jsx
@@ -20,6 +20,8 @@ import {
  *   jobData      - { id, county, vendor_type }
  *   userId       - current user id (for audit)
  *   dateRange    - { fromYear, toDate } scopes detection
+ *   normalizeToYear - job's configured HPI target year, so unmasked values land
+ *                     on the same footing as every other normalized sale
  *   onSaved      - callback after a successful save (parent should refresh cache)
  *   surfaceLabel - 'Sales Review' | 'Sales Pool' (header copy only)
  */
@@ -30,6 +32,7 @@ const ScanMaskedSalesModal = ({
   jobData = {},
   userId = null,
   dateRange = {},
+  normalizeToYear = MASKED_DEFAULTS.normalizeToYear,
   onSaved = () => {},
   surfaceLabel = 'Sales Review',
 }) => {
@@ -61,7 +64,7 @@ const ScanMaskedSalesModal = ({
     if (!isOpen) return;
     let cancelled = false;
     setHpiLoaded(false);
-    loadHpiMultiplier(county, MASKED_DEFAULTS.normalizeToYear).then(fn => {
+    loadHpiMultiplier(county, normalizeToYear).then(fn => {
       if (cancelled) return;
       setHpiFn(() => fn);
       setHpiLoaded(true);
@@ -132,7 +135,7 @@ const ScanMaskedSalesModal = ({
         };
       }
       const chosen = c.candidates.find(s => s.source === r.chosenSource) || c.best;
-      const norm = timeNormalizeUnmasked(chosen, hpiFn, MASKED_DEFAULTS.normalizeToYear);
+      const norm = timeNormalizeUnmasked(chosen, hpiFn, normalizeToYear);
       return {
         property_composite_key: c.property_composite_key,
         userId,
@@ -141,6 +144,8 @@ const ScanMaskedSalesModal = ({
           sales_price: chosen.sales_price,
           sales_date: chosen.sales_date,
           sales_nu: null, // BRT prev_sales carry no NU code
+          sales_book: chosen.sales_book ?? null,
+          sales_page: chosen.sales_page ?? null,
           source: chosen.source,
           hpi_multiplier: norm.hpi_multiplier,
           values_norm_time: norm.values_norm_time,
@@ -240,7 +245,7 @@ const ScanMaskedSalesModal = ({
                   const r = rows[c.property_composite_key] || {};
                   const decision = r.decision || 'pending';
                   const chosen = c.candidates.find(s => s.source === r.chosenSource) || c.best;
-                  const norm = timeNormalizeUnmasked(chosen, hpiFn, MASKED_DEFAULTS.normalizeToYear);
+                  const norm = timeNormalizeUnmasked(chosen, hpiFn, normalizeToYear);
                   const rowBg = decision === 'unmask'
                     ? 'bg-green-50'
                     : decision === 'skip'

--- a/src/components/job-modules/market-tabs/CostValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/CostValuationTab.jsx
@@ -345,6 +345,11 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
       BASE_COST: 17, REPL_DEPR: 18, IMPROV: 19, CCF: 20, ADJ_VALUE: 21, ADJ_RATIO: 22
     };
 
+    // Sale Price (I) always carries the raw sale, matching the on-screen grid.
+    // The basis drives the math only, so the ratio and improv formulas point at
+    // Price Time (K) when the user picked that basis.
+    const basisCol = priceBasis === 'price_time' ? 'K' : 'I';
+
     // Base cell style - Leelawadee, size 10, centered
     const baseStyle = {
       font: { name: 'Leelawadee', sz: 10 },
@@ -376,6 +381,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
 
       const saleDate = p.sales_date ? new Date(p.sales_date).toISOString().slice(0,10) : '';
       const salePrice = (priceBasis === 'price_time' && p.values_norm_time && p.values_norm_time > 0) ? Number(p.values_norm_time) : (p.sales_price !== undefined && p.sales_price !== null ? Number(p.sales_price) : 0);
+      const rawSalePrice = (p.sales_price !== undefined && p.sales_price !== null) ? Number(p.sales_price) : 0;
       const timeNorm = (p.values_norm_time !== undefined && p.values_norm_time !== null) ? Number(p.values_norm_time) : '';
       const detItems = getEffectiveDetItems(p);
       const baseCost = getEffectiveBaseCost(p);
@@ -398,7 +404,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
 
       // Sales Date, Sale Price, Sale NU, Price Time
       row[COL.SALE_DATE] = saleDate;
-      row[COL.SALE_PRICE] = salePrice || '';
+      row[COL.SALE_PRICE] = rawSalePrice || '';
       row[COL.SALE_NU] = p.sales_nu || '';
       row[COL.PRICE_TIME] = timeNorm || '';
 
@@ -430,7 +436,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
 
       // Improv - FORMULA: =I{rowNum} - P{rowNum} - Q{rowNum}
       if (salePrice) {
-        row[COL.IMPROV] = { f: `I${rowNum}-P${rowNum}-Q${rowNum}`, t: 'n' };
+        row[COL.IMPROV] = { f: `${basisCol}${rowNum}-P${rowNum}-Q${rowNum}`, t: 'n' };
       } else {
         row[COL.IMPROV] = '';
       }
@@ -451,7 +457,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
 
       // Adjusted Ratio - FORMULA: =V{rowNum} / I{rowNum}
       if (yearBuilt && salePrice) {
-        row[COL.ADJ_RATIO] = { f: `IF(I${rowNum}=0,"",V${rowNum}/I${rowNum})`, t: 'n' };
+        row[COL.ADJ_RATIO] = { f: `IF(${basisCol}${rowNum}=0,"",V${rowNum}/${basisCol}${rowNum})`, t: 'n' };
       } else {
         row[COL.ADJ_RATIO] = '';
       }
@@ -477,7 +483,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     // Summary formulas
     summaryRow[COL.SALE_PRICE] = { f: `SUM(I2:I${lastDataRow})`, t: 'n' };
     summaryRow[COL.SALE_NU] = '';
-    summaryRow[COL.PRICE_TIME] = '';
+    summaryRow[COL.PRICE_TIME] = { f: `SUM(K2:K${lastDataRow})`, t: 'n' };
     summaryRow[COL.YEAR_BUILT] = '';
     summaryRow[COL.DEPR] = '';
     summaryRow[COL.BLDG_CLASS] = '';
@@ -489,7 +495,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     summaryRow[COL.IMPROV] = { f: `SUM(T2:T${lastDataRow})`, t: 'n' };
     summaryRow[COL.CCF] = { f: `IF(S${summaryRowNum}=0,"",T${summaryRowNum}/S${summaryRowNum})`, t: 'n' }; // Overall CCF
     summaryRow[COL.ADJ_VALUE] = { f: `SUM(V2:V${lastDataRow})`, t: 'n' };
-    summaryRow[COL.ADJ_RATIO] = { f: `IF(I${summaryRowNum}=0,"",V${summaryRowNum}/I${summaryRowNum})`, t: 'n' }; // Overall Adjusted Ratio
+    summaryRow[COL.ADJ_RATIO] = { f: `IF(${basisCol}${summaryRowNum}=0,"",V${summaryRowNum}/${basisCol}${summaryRowNum})`, t: 'n' }; // Overall Adjusted Ratio
 
     wsData.push(summaryRow);
 

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -5220,6 +5220,24 @@ export const countyHpiService = {
         return properties;
       }
 
+      // Unmasking promotes the recovered sale into property_records, so a patch
+      // that only re-read market analysis would leave the stale junk sale in
+      // memory — and Sales Review's price filter would drop the parcel.
+      const salesMap = new Map();
+      let salesQuery = supabase
+        .from('property_records')
+        .select('property_composite_key, sales_price, sales_date, sales_nu, sales_book, sales_page, sales_override, sales_override_meta')
+        .eq('job_id', jobId);
+      if (Array.isArray(compositeKeys) && compositeKeys.length > 0) {
+        salesQuery = salesQuery.in('property_composite_key', compositeKeys);
+      }
+      const { data: salesRows, error: salesError } = await salesQuery;
+      if (salesError) {
+        console.error('❌ Surgical patch (sales) failed:', salesError);
+      } else {
+        (salesRows || []).forEach(row => salesMap.set(row.property_composite_key, row));
+      }
+
       // Build a map for O(1) lookup
       const analysisMap = new Map();
       marketAnalysisRows.forEach(row => {
@@ -5231,17 +5249,30 @@ export const countyHpiService = {
         const key = p.property_composite_key;
         const analysis = analysisMap.get(key);
 
+        const sales = salesMap.get(key);
+
         if (!analysis) return p; // No update for this property
 
         return {
           ...p,
+          ...(sales ? {
+            sales_price: sales.sales_price ?? null,
+            sales_date: sales.sales_date ?? null,
+            sales_nu: sales.sales_nu ?? null,
+            sales_book: sales.sales_book ?? null,
+            sales_page: sales.sales_page ?? null,
+            sales_override: sales.sales_override === true,
+            sales_override_meta: sales.sales_override_meta ?? null,
+          } : {}),
           location_analysis: analysis.location_analysis || p.location_analysis || null,
           new_vcs: analysis.new_vcs || p.new_vcs || null,
           asset_map_page: analysis.asset_map_page || p.asset_map_page || null,
           asset_key_page: analysis.asset_key_page || p.asset_key_page || null,
           asset_zoning: analysis.asset_zoning || p.asset_zoning || null,
           values_norm_size: analysis.values_norm_size || p.values_norm_size || null,
-          values_norm_time: analysis.values_norm_time || p.values_norm_time || null,
+          // Trust the fresh row — reverting an unmask nulls this, and an ||
+          // fallback would keep resurrecting the stale in-memory value.
+          values_norm_time: analysis.values_norm_time ?? null,
           sales_history: analysis.sales_history || p.sales_history || null,
           unmasked_sale: analysis.unmasked_sale || null, // Critical: refresh unmask data
           masked_review_skipped: analysis.masked_review_skipped === true,

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -5200,7 +5200,7 @@ export const countyHpiService = {
       // Build query for changed rows only (or all if not specified)
       let query = supabase
         .from('property_market_analysis')
-        .select('property_composite_key, location_analysis, new_vcs, asset_map_page, asset_key_page, asset_zoning, values_norm_size, values_norm_time, sales_history, unmasked_sale, market_manual_lot_acre, market_manual_lot_sf, market_manual_acre, asset_lot_acre, asset_lot_sf, asset_lot_frontage, asset_lot_depth, unit_rate_codes_applied')
+        .select('property_composite_key, location_analysis, new_vcs, asset_map_page, asset_key_page, asset_zoning, values_norm_size, values_norm_time, sales_history, unmasked_sale, masked_review_skipped, market_manual_lot_acre, market_manual_lot_sf, market_manual_acre, asset_lot_acre, asset_lot_sf, asset_lot_frontage, asset_lot_depth, unit_rate_codes_applied')
         .eq('job_id', jobId);
 
       // If specific keys provided, only fetch those (surgical)
@@ -5244,6 +5244,7 @@ export const countyHpiService = {
           values_norm_time: analysis.values_norm_time || p.values_norm_time || null,
           sales_history: analysis.sales_history || p.sales_history || null,
           unmasked_sale: analysis.unmasked_sale || null, // Critical: refresh unmask data
+          masked_review_skipped: analysis.masked_review_skipped === true,
           market_manual_lot_acre: analysis.market_manual_lot_acre ?? p.market_manual_lot_acre ?? null,
           market_manual_lot_sf: analysis.market_manual_lot_sf ?? p.market_manual_lot_sf ?? null,
           market_manual_acre: analysis.market_manual_acre ?? p.market_manual_acre ?? null,

--- a/src/lib/unmaskedSales.js
+++ b/src/lib/unmaskedSales.js
@@ -189,11 +189,12 @@ export function detectMaskedCandidates(properties, opts = {}) {
  */
 export async function saveUnmaskedSales(jobId, decisions) {
   if (!jobId || !Array.isArray(decisions) || decisions.length === 0) {
-    return { saved: 0, cleared: 0 };
+    return { saved: 0, cleared: 0, skipped: 0, changed: 0 };
   }
 
   let saved = 0;
   let cleared = 0;
+  let skipped = 0;
 
   for (const d of decisions) {
     const key = d.property_composite_key;
@@ -225,10 +226,12 @@ export async function saveUnmaskedSales(jobId, decisions) {
       console.error('saveUnmaskedSales failed for', key, error);
       continue;
     }
-    if (payload) saved++; else cleared++;
+    if (payload) saved++;
+    else if (d.skipped === true) skipped++;
+    else cleared++;
   }
 
-  return { saved, cleared };
+  return { saved, cleared, skipped, changed: saved + cleared + skipped };
 }
 
 /**

--- a/src/lib/unmaskedSales.js
+++ b/src/lib/unmaskedSales.js
@@ -123,6 +123,8 @@ export function detectMaskedCandidates(properties, opts = {}) {
       .map(s => ({
         sales_price: Number(s.price) || 0,
         sales_date: s.date || null,
+        sales_book: s.book || null,
+        sales_page: s.page || null,
         source: s.source || null,
       }))
       .filter(s => {
@@ -178,18 +180,50 @@ export function detectMaskedCandidates(properties, opts = {}) {
   return out;
 }
 
+// Marks an override as ours, so clearing an unmask never reverts a sale that
+// was promoted by the Detailed grid's swap-hidden-sale UI.
+const UNMASK_PROMOTED_FROM = 'masked_scan';
+
 /**
  * Persist a batch of unmask decisions.
+ *
+ * An unmask *promotes* the recovered prior into property_records — the same
+ * operation as DetailedAppraisalGrid's swap-hidden-sale and the updater's
+ * "Keep Old". Once promoted it is simply the parcel's sale, so normalization,
+ * the sales-period gate and the land/CME analyses all read it without knowing
+ * unmasking exists. sales_override protects it from the next file upload (see
+ * the respect_sales_override trigger), and sales_override_meta.original_sale
+ * carries the displaced junk deed so the decision can be reversed.
+ *
  * @param {string} jobId
  * @param {Array<{ property_composite_key, sale, userId, skipped? }>} decisions
- *   sale = { sales_price, sales_date, sales_nu?, source, hpi_multiplier, values_norm_time }
- *   A null/absent sale clears the unmask (sets column to null).
+ *   sale = { sales_price, sales_date, sales_nu?, sales_book?, sales_page?,
+ *            source, hpi_multiplier, values_norm_time }
+ *   A null/absent sale clears the unmask and restores the displaced sale.
  *   skipped is only written when the caller passes an explicit boolean, so
  *   callers that only manage unmasks (the post-upload re-check) leave it alone.
  */
 export async function saveUnmaskedSales(jobId, decisions) {
   if (!jobId || !Array.isArray(decisions) || decisions.length === 0) {
     return { saved: 0, cleared: 0, skipped: 0, changed: 0 };
+  }
+
+  // Read the sale each parcel currently carries so a promotion can record
+  // exactly what it displaced, and a reversal knows what to put back.
+  const keys = decisions.map(d => d.property_composite_key).filter(Boolean);
+  const currentByKey = new Map();
+  for (let i = 0; i < keys.length; i += 500) {
+    const slice = keys.slice(i, i + 500);
+    const { data, error } = await supabase
+      .from('property_records')
+      .select('property_composite_key, sales_price, sales_date, sales_nu, sales_book, sales_page, sales_override, sales_override_meta')
+      .eq('job_id', jobId)
+      .in('property_composite_key', slice);
+    if (error) {
+      console.error('saveUnmaskedSales: could not load current sales', error);
+      continue;
+    }
+    (data || []).forEach(r => currentByKey.set(r.property_composite_key, r));
   }
 
   let saved = 0;
@@ -199,6 +233,10 @@ export async function saveUnmaskedSales(jobId, decisions) {
   for (const d of decisions) {
     const key = d.property_composite_key;
     if (!key) continue;
+
+    const current = currentByKey.get(key) || {};
+    const ourOverride = current.sales_override === true
+      && current.sales_override_meta?.promoted_from === UNMASK_PROMOTED_FROM;
 
     const payload = d.sale
       ? {
@@ -213,8 +251,67 @@ export async function saveUnmaskedSales(jobId, decisions) {
         }
       : null;
 
+    let salesPatch = null;
+
+    if (payload) {
+      // Re-unmasking an already-promoted parcel must keep pointing at the real
+      // file sale, not at the prior we promoted last time.
+      const displaced = ourOverride
+        ? current.sales_override_meta.original_sale
+        : {
+            date: current.sales_date ?? null,
+            price: current.sales_price ?? null,
+            nu: current.sales_nu ?? null,
+            book: current.sales_book ?? null,
+            page: current.sales_page ?? null,
+          };
+
+      salesPatch = {
+        sales_date: d.sale.sales_date ?? null,
+        sales_price: d.sale.sales_price ?? null,
+        sales_nu: d.sale.sales_nu ?? null,
+        sales_book: d.sale.sales_book ?? null,
+        sales_page: d.sale.sales_page ?? null,
+        sales_override: true,
+        sales_override_meta: {
+          promoted_from: UNMASK_PROMOTED_FROM,
+          source_entry: d.sale.source ?? null,
+          original_sale: displaced,
+          decided_at: new Date().toISOString(),
+          decided_by: d.userId ?? 'user',
+        },
+      };
+    } else if (ourOverride) {
+      const orig = current.sales_override_meta.original_sale || {};
+      salesPatch = {
+        sales_date: orig.date ?? null,
+        sales_price: orig.price ?? null,
+        sales_nu: orig.nu ?? null,
+        sales_book: orig.book ?? null,
+        sales_page: orig.page ?? null,
+        sales_override: false,
+        sales_override_meta: null,
+      };
+    }
+
+    if (salesPatch) {
+      const { error: srErr } = await supabase
+        .from('property_records')
+        .update(salesPatch)
+        .eq('job_id', jobId)
+        .eq('property_composite_key', key);
+      if (srErr) {
+        console.error('saveUnmaskedSales: promote/revert failed for', key, srErr);
+        continue;
+      }
+    }
+
     const updates = { unmasked_sale: payload, updated_at: new Date().toISOString() };
     if (typeof d.skipped === 'boolean') updates.masked_review_skipped = d.skipped;
+    // The promoted sale is a real sale now, so it carries a real normalized
+    // value. Reverting puts the junk deed back, which must not keep one.
+    if (payload) updates.values_norm_time = payload.values_norm_time ?? null;
+    else if (salesPatch) updates.values_norm_time = null;
 
     const { error } = await supabase
       .from('property_market_analysis')
@@ -291,8 +388,13 @@ export async function recheckMaskedAfterUpload(jobId, opts = {}) {
   const changedKeys = salesChanges.map(c => c.property_composite_key).filter(Boolean);
   if (changedKeys.length === 0) return empty;
 
-  // Which of the changed parcels currently carry an unmasked_sale?
+  // Which of the changed parcels currently carry an unmasked_sale marker?
   const unmaskedKeys = new Set();
+  // Which still carry our promotion? The respect_sales_override trigger drops
+  // the override when the upload brings a newer, valid, arm's-length sale — so
+  // a marker without a matching override means the trigger already superseded
+  // this unmask and the marker has to follow.
+  const stillPromoted = new Set();
   // Supabase .in() caps out on huge lists; chunk to be safe.
   for (let i = 0; i < changedKeys.length; i += 500) {
     const slice = changedKeys.slice(i, i + 500);
@@ -306,6 +408,21 @@ export async function recheckMaskedAfterUpload(jobId, opts = {}) {
       continue;
     }
     (data || []).forEach(r => { if (r.unmasked_sale) unmaskedKeys.add(r.property_composite_key); });
+
+    const { data: srData, error: srError } = await supabase
+      .from('property_records')
+      .select('property_composite_key, sales_override, sales_override_meta')
+      .eq('job_id', jobId)
+      .in('property_composite_key', slice);
+    if (srError) {
+      console.error('recheckMaskedAfterUpload override load failed:', srError);
+      continue;
+    }
+    (srData || []).forEach(r => {
+      if (r.sales_override === true && r.sales_override_meta?.promoted_from === UNMASK_PROMOTED_FROM) {
+        stillPromoted.add(r.property_composite_key);
+      }
+    });
   }
 
   const stale = [];
@@ -319,8 +436,10 @@ export async function recheckMaskedAfterUpload(jobId, opts = {}) {
     const oldPrice = Number(c?.differences?.sales_price?.old) || 0;
 
     if (unmaskedKeys.has(key)) {
-      // Existing unmask + a now-valid current sale → stale, clear it.
-      if (effPrice > junkPriceCeiling) stale.push(key);
+      // The trigger already decided whether the promotion survives this upload.
+      // If it dropped the override, the marker is stale — clearing it only
+      // removes the marker, since property_records is already correct.
+      if (!stillPromoted.has(key)) stale.push(key);
     } else if (effPrice > 0 && effPrice <= junkPriceCeiling && oldPrice >= priceThreshold) {
       // Kept a junk dollar-sale over a healthy prior → newly masked.
       newMasks.push({

--- a/src/lib/unmaskedSales.js
+++ b/src/lib/unmaskedSales.js
@@ -94,7 +94,8 @@ export function timeNormalizeUnmasked(sale, hpiMultiplierFn, normalizeToYear = M
  *   best: { sales_price, sales_date, source },               // top candidate
  *   currentIsJunk: boolean,
  *   autoSuggest: boolean,                                     // pre-check in UI
- *   alreadyUnmasked: { sales_price, sales_date } | null
+ *   alreadyUnmasked: { sales_price, sales_date } | null,
+ *   alreadySkipped: boolean
  * }>
  */
 export function detectMaskedCandidates(properties, opts = {}) {
@@ -148,6 +149,7 @@ export function detectMaskedCandidates(properties, opts = {}) {
     const alreadyUnmasked = p.unmasked_sale
       ? { sales_price: p.unmasked_sale.sales_price, sales_date: p.unmasked_sale.sales_date }
       : null;
+    const alreadySkipped = p.masked_review_skipped === true;
 
     // Only surface true masked candidates (junk current sale) — plus any parcel
     // already unmasked, so the user can review/clear that decision.
@@ -169,6 +171,7 @@ export function detectMaskedCandidates(properties, opts = {}) {
       currentIsJunk,
       autoSuggest: currentIsJunk, // pre-check rows where current sale is junk
       alreadyUnmasked,
+      alreadySkipped,
     });
   }
 
@@ -178,9 +181,11 @@ export function detectMaskedCandidates(properties, opts = {}) {
 /**
  * Persist a batch of unmask decisions.
  * @param {string} jobId
- * @param {Array<{ property_composite_key, sale, userId }>} decisions
+ * @param {Array<{ property_composite_key, sale, userId, skipped? }>} decisions
  *   sale = { sales_price, sales_date, sales_nu?, source, hpi_multiplier, values_norm_time }
  *   A null/absent sale clears the unmask (sets column to null).
+ *   skipped is only written when the caller passes an explicit boolean, so
+ *   callers that only manage unmasks (the post-upload re-check) leave it alone.
  */
 export async function saveUnmaskedSales(jobId, decisions) {
   if (!jobId || !Array.isArray(decisions) || decisions.length === 0) {
@@ -207,9 +212,12 @@ export async function saveUnmaskedSales(jobId, decisions) {
         }
       : null;
 
+    const updates = { unmasked_sale: payload, updated_at: new Date().toISOString() };
+    if (typeof d.skipped === 'boolean') updates.masked_review_skipped = d.skipped;
+
     const { error } = await supabase
       .from('property_market_analysis')
-      .update({ unmasked_sale: payload, updated_at: new Date().toISOString() })
+      .update(updates)
       .eq('job_id', jobId)
       .eq('property_composite_key', key);
 


### PR DESCRIPTION
### Summary
Reworks the masked-sales feature so unmasking a sale promotes it directly into `property_records` instead of overlaying it at render time, and moves skip decisions from `localStorage` into the database so they persist for the whole team.

### Problem
Unmasked sales were previously injected as synthetic rows/overlays in Sales Review and Sales Pool only at display time. This meant every downstream consumer (normalization, sales-period gate, Land Valuation, CME) had to know about unmasking individually — most never did, so unmasked sales weren't reflected in the values used by market/land analysis or the final roster. Skip decisions were also stored in `localStorage`, so they didn't survive across users/browsers/machines, causing duplicated review work. Separately, the Cost Valuation export used the normalized "Price Time" value for Sale Price instead of the raw sale price, and masked-sale dates displayed a day early due to UTC parsing.

### Solution
An unmask now **promotes** the recovered sale into `property_records` (`sales_date/price/nu/book/page`) and sets `sales_override = true`, the same mechanism used by the Detailed grid's swap-hidden-sale and the updater's "Keep Old" flow. Once promoted, the sale is simply the parcel's sale, so all downstream consumers pick it up automatically without special-casing. `values_norm_time` is written at save time so no separate normalization pass is required. Skip decisions move to a DB column (`masked_review_skipped`) shared across the team. A DB trigger (`respect_sales_override`) now owns the "does a new upload supersede this promotion" rule, replacing JS-side logic.

### Key Changes
- **`src/lib/unmaskedSales.js`**: `saveUnmaskedSales` now promotes/reverts sales in `property_records` (tracking `sales_override_meta` with `promoted_from`, `original_sale`, audit fields), writes `values_norm_time` directly, and reports `skipped`/`changed` counts. `detectMaskedCandidates` returns `alreadySkipped`. `recheckMaskedAfterUpload` now trusts the `respect_sales_override` trigger's decision instead of re-deriving supersede logic.
- **`ScanMaskedSalesModal.jsx`**: Removed `localStorage`-based skip persistence in favor of DB-backed skips; added `normalizeToYear` prop threaded from the job's normalization config; fixed date rendering with `parseDateLocal` to avoid UTC off-by-one display; save payload now includes `sales_book`/`sales_page`.
- **`SalesReviewTab.jsx` / `SalesComparisonTab.jsx`**: Removed synthetic overlay rows for unmasked sales; `_isUnmasked` badge now derives from `sales_override` + `sales_override_meta.promoted_from === 'masked_scan'`; pass `normalizeToYear` into the modal; updated save-result toasts to use `changed` count.
- **`supabaseClient.js` (`patchPropertiesWithMarketAnalysis`)**: Now re-reads sale fields from `property_records` (not just market analysis) after a save, and trusts the fresh `values_norm_time` instead of falling back to a stale in-memory value; includes `masked_review_skipped` in the surgical patch.
- **`JobContainer.jsx`**: Fetches and passes through `masked_review_skipped` alongside `unmasked_sale`.
- **`CostValuationTab.jsx`**: Export "Sale Price" column now always reports the raw sale price; formulas that depend on price basis (Improv, Adj Ratio, summary rows) reference the correct basis column (`I` raw vs `K` price-time) based on the selected basis.
- **`copilot-os.md`**: Documents the promotion model, the `respect_sales_override` trigger contract, DB-backed skip persistence, agent DB access via `SUPABASE_SECRET_KEY` env var (never `.env`), and several "looks wrong but is correct" patterns for future reference.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/stable-vault-9voirhqo"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-stable-vault-9voirhqo.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 264`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>stable-vault-9voirhqo</branchName>-->