### PR TITLE
Fix masked-sale re-flagging, cost tab sorting, and eco obs rollup

### DIFF
--- a/src/components/job-modules/FileUploadButton.jsx
+++ b/src/components/job-modules/FileUploadButton.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Upload, FileText, CheckCircle, AlertTriangle, X, Database, Settings, Download, Eye, Calendar, RefreshCw } from 'lucide-react';
 import { jobService, propertyService, supabase, preservedFieldsHandler, interpretCodes, worksheetService } from '../../lib/supabaseClient';
 import { computeTargetNormalization, saveNormalizationDecisions } from '../../lib/targetNormalization';
-import { recheckMaskedAfterUpload, saveUnmaskedSales } from '../../lib/unmaskedSales';
+import { recheckMaskedAfterUpload, saveUnmaskedSales, UNMASK_PROMOTED_FROM } from '../../lib/unmaskedSales';
 import * as XLSX from 'xlsx';
 
 const FileUploadButton = ({
@@ -939,7 +939,7 @@ const handleCodeFileUpdate = async () => {
       while (hasMore) {
         const { data: batch, error: batchError } = await supabase
           .from('property_records')
-          .select('property_composite_key, property_block, property_lot, property_qualifier, property_location, sales_price, sales_date, sales_nu, sales_book, sales_page, property_m4_class, property_cama_class')
+          .select('property_composite_key, property_block, property_lot, property_qualifier, property_location, sales_price, sales_date, sales_nu, sales_book, sales_page, property_m4_class, property_cama_class, sales_override, sales_override_meta')
           .eq('job_id', job.id)
           .eq('file_version', currentDbVersion)  // CRITICAL FIX: Only get current version!
           .range(rangeStart, rangeStart + batchSize - 1);
@@ -1124,7 +1124,23 @@ const handleCodeFileUpdate = async () => {
           });
         }
         */
-        if (pricesDifferent || datesDifferent) {
+        // A masked-sale promotion holds a recovered prior in property_records while
+        // the file keeps shipping the junk deed it displaced, so the two never agree
+        // and the parcel gets re-flagged on every upload forever. Suppress that one
+        // case. A sale above the junk floor still surfaces for review, where Keep Old
+        // preserves the promotion. The $100 floor matches the respect_sales_override
+        // trigger, which decides whether an incoming sale supersedes the promotion.
+        let isDisplacedJunkDeed = false;
+        if (dbRecord.sales_override === true
+            && dbRecord.sales_override_meta
+            && dbRecord.sales_override_meta.promoted_from === UNMASK_PROMOTED_FROM) {
+          const displaced = dbRecord.sales_override_meta.original_sale || {};
+          const sameTransaction = parseDate(displaced.date) === sourceSalesDate
+            && Math.abs((parseFloat(displaced.price) || 0) - sourceSalesPrice) <= 0.01;
+          isDisplacedJunkDeed = sameTransaction || sourceSalesPrice <= 100;
+        }
+
+        if ((pricesDifferent || datesDifferent) && !isDisplacedJunkDeed) {
           salesChanges.push({
             property_composite_key: key,
             property_block: dbRecord.property_block,

--- a/src/components/job-modules/market-tabs/CostValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/CostValuationTab.jsx
@@ -170,12 +170,11 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
       if (!year) return false;
       if (year < fromYear || year > toYear) return false;
 
-      // Require a valid price depending on selected basis
-      if (priceBasis === 'price_time') {
-        if (!(p.values_norm_time && p.values_norm_time > 0)) return false;
-      } else {
-        if (!(p.sales_price && Number(p.sales_price) > 0)) return false;
-      }
+      // The study population is the normalized sales set on either basis. The Sale
+      // Price toggle swaps the numerator in the CCF math; it does not admit sales the
+      // normalization pass rejected. Those are $1 deeds and non-usable NU codes, and
+      // they drive improv (and so CCF) negative.
+      if (!(p.values_norm_time && p.values_norm_time > 0)) return false;
 
       // asset_type_use exists on property_records
       const typeVal = p.asset_type_use ? p.asset_type_use.toString().trim() : '';
@@ -204,7 +203,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
 
       return true;
     });
-  }, [properties, fromYear, toYear, typeGroup]);
+  }, [properties, fromYear, toYear, typeGroup, currentYear]);
 
   // Unique building class codes from all properties in this town
   const uniqueBuildingClasses = useMemo(() => {
@@ -299,7 +298,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     if (rows.length === 0) return null;
     const sum = rows.reduce((a, b) => a + b, 0);
     return sum / rows.length;
-  }, [filtered, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap]);
+  }, [filtered, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap, priceBasis, currentYear]);
 
   // Recommended median for robustness
   const recommendedMedian = useMemo(() => {
@@ -327,7 +326,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     if (rows.length === 0) return null;
     const mid = Math.floor(rows.length / 2);
     return rows.length % 2 !== 0 ? rows[mid] : (rows[mid - 1] + rows[mid]) / 2;
-  }, [filtered, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap]);
+  }, [filtered, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap, priceBasis, currentYear]);
 
   // Export to Excel with formulas and formatting
   const exportToExcel = () => {

--- a/src/components/job-modules/market-tabs/CostValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/CostValuationTab.jsx
@@ -25,6 +25,11 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
   const [editedBaseCostMap, setEditedBaseCostMap] = useState({});
   const [editedBuildingClassMap, setEditedBuildingClassMap] = useState({});
   const [sortConfig, setSortConfig] = useState({ field: null, direction: 'asc' });
+  // Persisted exclusions. Kept separate from includedMap because that map only
+  // covers rows in the current filter, and narrowing the years must not silently
+  // drop exclusions for rows that scrolled out of scope.
+  const [excludedKeys, setExcludedKeys] = useState(new Set());
+  const excludedList = useMemo(() => Array.from(excludedKeys), [excludedKeys]);
 
   // Helpers to get effective values (edited override or original)
   const getEffectiveDetItems = (p) => {
@@ -54,6 +59,9 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     if (marketLandData?.cost_valuation_to_year !== undefined && marketLandData?.cost_valuation_to_year !== null) {
       setToYear(Number(marketLandData.cost_valuation_to_year));
     }
+    if (Array.isArray(marketLandData?.cost_valuation_excluded)) {
+      setExcludedKeys(new Set(marketLandData.cost_valuation_excluded));
+    }
   }, [marketLandData]);
 
   // Auto-save cost valuation year range (debounced) to market_land_valuation
@@ -64,7 +72,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     try {
       const { data, error } = await supabase
         .from('market_land_valuation')
-        .upsert([{ job_id: jobData.id, cost_valuation_from_year: from, cost_valuation_to_year: to, updated_at: new Date().toISOString() }], { onConflict: 'job_id' })
+        .upsert([{ job_id: jobData.id, cost_valuation_from_year: from, cost_valuation_to_year: to, cost_valuation_excluded: excludedList, updated_at: new Date().toISOString() }], { onConflict: 'job_id' })
         .select()
         .single();
       if (error) throw error;
@@ -81,7 +89,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
       }
       setSavedYears(true);
       setTimeout(() => setSavedYears(false), 1500);
-      console.log('Saved cost valuation year range', { from, to });
+      console.log('Saved cost valuation year range', { from, to, excluded: excludedList.length });
     } catch (e) {
       console.error('Error saving cost valuation date range:', e);
       alert('Failed to save sales year range. See console.');
@@ -221,12 +229,12 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
     const landMap = {};
     filtered.forEach(p => {
       const key = p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`;
-      map[key] = true;
+      map[key] = !excludedKeys.has(key);
       landMap[key] = p.values_cama_land !== undefined && p.values_cama_land !== null ? p.values_cama_land : '';
     });
     setIncludedMap(map);
     setEditedLandMap(landMap);
-  }, [filtered]);
+  }, [filtered, excludedKeys]);
 
   // formatting helpers
   const getLivingAreaValue = (p) => {
@@ -890,7 +898,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
             onClick={() => saveYearRange(fromYear, toYear)}
             disabled={isSavingRange}
           >
-            {isSavingRange ? 'Saving...' : (savedYears ? 'Saved' : 'Save Years')}
+            {isSavingRange ? 'Saving...' : (savedYears ? 'Saved' : (excludedList.length > 0 ? `Save Years + ${excludedList.length} Excluded` : 'Save Years'))}
           </button>
           <button
             className="px-3 py-2 bg-indigo-600 text-white rounded text-sm"
@@ -990,7 +998,13 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
                   <td className="px-3 py-2 text-sm border-b border-r border-gray-100">
                     <input type="checkbox" checked={includedMap[p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`] !== false} onChange={(e) => {
                       const key = p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`;
-                      setIncludedMap(prev => ({ ...prev, [key]: e.target.checked }));
+                      const checked = e.target.checked;
+                      setIncludedMap(prev => ({ ...prev, [key]: checked }));
+                      setExcludedKeys(prev => {
+                        const next = new Set(prev);
+                        if (checked) next.delete(key); else next.add(key);
+                        return next;
+                      });
                     }} />
                   </td>
 

--- a/src/components/job-modules/market-tabs/CostValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/CostValuationTab.jsx
@@ -273,32 +273,40 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
 
   // Recommended mean (average) based on included comparables
   // Use CCF = Improv / ReplWithDepr so a single comparable with CCF 2.88 yields recommendedFactor 2.88
-  const recommendedFactor = useMemo(() => {
-    const rows = filtered
-      .map(p => {
-        const key = p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`;
-        const included = includedMap[key] !== undefined ? includedMap[key] : true;
-        if (!included) return null;
-        const salePrice = (priceBasis === 'price_time' && p.values_norm_time && p.values_norm_time > 0) ? Number(p.values_norm_time) : (p.sales_price !== undefined && p.sales_price !== null ? Number(p.sales_price) : 0);
-        const detItems = getEffectiveDetItems(p);
-        const baseCost = getEffectiveBaseCost(p);
-        const cama = (editedLandMap && editedLandMap[key] !== undefined && editedLandMap[key] !== '') ? Number(editedLandMap[key]) : (p.values_cama_land !== undefined && p.values_cama_land !== null ? Number(p.values_cama_land) : 0);
-        const yearBuilt = p.asset_year_built || '';
-        const depr = yearBuilt ? (1 - ((currentYear - parseInt(yearBuilt, 10)) / 100)) : '';
-        if (!depr) return null;
-        const replWithDepr = (detItems + baseCost) * depr;
-        if (!replWithDepr || replWithDepr === 0) return null;
-        const improv = salePrice - cama - detItems;
-        if (!isFinite(improv)) return null;
-        const ccf = improv / replWithDepr;
-        return isFinite(ccf) ? ccf : null;
-      })
-      .filter(v => v !== null && v !== undefined && isFinite(v));
+  // Both bases are computed so the banner can show them side by side. Same
+  // population and same math either way, only the numerator differs.
+  const recommendedFactors = useMemo(() => {
+    const meanForBasis = (basis) => {
+      const rows = filtered
+        .map(p => {
+          const key = p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`;
+          const included = includedMap[key] !== undefined ? includedMap[key] : true;
+          if (!included) return null;
+          const salePrice = (basis === 'price_time' && p.values_norm_time && p.values_norm_time > 0) ? Number(p.values_norm_time) : (p.sales_price !== undefined && p.sales_price !== null ? Number(p.sales_price) : 0);
+          const detItems = getEffectiveDetItems(p);
+          const baseCost = getEffectiveBaseCost(p);
+          const cama = (editedLandMap && editedLandMap[key] !== undefined && editedLandMap[key] !== '') ? Number(editedLandMap[key]) : (p.values_cama_land !== undefined && p.values_cama_land !== null ? Number(p.values_cama_land) : 0);
+          const yearBuilt = p.asset_year_built || '';
+          const depr = yearBuilt ? (1 - ((currentYear - parseInt(yearBuilt, 10)) / 100)) : '';
+          if (!depr) return null;
+          const replWithDepr = (detItems + baseCost) * depr;
+          if (!replWithDepr || replWithDepr === 0) return null;
+          const improv = salePrice - cama - detItems;
+          if (!isFinite(improv)) return null;
+          const ccf = improv / replWithDepr;
+          return isFinite(ccf) ? ccf : null;
+        })
+        .filter(v => v !== null && v !== undefined && isFinite(v));
 
-    if (rows.length === 0) return null;
-    const sum = rows.reduce((a, b) => a + b, 0);
-    return sum / rows.length;
-  }, [filtered, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap, priceBasis, currentYear]);
+      if (rows.length === 0) return null;
+      const sum = rows.reduce((a, b) => a + b, 0);
+      return sum / rows.length;
+    };
+
+    return { price_time: meanForBasis('price_time'), sale_price: meanForBasis('sale_price') };
+  }, [filtered, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap, currentYear]);
+
+  const recommendedFactor = recommendedFactors[priceBasis] ?? null;
 
   // Recommended median for robustness
   const recommendedMedian = useMemo(() => {
@@ -825,13 +833,25 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
         <div className="mb-4 p-3 border border-gray-200 rounded bg-green-50 flex items-center justify-between">
           <div>
             <div className="text-sm text-gray-700 font-medium">Recommended Factor (mean)</div>
-            <div className="text-lg font-semibold">{Number(recommendedFactor).toFixed(2)}</div>
-            <div className="text-xs text-gray-500">Based on {filtered.filter(p => {
-              const has = (p.values_repl_cost || p.values_base_cost) && (priceBasis === 'price_time' ? p.values_norm_time : p.sales_price);
+            <div className="flex items-end gap-6 mt-1">
+              <div>
+                <div className={`text-xs ${priceBasis === 'price_time' ? 'text-indigo-700 font-medium' : 'text-gray-500'}`}>Price Time</div>
+                <div className={`text-lg ${priceBasis === 'price_time' ? 'font-semibold text-gray-900' : 'text-gray-500'}`}>
+                  {recommendedFactors.price_time !== null ? Number(recommendedFactors.price_time).toFixed(2) : '—'}
+                </div>
+              </div>
+              <div>
+                <div className={`text-xs ${priceBasis === 'sale_price' ? 'text-indigo-700 font-medium' : 'text-gray-500'}`}>Sale Price</div>
+                <div className={`text-lg ${priceBasis === 'sale_price' ? 'font-semibold text-gray-900' : 'text-gray-500'}`}>
+                  {recommendedFactors.sale_price !== null ? Number(recommendedFactors.sale_price).toFixed(2) : '—'}
+                </div>
+              </div>
+            </div>
+            <div className="text-xs text-gray-500 mt-1">Based on {filtered.filter(p => {
               const key = p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`;
               const included = includedMap[key] !== undefined ? includedMap[key] : true;
-              return has && included;
-            }).length} comparable properties</div>
+              return (p.values_repl_cost || p.values_base_cost) && included;
+            }).length} comparable properties &middot; bold is the active basis</div>
           </div>
                 {/* Recommendation actions removed - keep Save Recommendation manual via Save Factor */}
         </div>

--- a/src/components/job-modules/market-tabs/CostValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/CostValuationTab.jsx
@@ -24,6 +24,7 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
   const [editedDetItemMap, setEditedDetItemMap] = useState({});
   const [editedBaseCostMap, setEditedBaseCostMap] = useState({});
   const [editedBuildingClassMap, setEditedBuildingClassMap] = useState({});
+  const [sortConfig, setSortConfig] = useState({ field: null, direction: 'asc' });
 
   // Helpers to get effective values (edited override or original)
   const getEffectiveDetItems = (p) => {
@@ -269,6 +270,92 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
   const formatPercentNoDecimals = (v) => {
     if (v === '' || v === null || v === undefined || !isFinite(Number(v))) return '—';
     return `${Math.round(Number(v) * 100)}%`;
+  };
+
+  const rowKey = (p) => p.property_composite_key || `${p.property_block}-${p.property_lot}-${p.property_card}`;
+
+  // Derived columns recompute the CCF math here rather than reading it off the
+  // rendered row, the same way recommendedFactors and summaryTotals do.
+  const sortValue = (p, field) => {
+    const key = rowKey(p);
+    const depr = p.asset_year_built ? (1 - ((currentYear - parseInt(p.asset_year_built, 10)) / 100)) : null;
+    const detItems = getEffectiveDetItems(p);
+    const baseCost = getEffectiveBaseCost(p);
+    const cama = (editedLandMap[key] !== undefined && editedLandMap[key] !== '') ? Number(editedLandMap[key]) : (p.values_cama_land ?? 0);
+    const basisPrice = (priceBasis === 'price_time' && p.values_norm_time > 0) ? Number(p.values_norm_time) : Number(p.sales_price || 0);
+    const replWithDepr = depr ? (detItems + baseCost) * depr : null;
+    const improv = basisPrice - cama - detItems;
+    const ccf = (replWithDepr && replWithDepr !== 0) ? improv / replWithDepr : null;
+    const factor = (costConvFactor !== null && costConvFactor !== '') ? Number(costConvFactor) : (ccf ?? 0);
+    const adjusted = depr ? (cama + ((baseCost * depr) * factor) + detItems) : null;
+
+    switch (field) {
+      case 'incl': return includedMap[key] !== false ? 1 : 0;
+      case 'block': return p.property_block;
+      case 'lot': return p.property_lot;
+      case 'qualifier': return p.asset_qualifier || p.qualifier || '';
+      case 'card': return p.property_card;
+      case 'location': return p.property_location || '';
+      case 'vcs': return p.new_vcs || p.property_vcs || '';
+      case 'salesDate': return p.sales_date || '';
+      case 'salePrice': return Number(p.sales_price || 0);
+      case 'saleNu': return p.sales_nu || '';
+      case 'priceTime': return Number(p.values_norm_time || 0);
+      case 'yearBuilt': return Number(p.asset_year_built || 0);
+      case 'depr': return depr;
+      case 'buildingClass': return editedBuildingClassMap[key] ?? p.asset_building_class ?? '';
+      case 'livingArea': return getLivingAreaValue(p);
+      case 'currentLand': return cama;
+      case 'detItem': return detItems;
+      case 'baseCost': return baseCost;
+      case 'replDepr': return replWithDepr;
+      case 'improv': return improv;
+      case 'ccf': return ccf;
+      case 'adjustedValue': return adjusted;
+      case 'adjustedRatio': return (adjusted && basisPrice) ? adjusted / basisPrice : null;
+      default: return null;
+    }
+  };
+
+  const sortedFiltered = useMemo(() => {
+    if (!sortConfig.field) return filtered;
+    const dir = sortConfig.direction === 'desc' ? -1 : 1;
+    const isBlank = (v) => v === null || v === undefined || v === '' || (typeof v === 'number' && !isFinite(v));
+
+    return [...filtered].sort((a, b) => {
+      const av = sortValue(a, sortConfig.field);
+      const bv = sortValue(b, sortConfig.field);
+      // Blanks always sink, so flipping direction doesn't fill the top with empties.
+      if (isBlank(av) && isBlank(bv)) return 0;
+      if (isBlank(av)) return 1;
+      if (isBlank(bv)) return -1;
+
+      const an = typeof av === 'number' ? av : parseFloat(av);
+      const bn = typeof bv === 'number' ? bv : parseFloat(bv);
+      if (!isNaN(an) && !isNaN(bn)) return (an - bn) * dir;
+      return String(av).localeCompare(String(bv)) * dir;
+    });
+  }, [filtered, sortConfig, includedMap, editedLandMap, editedDetItemMap, editedBaseCostMap, editedBuildingClassMap, priceBasis, costConvFactor, currentYear]);
+
+  const toggleSort = (field) => {
+    setSortConfig(prev => prev.field === field
+      ? { field, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
+      : { field, direction: 'asc' });
+  };
+
+  const sortableTh = (label, field, lastCol) => {
+    const active = sortConfig.field === field;
+    const arrow = !active ? '\u21C5' : (sortConfig.direction === 'asc' ? '\u25B2' : '\u25BC');
+    return (
+      <th
+        onClick={() => toggleSort(field)}
+        title={`Sort by ${label}`}
+        className={`px-3 py-2 text-xs border-b ${lastCol ? '' : 'border-r'} border-gray-200 cursor-pointer select-none hover:bg-gray-100 ${active ? 'text-gray-900 font-semibold' : 'text-gray-600'}`}
+      >
+        {label}
+        <span className="ml-1" style={{ fontSize: '10px', opacity: active ? 1 : 0.35 }}>{arrow}</span>
+      </th>
+    );
   };
 
   // Recommended mean (average) based on included comparables
@@ -862,35 +949,35 @@ const CostValuationTab = ({ jobData, properties = [], marketLandData = {}, onUpd
         <table className="min-w-full text-left">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Incl</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Block</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Lot</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Qualifier</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Card</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Location</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">VCS</th>
+              {sortableTh('Incl', 'incl')}
+              {sortableTh('Block', 'block')}
+              {sortableTh('Lot', 'lot')}
+              {sortableTh('Qualifier', 'qualifier')}
+              {sortableTh('Card', 'card')}
+              {sortableTh('Location', 'location')}
+              {sortableTh('VCS', 'vcs')}
 
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Sales Date</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Sale Price</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Sale NU</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Price Time</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Year Built</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Depr</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Building Class</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Living Area</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Current Land</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Det Item</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Base Cost</th>
+              {sortableTh('Sales Date', 'salesDate')}
+              {sortableTh('Sale Price', 'salePrice')}
+              {sortableTh('Sale NU', 'saleNu')}
+              {sortableTh('Price Time', 'priceTime')}
+              {sortableTh('Year Built', 'yearBuilt')}
+              {sortableTh('Depr', 'depr')}
+              {sortableTh('Building Class', 'buildingClass')}
+              {sortableTh('Living Area', 'livingArea')}
+              {sortableTh('Current Land', 'currentLand')}
+              {sortableTh('Det Item', 'detItem')}
+              {sortableTh('Base Cost', 'baseCost')}
 
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Repl w/Depr</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">Improv</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-r border-gray-200">CCF</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-gray-200">Adjusted Value</th>
-              <th className="px-3 py-2 text-xs text-gray-600 border-b border-gray-200">Adjusted Ratio</th>
+              {sortableTh('Repl w/Depr', 'replDepr')}
+              {sortableTh('Improv', 'improv')}
+              {sortableTh('CCF', 'ccf')}
+              {sortableTh('Adjusted Value', 'adjustedValue', true)}
+              {sortableTh('Adjusted Ratio', 'adjustedRatio', true)}
             </tr>
           </thead>
           <tbody>
-            {filtered.slice(0, 500).map((p, i) => {
+            {sortedFiltered.slice(0, 500).map((p, i) => {
               const saleYear = safeSaleYear(p);
               const salePriceDisplay = (p.sales_price !== undefined && p.sales_price !== null) ? Number(p.sales_price) : 0;
               const priceTimeDisplay = (p.values_norm_time !== undefined && p.values_norm_time !== null) ? Number(p.values_norm_time) : 0;

--- a/src/components/job-modules/market-tabs/LandValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/LandValuationTab.jsx
@@ -1626,7 +1626,9 @@ const getPricePerUnit = useCallback((price, size) => {
       setTimeout(() => {
         delete window._method1ExcludedSales;
         delete window._method1IncludedSales;
-        delete window._method1ManuallyAdded;
+        // _method1ManuallyAdded is NOT cleared - filterVacantSales rebuilds vacantSales
+        // from scratch on every date/mode/properties change, and this registry is the
+        // only record that a hand-added sale should survive that rebuild.
       }, 1000); // Small delay to ensure filterVacantSales completes
     }
   }, [isInitialLoadComplete, vacantSales.length]);
@@ -3016,6 +3018,10 @@ const getPricePerUnit = useCallback((price, size) => {
         land_zoning: prop.land_zoning || prop.asset_zoning || prop.zoning || 'N/A'
       };
     });
+
+    // Register in the same set filterVacantSales reads, or the next rebuild drops these.
+    if (!window._method1ManuallyAdded) window._method1ManuallyAdded = new Set();
+    toAdd.forEach(p => window._method1ManuallyAdded.add(p.id));
 
     setVacantSales([...vacantSales, ...enriched]);
     setIncludedSales(new Set([...includedSales, ...toAdd.map(p => p.id)]));

--- a/src/components/job-modules/market-tabs/LandValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/LandValuationTab.jsx
@@ -12440,21 +12440,31 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
       // Skip empty/none and compounded descriptions
       if (!loc || /\bnone\b|\bno analysis\b/i.test(loc)) return;
       if (/[\/\|,]|\band\b|&/.test(loc)) return; // compound separators
-      if (!standaloneLocations[loc]) standaloneLocations[loc] = { vcsList: new Set(), impacts: [] };
+      if (!standaloneLocations[loc]) standaloneLocations[loc] = { vcsList: new Set(), impacts: [], sumWith: 0, sumWithout: 0, scored: new Set() };
       standaloneLocations[loc].vcsList.add(vcs);
       const impact = calculateEcoObsImpact(vcs, loc, globalEcoObsTypeFilter);
       if (impact && impact.percentImpact && impact.percentImpact !== 'N/A') {
         const num = parseFloat(String(impact.percentImpact));
         if (!isNaN(num)) standaloneLocations[loc].impacts.push(num);
+        // Only a VCS with sales on both sides can contribute to the rollup. One
+        // with no with-sales (or, rarely, no baseline) has nothing to compare and
+        // is left out of the totals entirely rather than counted as zero.
+        if (impact.withCount > 0 && impact.withoutCount > 0) {
+          standaloneLocations[loc].sumWith += impact.adjustedSaleWith;
+          standaloneLocations[loc].sumWithout += impact.adjustedSaleWithout;
+          standaloneLocations[loc].scored.add(vcs);
+        }
       }
     });
   });
 
-  // Compute standalone averages
+  // Compute standalone recommendations. Dollar-weighted across the contributing
+  // VCS, not a mean of their percentages -- a VCS carrying most of the dollars
+  // should move the recommendation more than a small one.
   const standaloneAvg = {};
   Object.entries(standaloneLocations).forEach(([loc, data]) => {
-    const avg = data.impacts.length ? (data.impacts.reduce((a, b) => a + b, 0) / data.impacts.length) : null;
-    standaloneAvg[loc] = { avg, count: data.vcsList.size, impacts: data.impacts };
+    const avg = data.sumWithout > 0 ? ((data.sumWith - data.sumWithout) / data.sumWithout) * 100 : null;
+    standaloneAvg[loc] = { avg, count: data.vcsList.size, scoredCount: data.scored.size, impacts: data.impacts };
   });
 
   // Find compound locations and compute summed averages from parts (cap at 25% absolute)
@@ -12490,7 +12500,7 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
   });
 
   // Build combined summary list based on includeCompounded toggle
-  let combined = Object.entries(standaloneAvg).map(([loc, d]) => ({ location: loc, avgPercent: d.avg, count: d.count, impacts: d.impacts, isCompound: false }));
+  let combined = Object.entries(standaloneAvg).map(([loc, d]) => ({ location: loc, avgPercent: d.avg, count: d.count, scoredCount: d.scoredCount, impacts: d.impacts, isCompound: false }));
   if (includeCompounded) {
     combined = combined.concat(Object.keys(compoundLocations).map(loc => ({ location: loc, avgPercent: compoundLocations[loc].summedAvg || null, count: compoundLocations[loc].vcsList.size, impacts: [], isCompound: true })));
   }
@@ -12999,7 +13009,11 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
                 {summaryList.map(item => (
                   <tr key={item.location} style={{ borderTop: '1px solid #E5E7EB' }}>
                     <td style={{ padding: '8px' }}>{item.location}</td>
-                    <td style={{ padding: '8px', textAlign: 'center' }}>{item.count}</td>
+                    <td style={{ padding: '8px', textAlign: 'center' }}>
+                      {item.scoredCount !== undefined && item.scoredCount !== item.count
+                        ? `${item.scoredCount} of ${item.count}`
+                        : item.count}
+                    </td>
                     <td style={{ padding: '8px', textAlign: 'center', fontWeight: '600' }}>{item.avgPercent !== null ? `${item.avgPercent.toFixed(1)}%` : 'N/A'}</td>
                     <td style={{ padding: '8px', textAlign: 'center', display: 'flex', gap: '8px', justifyContent: 'center', alignItems: 'center' }}>
                       <input

--- a/src/lib/unmaskedSales.js
+++ b/src/lib/unmaskedSales.js
@@ -182,7 +182,7 @@ export function detectMaskedCandidates(properties, opts = {}) {
 
 // Marks an override as ours, so clearing an unmask never reverts a sale that
 // was promoted by the Detailed grid's swap-hidden-sale UI.
-const UNMASK_PROMOTED_FROM = 'masked_scan';
+export const UNMASK_PROMOTED_FROM = 'masked_scan';
 
 /**
  * Persist a batch of unmask decisions.


### PR DESCRIPTION
### Summary
Fixes several data-integrity and usability issues in file update, Cost Valuation, and Land Valuation: masked sales that were previously unmasked/promoted no longer keep reappearing in File Update, the Cost Conversion table gains sortable, persistent-exclusion columns with both price bases shown side-by-side, and the Economic Obstruction summary now correctly excludes VCS with no comparable sales from its rollup math.

### Problem
- After a masked sale was promoted (recovering a prior valid sale to replace a junk deed), the same junk transaction from the source file kept re-triggering a "sales changed" flag on every subsequent File Update, forcing users to repeatedly re-review the same 23+ already-resolved parcels.
- The Cost Valuation table had no way to sort columns, and unchecking a comparable from inclusion did not persist — it would silently return the next time the tab was revisited or the year range changed.
- Switching between Price Time and Sale Price basis in Cost Valuation changed which properties were included in the comparable set (21 vs 43), since Sale Price basis wasn't filtering out sales the normalization pass had already rejected, letting $1 deeds and non-usable NU codes skew Improv/CCF negative.
- The Recommended Factor banner only showed one basis at a time, making it hard to compare Price Time vs Sale Price recommendations.
- The Economic Obstruction summary averaged percent impacts across VCS uniformly, even when a VCS had no with-sales (or no baseline) to compare, inflating or skewing the reported adjustment.

### Solution
- Added a targeted suppression rule in the File Update sales-diff logic: if a property's current record is a masked-sale promotion and the incoming file transaction is the same displaced deed (or below the $100 junk floor matching the `respect_sales_override` trigger), it's no longer flagged as changed. A genuinely new, higher sale still surfaces for review.
- Introduced persistent exclusion tracking for Cost Valuation comparables, saved to `market_land_valuation.cost_valuation_excluded`, independent of the current year-range filter.
- Added click-to-sort column headers to the Cost Valuation table with ascending/descending toggling and blank-value handling.
- Unified the comparable-set filter to always require a valid normalized sale (`values_norm_time`), regardless of price basis, so both bases reflect the same underlying population.
- Computed and displayed both Price Time and Sale Price recommended factors simultaneously in the banner, highlighting the active basis.
- Reworked the Economic Obstruction standalone rollup to be dollar-weighted (sum of adjusted-with vs adjusted-without sales) rather than a simple average of percentages, and to only include VCS that have both with- and without-sales, showing "N of M" in the count column when some VCS are excluded from scoring.
- Preserved manually-added Method 1 land sales across `filterVacantSales` rebuilds by registering them in the existing `window._method1ManuallyAdded` set instead of clearing it.
- Exported `UNMASK_PROMOTED_FROM` from `unmaskedSales.js` so File Update can identify masked-sale promotions.

### Key Changes
- `FileUploadButton.jsx`: pull `sales_override`/`sales_override_meta` in the batch query and skip flagging sales changes for displaced junk deeds tied to a masked-sale promotion.
- `CostValuationTab.jsx`: add `sortConfig`/`excludedKeys` state, `sortValue`/`sortedFiltered`/`toggleSort`/`sortableTh` helpers, persist exclusions to Supabase, compute `recommendedFactors` for both bases, and unify the comparable filter to require `values_norm_time`.
- `LandValuationTab.jsx`: stop clearing `window._method1ManuallyAdded` after manual add, and register newly added sale IDs into that set; rework standalone Economic Obstruction rollup to sum with/without adjusted sale dollars and track scored VCS count.
- `unmaskedSales.js`: export `UNMASK_PROMOTED_FROM` constant for reuse in File Update.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/quad-velocity-oulrth2n"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-quad-velocity-oulrth2n.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 267`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>quad-velocity-oulrth2n</branchName>-->