### PR TITLE
Fix true ratio calc, sale pairing, payroll initials, and zoning input

### DIFF
--- a/src/components/GeocodingTool.jsx
+++ b/src/components/GeocodingTool.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import Papa from 'papaparse';
-import { supabase, parseDateLocal, getAssessmentYear } from '../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { njCityForZip } from '../data/njZipToCity';
 import { isPpaJob } from '../lib/tenantConfig';
 
@@ -417,11 +417,7 @@ const GeocodingTool = () => {
   const [manualSaving, setManualSaving] = useState({}); // { compositeKey: bool }
   const [manualFilter, setManualFilter] = useState('ungeocoded'); // 'ungeocoded' | 'all'
 
-  // Manual cleanup queue filters — mirror the user-facing CoordinatesSubTab
-  // so I can prioritize parcels that landed in the sales pool (so an
-  // ungeocoded sale doesn't slip through search-radius later).
   const [csvClassFilter, setCsvClassFilter] = useState(() => new Set());
-  const [csvSalesInPool, setCsvSalesInPool] = useState(false);
 
   const selectedJob = useMemo(
     () => jobs.find((j) => j.id === selectedJobId) || null,
@@ -629,47 +625,18 @@ const GeocodingTool = () => {
     });
   }, [properties]);
 
-  // Sales-pool window: 10/1 (assessmentYear-2) → 10/31 (assessmentYear-1).
-  // Anchored on the selected job's end_date with the same Lojik adjustment
-  // (org_type = 'assessor' → assessmentYear = end_date.year - 1) used by
-  // SalesComparisonTab. One window only — replaces the old CSP/PSP/HSP
-  // chip set since the cleanup queue cares about "is this parcel a sale
-  // we'll need a coordinate for", not which sub-bucket it lives in.
-  const csvSalesWindow = useMemo(() => {
-    if (!selectedJob?.end_date) return null;
-    const rawYear = getAssessmentYear(selectedJob.end_date, null);
-    if (!rawYear) return null;
-    const isLojik = selectedJob?.organizations?.org_type === 'assessor';
-    const ay = isLojik ? rawYear - 1 : rawYear;
-    return {
-      start: new Date(ay - 2, 9, 1),  // 10/1 two years before assessment year
-      end: new Date(ay - 1, 9, 31),   // 10/31 last year (relative to assessment year)
-      isLojik,
-      assessmentYear: ay,
-    };
-  }, [selectedJob?.end_date, selectedJob?.organizations?.org_type]);
-
-  // Predicate applied inside the manual cleanup queue. csvSalesInPool = true
-  // restricts to parcels whose sales_date falls inside the sales-pool window
-  // (10/1 ay-2 → 10/31 ay-1). Class filter is unchanged (multi-select set).
   const passesCsvFilters = useCallback(
     (p) => {
       if (csvClassFilter.size > 0) {
         const c = String(p.property_m4_class || '').trim();
         if (!csvClassFilter.has(c)) return false;
       }
-      if (csvSalesInPool && csvSalesWindow) {
-        if (!p.sales_date) return false;
-        const d = parseDateLocal(p.sales_date);
-        if (!d) return false;
-        if (d < csvSalesWindow.start || d > csvSalesWindow.end) return false;
-      }
       return true;
     },
-    [csvClassFilter, csvSalesInPool, csvSalesWindow],
+    [csvClassFilter],
   );
 
-  const csvFiltersActive = csvClassFilter.size > 0 || csvSalesInPool;
+  const csvFiltersActive = csvClassFilter.size > 0;
 
   const stats = useMemo(() => {
     const total = properties.length;
@@ -1211,18 +1178,6 @@ const GeocodingTool = () => {
     }
     return m;
   }, [manualBaseList]);
-
-  const salesPoolChipCount = useMemo(() => {
-    if (!csvSalesWindow) return 0;
-    let n = 0;
-    for (const p of manualBaseList) {
-      if (!p.sales_date) continue;
-      const d = parseDateLocal(p.sales_date);
-      if (!d) continue;
-      if (d >= csvSalesWindow.start && d <= csvSalesWindow.end) n += 1;
-    }
-    return n;
-  }, [manualBaseList, csvSalesWindow]);
 
   const manualUngeocodedCount = useMemo(() => {
     const seen = new Set();
@@ -2408,34 +2363,6 @@ const GeocodingTool = () => {
                     clear
                   </button>
                 )}
-              </div>
-            )}
-            {csvSalesWindow && (
-              <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
-                <span style={{ fontSize: 11, color: '#6b7280', fontWeight: 600, textTransform: 'uppercase' }}>
-                  Sales pool:
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setCsvSalesInPool(!csvSalesInPool)}
-                  style={{
-                    padding: '3px 10px',
-                    borderRadius: 999,
-                    fontSize: 12,
-                    border: '1px solid',
-                    cursor: 'pointer',
-                    ...(csvSalesInPool
-                      ? { background: '#7c3aed', color: '#fff', borderColor: '#7c3aed' }
-                      : { background: '#fff', color: '#374151', borderColor: '#d1d5db' }),
-                  }}
-                  title={`Sales between ${csvSalesWindow.start.toLocaleDateString()} and ${csvSalesWindow.end.toLocaleDateString()}`}
-                >
-                  In sales pool window <span style={{ opacity: 0.75, marginLeft: 4 }}>({salesPoolChipCount.toLocaleString()})</span>
-                </button>
-                <span style={{ fontSize: 11, color: '#9ca3af' }}>
-                  ({csvSalesWindow.start.toLocaleDateString()} – {csvSalesWindow.end.toLocaleDateString()}
-                  {csvSalesWindow.isLojik ? ' · Lojik' : ''})
-                </span>
               </div>
             )}
             {csvFiltersActive && (

--- a/src/components/PayrollManagement.jsx
+++ b/src/components/PayrollManagement.jsx
@@ -64,6 +64,28 @@ const PayrollManagement = ({
   };
 
   // Helper functions
+  const findEmployeeByWorksheetName = (worksheetName) => {
+    const name = String(worksheetName).toLowerCase();
+    if (!name) return undefined;
+    return employees.find(emp => {
+      if (!emp.first_name) return false;
+      if (!emp.last_name) return false;
+      if (!name.includes(emp.last_name.toLowerCase())) return false;
+      return name.includes(emp.first_name.toLowerCase());
+    });
+  };
+
+  // Worksheet initials are hand-entered and often blank for new hires, so fall
+  // back to the employee record rather than silently paying a zero bonus.
+  const resolveInitials = (worksheetName, rawCell) => {
+    const fromSheet = rawCell ? String(rawCell).toUpperCase().trim() : '';
+    if (fromSheet) return fromSheet;
+    const employee = findEmployeeByWorksheetName(worksheetName);
+    if (!employee) return null;
+    if (!employee.initials) return null;
+    return String(employee.initials).toUpperCase().trim();
+  };
+
   const calculateExpectedHours = (startDate, endDate) => {
     if (!startDate || !endDate) return 0;
     
@@ -428,7 +450,7 @@ const loadInitialData = async () => {
           const row = rawData[i];
           if (row[0] && typeof row[0] === 'string' && !row[0].includes('TOTAL HOURS')) {
             const employeeName = row[0].trim();
-            const initials = row[1] || null;
+            const initials = resolveInitials(employeeName, row[1]);
             const hours = row[2];
             const timeOff = row[3] || '';
             const apptOT = row[4] || 0;
@@ -448,6 +470,10 @@ const loadInitialData = async () => {
               issues: []
             };
             
+            if (!initials) {
+              empData.issues.push(`No initials on the worksheet and none on the employee record - any inspection bonus will be missed`);
+            }
+
             const calculatedTotal = (typeof apptOT === 'number' ? apptOT : 0) + (typeof fieldOT === 'number' ? fieldOT : 0);
             if (typeof total === 'number' && Math.abs(total - calculatedTotal) > 0.01) {
               empData.issues.push(`TOTAL formula error: Shows $${total} but should be $${calculatedTotal} (${apptOT} + ${fieldOT})`);

--- a/src/components/PayrollManagement.jsx
+++ b/src/components/PayrollManagement.jsx
@@ -75,15 +75,14 @@ const PayrollManagement = ({
     });
   };
 
-  // Worksheet initials are hand-entered and often blank for new hires, so fall
-  // back to the employee record rather than silently paying a zero bonus.
+  // The employee roster is the system of record for initials, same as the
+  // production tracker. The hand-entered worksheet cell is only a fallback for
+  // anyone missing from the roster.
   const resolveInitials = (worksheetName, rawCell) => {
     const fromSheet = rawCell ? String(rawCell).toUpperCase().trim() : '';
-    if (fromSheet) return fromSheet;
     const employee = findEmployeeByWorksheetName(worksheetName);
-    if (!employee) return null;
-    if (!employee.initials) return null;
-    return String(employee.initials).toUpperCase().trim();
+    const fromRecord = employee?.initials ? String(employee.initials).toUpperCase().trim() : '';
+    return { initials: fromRecord || fromSheet || null, fromSheet, fromRecord };
   };
 
   const calculateExpectedHours = (startDate, endDate) => {
@@ -450,7 +449,8 @@ const loadInitialData = async () => {
           const row = rawData[i];
           if (row[0] && typeof row[0] === 'string' && !row[0].includes('TOTAL HOURS')) {
             const employeeName = row[0].trim();
-            const initials = resolveInitials(employeeName, row[1]);
+            const resolved = resolveInitials(employeeName, row[1]);
+            const initials = resolved.initials;
             const hours = row[2];
             const timeOff = row[3] || '';
             const apptOT = row[4] || 0;
@@ -471,7 +471,9 @@ const loadInitialData = async () => {
             };
             
             if (!initials) {
-              empData.issues.push(`No initials on the worksheet and none on the employee record - any inspection bonus will be missed`);
+              empData.issues.push(`No initials on the worksheet and no matching employee record - any inspection bonus will be missed`);
+            } else if (resolved.fromSheet && resolved.fromRecord && resolved.fromSheet !== resolved.fromRecord) {
+              empData.issues.push(`Worksheet initials (${resolved.fromSheet}) do not match the employee record (${resolved.fromRecord}) - using ${resolved.fromRecord}`);
             }
 
             const calculatedTotal = (typeof apptOT === 'number' ? apptOT : 0) + (typeof fieldOT === 'number' ? fieldOT : 0);

--- a/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
@@ -10,7 +10,7 @@
 // ============================================================
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { X, Search } from 'lucide-react';
-import { supabase, interpretCodes, getAssessmentYear } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, getSalesPeriodYear } from '../../../lib/supabaseClient';
 import {
   evaluateAppellantComp,
   COLOR_CLASSES,
@@ -205,16 +205,14 @@ const AppellantEvidencePanel = ({
   onPromoteComp           // optional — (compProperty, slotData) => void — Detailed +Comp button
 }) => {
   // ----- Derived job/market context -----
-  const isLojikTenant = tenantConfig?.orgType === 'assessor';
   const sampleRange = useMemo(() => {
     if (!jobData?.end_date) return { start: '', end: '' };
-    const rawYear = getAssessmentYear(jobData.end_date);
-    const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
+    const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
     return {
       start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0],
       end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0]
     };
-  }, [jobData?.end_date, isLojikTenant]);
+  }, [jobData, tenantConfig]);
 
   const landMethod = useMemo(() => (
     marketLandData?.land_method

--- a/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
+++ b/src/components/job-modules/final-valuation-tabs/AppellantEvidencePanel.jsx
@@ -10,7 +10,7 @@
 // ============================================================
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { X, Search } from 'lucide-react';
-import { supabase, interpretCodes, getSalesPeriodYear } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, getAssessmentYear } from '../../../lib/supabaseClient';
 import {
   evaluateAppellantComp,
   COLOR_CLASSES,
@@ -204,15 +204,17 @@ const AppellantEvidencePanel = ({
   onSaved,                // (updatedAppeal) => void — called after successful save
   onPromoteComp           // optional — (compProperty, slotData) => void — Detailed +Comp button
 }) => {
+  const isLojikTenant = tenantConfig?.orgType === 'assessor';
   // ----- Derived job/market context -----
   const sampleRange = useMemo(() => {
     if (!jobData?.end_date) return { start: '', end: '' };
-    const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
+    const rawYear = getAssessmentYear(jobData.end_date);
+    const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
     return {
       start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0],
       end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0]
     };
-  }, [jobData, tenantConfig]);
+  }, [jobData?.end_date, isLojikTenant]);
 
   const landMethod = useMemo(() => (
     marketLandData?.land_method

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { interpretCodes, supabase, getSalesPeriodYear } from '../../../lib/supabaseClient';
+import { interpretCodes, supabase, getAssessmentYear } from '../../../lib/supabaseClient';
 import { FileDown, X, Eye, EyeOff, Printer, Map as MapIcon, History, Flag } from 'lucide-react';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
@@ -2935,7 +2935,9 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
             // shows them green.
             const sampleRange = (() => {
               if (!jobData?.end_date) return { start: '', end: '' };
-              const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
+              const rawYear = getAssessmentYear(jobData.end_date);
+              const isLojikTenant = tenantConfig?.orgType === 'assessor';
+              const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
               return {
                 start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0],
                 end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0]

--- a/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
+++ b/src/components/job-modules/final-valuation-tabs/DetailedAppraisalGrid.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { interpretCodes, supabase, getAssessmentYear } from '../../../lib/supabaseClient';
+import { interpretCodes, supabase, getSalesPeriodYear } from '../../../lib/supabaseClient';
 import { FileDown, X, Eye, EyeOff, Printer, Map as MapIcon, History, Flag } from 'lucide-react';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
@@ -2932,13 +2932,10 @@ const DetailedAppraisalGrid = ({ result, jobData, codeDefinitions, vendorType, a
 
             // Mirror AppellantEvidencePanel's sample-range math EXACTLY so
             // the PDF doesn't paint sale dates red when the on-screen panel
-            // shows them green. For Lojik (assessor) tenants the assessment
-            // year is end_date.year - 1.
+            // shows them green.
             const sampleRange = (() => {
               if (!jobData?.end_date) return { start: '', end: '' };
-              const rawYear = getAssessmentYear(jobData.end_date);
-              const isLojikTenant = tenantConfig?.orgType === 'assessor';
-              const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
+              const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
               return {
                 start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0],
                 end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0]

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { supabase, interpretCodes, getRawDataForJob, getSalesPeriodYear } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, getRawDataForJob, getAssessmentYear } from '../../../lib/supabaseClient';
 import { Search, X, Upload, Sliders, FileText, BarChart3, Download, List, CheckCircle, XCircle, ChevronDown, ChevronRight, Scale, Pin, PinOff, Archive, Pencil, Info } from 'lucide-react';
 import * as XLSX from 'xlsx';
 import AdjustmentsTab from './AdjustmentsTab';
@@ -12,6 +12,7 @@ import ManualSalesModal from './ManualSalesModal';
 import { distanceMiles } from '../../AppealMap';
 
 const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {}, onUpdateJobCache, isJobContainerLoading = false, tenantConfig = null, initialManualSubject = null, onManualSubjectConsumed = null, initialAppealSubjects = null, initialBracket = null, patchPropertiesWithMarketAnalysis = null }) => {
+  const isLojikTenant = tenantConfig?.orgType === 'assessor';
   // ==================== NESTED TAB STATE ====================
   const [activeSubTab, setActiveSubTab] = useState('search');
   // Scan Masked Sales modal (BRT only) — Sales Pool surface, tight user window
@@ -45,12 +46,13 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   // Calculate CSP date range on mount
   const getCSPDateRange = useCallback(() => {
     if (!jobData?.end_date) return { start: '', end: '' };
-    const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
+    const rawYear = getAssessmentYear(jobData.end_date);
+    const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
     return {
       start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0], // 10/1 prior year
       end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0] // 10/31 assessment year
     };
-  }, [jobData, tenantConfig]);
+  }, [jobData?.end_date, isLojikTenant]);
 
   const cspDateRange = useMemo(() => getCSPDateRange(), [getCSPDateRange]);
 
@@ -2962,7 +2964,8 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         }
 
         // SUBJECT SALE PRIORITY: If subject sold in CSP, it becomes Comp #1 with 0% adjustment
-        const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
+        const rawYear = getAssessmentYear(jobData.end_date);
+        const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
         const cspStart = new Date(assessmentYear - 1, 9, 1);
         const cspEnd = new Date(assessmentYear, 9, 31);
 

--- a/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
+++ b/src/components/job-modules/final-valuation-tabs/SalesComparisonTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { supabase, interpretCodes, getRawDataForJob, getAssessmentYear } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, getRawDataForJob, getSalesPeriodYear } from '../../../lib/supabaseClient';
 import { Search, X, Upload, Sliders, FileText, BarChart3, Download, List, CheckCircle, XCircle, ChevronDown, ChevronRight, Scale, Pin, PinOff, Archive, Pencil, Info } from 'lucide-react';
 import * as XLSX from 'xlsx';
 import AdjustmentsTab from './AdjustmentsTab';
@@ -12,7 +12,6 @@ import ManualSalesModal from './ManualSalesModal';
 import { distanceMiles } from '../../AppealMap';
 
 const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {}, onUpdateJobCache, isJobContainerLoading = false, tenantConfig = null, initialManualSubject = null, onManualSubjectConsumed = null, initialAppealSubjects = null, initialBracket = null, patchPropertiesWithMarketAnalysis = null }) => {
-  const isLojikTenant = tenantConfig?.orgType === 'assessor';
   // ==================== NESTED TAB STATE ====================
   const [activeSubTab, setActiveSubTab] = useState('search');
   // Scan Masked Sales modal (BRT only) — Sales Pool surface, tight user window
@@ -46,14 +45,12 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
   // Calculate CSP date range on mount
   const getCSPDateRange = useCallback(() => {
     if (!jobData?.end_date) return { start: '', end: '' };
-    const rawYear = getAssessmentYear(jobData.end_date);
-    // LOJIK: assessment year is prior year (end_date is the job end, not assessment date)
-    const assessmentYear = isLojikTenant ? rawYear - 1 : rawYear;
+    const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
     return {
       start: new Date(assessmentYear - 1, 9, 1).toISOString().split('T')[0], // 10/1 prior year
       end: new Date(assessmentYear, 9, 31).toISOString().split('T')[0] // 10/31 assessment year
     };
-  }, [jobData?.end_date, isLojikTenant]);
+  }, [jobData, tenantConfig]);
 
   const cspDateRange = useMemo(() => getCSPDateRange(), [getCSPDateRange]);
 
@@ -2965,12 +2962,7 @@ const SalesComparisonTab = ({ jobData, properties, hpiData, marketLandData = {},
         }
 
         // SUBJECT SALE PRIORITY: If subject sold in CSP, it becomes Comp #1 with 0% adjustment
-        // NOTE: LOJIK end_date is the job end (one year after the assessment year),
-        // so we have to subtract 1 to land on the correct assessment year — same
-        // logic as getCSPDateRange above. Without this, the CSP window shifts a
-        // year forward and valid in-window subject sales get skipped.
-        const rawAssessmentYear = getAssessmentYear(jobData.end_date);
-        const assessmentYear = isLojikTenant ? rawAssessmentYear - 1 : rawAssessmentYear;
+        const assessmentYear = getSalesPeriodYear(jobData, tenantConfig);
         const cspStart = new Date(assessmentYear - 1, 9, 1);
         const cspEnd = new Date(assessmentYear, 9, 31);
 

--- a/src/components/job-modules/market-tabs/CoordinatesSubTab.jsx
+++ b/src/components/job-modules/market-tabs/CoordinatesSubTab.jsx
@@ -14,7 +14,7 @@
 
 import { useMemo, useState } from 'react';
 import GeocodeStatusChip from '../../GeocodeStatusChip';
-import { getSalesPeriodYear } from '../../../lib/supabaseClient';
+import { getAssessmentYear } from '../../../lib/supabaseClient';
 
 // Quality strings the Census batch returns that we treat as "needs review".
 // Anything not in this list and not 'Manual' / 'Exact' / 'Match' is also
@@ -135,14 +135,15 @@ export default function CoordinatesSubTab({ properties = [], jobData }) {
   }, [filteredForSkipped, classFilter]);
 
   // Sales-pool window: 10/1 (assessmentYear-2) → 10/31 (assessmentYear-1).
-  // Anchor year comes from getSalesPeriodYear (current calendar year for Lojik).
+  // Lojik tenants subtract one from end_date.year because end_date is the job end.
   const salesWindow = useMemo(() => {
     if (!jobData?.end_date) return null;
-    const ay = getSalesPeriodYear(jobData);
-    if (!ay) return null;
+    const rawYear = getAssessmentYear(jobData.end_date, null);
+    if (!rawYear) return null;
     const isLojik =
       jobData?.organizations?.org_type === 'assessor' ||
       jobData?.org_type === 'assessor';
+    const ay = isLojik ? rawYear - 1 : rawYear;
     return {
       start: new Date(ay - 2, 9, 1),
       end: new Date(ay - 1, 9, 31),

--- a/src/components/job-modules/market-tabs/CoordinatesSubTab.jsx
+++ b/src/components/job-modules/market-tabs/CoordinatesSubTab.jsx
@@ -14,7 +14,7 @@
 
 import { useMemo, useState } from 'react';
 import GeocodeStatusChip from '../../GeocodeStatusChip';
-import { getAssessmentYear } from '../../../lib/supabaseClient';
+import { getSalesPeriodYear } from '../../../lib/supabaseClient';
 
 // Quality strings the Census batch returns that we treat as "needs review".
 // Anything not in this list and not 'Manual' / 'Exact' / 'Match' is also
@@ -135,17 +135,14 @@ export default function CoordinatesSubTab({ properties = [], jobData }) {
   }, [filteredForSkipped, classFilter]);
 
   // Sales-pool window: 10/1 (assessmentYear-2) → 10/31 (assessmentYear-1).
-  // Lojik tenants (org_type = 'assessor') subtract one from end_date.year
-  // because end_date is the job end, not the assessment date — same
-  // adjustment SalesComparisonTab makes.
+  // Anchor year comes from getSalesPeriodYear (current calendar year for Lojik).
   const salesWindow = useMemo(() => {
     if (!jobData?.end_date) return null;
-    const rawYear = getAssessmentYear(jobData.end_date, null);
-    if (!rawYear) return null;
+    const ay = getSalesPeriodYear(jobData);
+    if (!ay) return null;
     const isLojik =
       jobData?.organizations?.org_type === 'assessor' ||
       jobData?.org_type === 'assessor';
-    const ay = isLojik ? rawYear - 1 : rawYear;
     return {
       start: new Date(ay - 2, 9, 1),
       end: new Date(ay - 1, 9, 31),

--- a/src/components/job-modules/market-tabs/LandValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/LandValuationTab.jsx
@@ -6,7 +6,7 @@ import {
   Save, FileDown, MapPin,
   Home, History
 } from 'lucide-react';
-import { supabase, interpretCodes, checklistService, getDepthFactor, getDepthFactors } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, checklistService, getDepthFactor, getDepthFactors, parseDateLocal } from '../../../lib/supabaseClient';
 import { loadHpiMultiplier, timeNormalizeUnmasked } from '../../../lib/unmaskedSales';
 import { exportMethod2SalesToExcel } from '../../../lib/method2SalesExport';
 import * as XLSX from 'xlsx-js-style';
@@ -6899,6 +6899,17 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
     debug('�������� Teardown sales in checked:', checkedSales.filter(s => saleCategories[s.id] === 'teardown').map(s => `${s.property_block}/${s.property_lot}`));
     debug('��� Building lot sales in checked:', checkedSales.filter(s => saleCategories[s.id] === 'building_lot').map(s => `${s.property_block}/${s.property_lot}`));
 
+
+    // Paired-sales gate: only pair sales from the same VCS and the same sale
+    // year. Pairing across years compares different markets, which produced
+    // wild incremental rates. Size difference is enforced separately.
+    const canPairSales = (a, b) => {
+      if ((a.property_vcs || null) !== (b.property_vcs || null)) return false;
+      const da = parseDateLocal(a.sales_date);
+      const db = parseDateLocal(b.sales_date);
+      if (!da || !db) return false;
+      return da.getFullYear() === db.getFullYear();
+    };
     // Helper function to calculate average for a category
     const getCategoryAverage = (filterFn, categoryType) => {
       const filtered = checkedSales.filter(filterFn);
@@ -6978,7 +6989,8 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
             const sizeDiff = largerSize - smallerSize;
             const priceDiff = (larger.values_norm_time || larger.sales_price) - (smaller.values_norm_time || smaller.sales_price);
 
-            if (sizeDiff > 0) {
+            const pairAllowed = sizeDiff > 0 && canPairSales(smaller, larger);
+            if (pairAllowed) {
               const incrementalRate = priceDiff / sizeDiff;
               pairedRates.push({
                 rate: incrementalRate,
@@ -7208,7 +7220,8 @@ Provide only verifiable facts with sources. Be specific and actionable for valua
             const sizeDiff = largerSize - smallerSize;
             const priceDiff = (larger.values_norm_time || larger.sales_price) - (smaller.values_norm_time || smaller.sales_price);
 
-            if (sizeDiff > 0) {
+            const pairAllowed = sizeDiff > 0 && canPairSales(smaller, larger);
+            if (pairAllowed) {
               pairedRates.push(priceDiff / sizeDiff);
             }
           }

--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -4086,8 +4086,9 @@ const analyzeImportFile = async (file) => {
                             .slice((normCurrentPage - 1) * normItemsPerPage, normCurrentPage * normItemsPerPage)
                             .map((sale) => {
                               const parsed = parseCompositeKey(sale.property_composite_key);
+                              const saleUnderAssessment = Number(sale.sales_price) > 0 && Number(sale.values_mod_total) > 0 && Number(sale.sales_price) < Number(sale.values_mod_total);
                               return (
-                                <tr key={sale.id} className="border-b hover:bg-gray-50">
+                                <tr key={sale.id} title={saleUnderAssessment ? "Raw sale price is below the current assessment" : undefined} className={"border-b hover:bg-gray-50 " + (saleUnderAssessment ? "bg-yellow-50" : "")}>
                                   <td className="px-4 py-3 text-sm">{parsed.block}</td>
                                   <td className="px-4 py-3 text-sm">{parsed.lot}</td>
                                   <td className="px-4 py-3 text-sm">{parsed.qualifier || ''}</td>

--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -5977,7 +5977,7 @@ const analyzeImportFile = async (file) => {
                         if (editingZoning[zone]) {
                           zoningRequirements[zone] = {
                             description: editingZoning[zone].description || '',
-                            min_size: parseInt(editingZoning[zone].min_size) || null,
+                            min_size: parseFloat(editingZoning[zone].min_size) || null,
                             min_size_unit: editingZoning[zone].minSizeUnit || 'SF',
                             min_frontage: parseInt(editingZoning[zone].min_frontage) || null,
                             min_depth: parseInt(editingZoning[zone].min_depth) || null,

--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { supabase, interpretCodes, worksheetService, checklistService, runUnitRateLotCalculation, runUnitRateLotCalculation_v2, computeLotAcreForProperty, persistComputedLotAcre, normalizeSelectedCodes, saveUnitRateMappings, generateLotSizesForJob } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, worksheetService, checklistService, runUnitRateLotCalculation, runUnitRateLotCalculation_v2, computeLotAcreForProperty, persistComputedLotAcre, normalizeSelectedCodes, saveUnitRateMappings, generateLotSizesForJob, classifySalesPeriod, getSalesPeriodYear } from '../../../lib/supabaseClient';
 import * as XLSX from 'xlsx-js-style';
 import './sharedTabNav.css';
 import TypeUseNormalizationSubTab from './TypeUseNormalizationSubTab';
@@ -75,6 +75,42 @@ const PreValuationTab = ({
     conversions: 0,
     avgSizeAdjustment: 0
   });
+  // True ratio over the CSP/PSP/HSP window, pooled as Σ assessed ÷ Σ time-normalized
+  // price. Reads the kept rows of the Sales Review table below so the headline
+  // figure and the per-sale ratios can never disagree.
+  const trueRatioByPeriod = useMemo(() => {
+    const buckets = {
+      CSP: { assessed: 0, normalized: 0, count: 0 },
+      PSP: { assessed: 0, normalized: 0, count: 0 },
+      HSP: { assessed: 0, normalized: 0, count: 0 }
+    };
+
+    timeNormalizedSales.forEach(sale => {
+      if (sale.keep_reject !== 'keep') return;
+      if (!sale.time_normalized_price || sale.time_normalized_price <= 0) return;
+      const bucket = buckets[classifySalesPeriod(sale.sales_date, jobData)];
+      if (!bucket) return;
+      bucket.assessed += sale.values_mod_total || 0;
+      bucket.normalized += sale.time_normalized_price;
+      bucket.count += 1;
+    });
+
+    const pct = b => (b.normalized > 0 ? (b.assessed / b.normalized) * 100 : null);
+    const combined = ['CSP', 'PSP', 'HSP'].reduce((acc, key) => ({
+      assessed: acc.assessed + buckets[key].assessed,
+      normalized: acc.normalized + buckets[key].normalized,
+      count: acc.count + buckets[key].count
+    }), { assessed: 0, normalized: 0, count: 0 });
+
+    return {
+      assessmentYear: getSalesPeriodYear(jobData),
+      periods: { CSP: pct(buckets.CSP), PSP: pct(buckets.PSP), HSP: pct(buckets.HSP) },
+      counts: { CSP: buckets.CSP.count, PSP: buckets.PSP.count, HSP: buckets.HSP.count },
+      combined: pct(combined),
+      combinedCount: combined.count
+    };
+  }, [timeNormalizedSales, jobData]);
+
   const [worksheetProperties, setWorksheetProperties] = useState([]);
   const [lastTimeNormalizationRun, setLastTimeNormalizationRun] = useState(null);
   const [lastSizeNormalizationRun, setLastSizeNormalizationRun] = useState(null);
@@ -3779,50 +3815,27 @@ const analyzeImportFile = async (file) => {
                   </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-blue-700">
-                    {(() => {
-                      const currentYear = new Date().getFullYear();
-                      const minPrice = typeof minSalePrice === 'number' && !isNaN(minSalePrice) ? minSalePrice : 100;
-                      const currentYearSales = properties.filter(p => {
-                        if (!p.sales_price || p.sales_price <= minPrice) return false;
-                        if (!p.sales_date) return false;
-
-                        const saleYear = new Date(p.sales_date).getFullYear();
-                        if (saleYear !== currentYear) return false;
-
-                        // Check sales_nu conditions (empty, null, 00, 7, or 07 are valid)
-                        const nu = p.sales_nu?.toString().trim();
-                        const validNU = !nu || nu === '' || nu === '00' || nu === '7' || nu === '07';
-                        if (!validNU) return false;
-
-                        // Same filters as normalization
-                        const parsed = parseCompositeKey(p.property_composite_key);
-                        const card = parsed.card?.toUpperCase();
-
-                        // Card filter based on vendor
-                        if (vendorType === 'Microsystems') {
-                          if (card !== 'M') return false;
-                        } else {
-                          if (card !== '1') return false;
-                        }
-
-                        const buildingClass = p.asset_building_class?.toString().trim();
-                        const typeUse = p.asset_type_use?.toString().trim();
-                        const designStyle = p.asset_design_style?.toString().trim();
-
-                        if (!buildingClass || parseInt(buildingClass) <= 10) return false;
-                        if (!typeUse) return false;
-                        if (!designStyle) return false;
-
-                        return true;
-                      });
-
-                      const totalAssessedValue = currentYearSales.reduce((sum, p) => sum + (p.values_mod_total || 0), 0);
-                      const totalSalesPrice = currentYearSales.reduce((sum, p) => sum + (p.sales_price || 0), 0);
-                      const avgRatio = totalSalesPrice > 0 ? totalAssessedValue / totalSalesPrice : 0;
-                      return `${(avgRatio * 100).toFixed(2)}%`;
-                    })()}
+                    {trueRatioByPeriod.combined !== null
+                      ? `${trueRatioByPeriod.combined.toFixed(2)}%`
+                      : '—'}
                   </div>
-                  <div className="text-sm text-gray-500">True Ratio (Current Year)</div>
+                  <div className="text-sm text-gray-500">
+                    True Ratio (CSP+PSP+HSP)
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    {trueRatioByPeriod.combinedCount} sales · AY {trueRatioByPeriod.assessmentYear}
+                  </div>
+                  <div className="mt-1 space-y-0.5">
+                    {['CSP', 'PSP', 'HSP'].map(period => (
+                      <div key={period} className="text-xs text-gray-500">
+                        <span className="font-medium">{period}</span>{' '}
+                        {trueRatioByPeriod.periods[period] !== null
+                          ? `${trueRatioByPeriod.periods[period].toFixed(2)}%`
+                          : '—'}{' '}
+                        <span className="text-gray-400">({trueRatioByPeriod.counts[period]})</span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
                 </div>
               </div>

--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { supabase, interpretCodes, worksheetService, checklistService, runUnitRateLotCalculation, runUnitRateLotCalculation_v2, computeLotAcreForProperty, persistComputedLotAcre, normalizeSelectedCodes, saveUnitRateMappings, generateLotSizesForJob, classifySalesPeriod, getSalesPeriodYear } from '../../../lib/supabaseClient';
+import { supabase, interpretCodes, worksheetService, checklistService, runUnitRateLotCalculation, runUnitRateLotCalculation_v2, computeLotAcreForProperty, persistComputedLotAcre, normalizeSelectedCodes, saveUnitRateMappings, generateLotSizesForJob, classifySalesPeriod, getAssessmentYear } from '../../../lib/supabaseClient';
 import * as XLSX from 'xlsx-js-style';
 import './sharedTabNav.css';
 import TypeUseNormalizationSubTab from './TypeUseNormalizationSubTab';
@@ -103,7 +103,7 @@ const PreValuationTab = ({
     }), { assessed: 0, normalized: 0, count: 0 });
 
     return {
-      assessmentYear: getSalesPeriodYear(jobData),
+      assessmentYear: getAssessmentYear(jobData?.end_date),
       periods: { CSP: pct(buckets.CSP), PSP: pct(buckets.PSP), HSP: pct(buckets.HSP) },
       counts: { CSP: buckets.CSP.count, PSP: buckets.PSP.count, HSP: buckets.HSP.count },
       combined: pct(combined),

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -189,6 +189,41 @@ export function getAssessmentYear(endDate, fallback = new Date().getFullYear()) 
   return dueYear - 1;
 }
 
+/**
+ * Anchor year for the CSP/PSP/HSP sales periods.
+ *
+ * Assessor ("Lojik") clients are ongoing engagements, not revaluations with a
+ * due date, so their periods track the current calendar year. Deriving theirs
+ * from end_date parks them in a window that closed months ago.
+ */
+export function getSalesPeriodYear(jobData) {
+  const isLojik =
+    jobData?.organizations?.org_type === 'assessor' ||
+    jobData?.org_type === 'assessor';
+  if (isLojik) return new Date().getFullYear();
+  return getAssessmentYear(jobData?.end_date);
+}
+
+export function getSalesPeriodRanges(jobData) {
+  const ay = getSalesPeriodYear(jobData);
+  return {
+    assessmentYear: ay,
+    CSP: { start: new Date(ay - 1, 9, 1), end: new Date(ay, 11, 31, 23, 59, 59) },
+    PSP: { start: new Date(ay - 2, 9, 1), end: new Date(ay - 1, 8, 30, 23, 59, 59) },
+    HSP: { start: new Date(ay - 3, 9, 1), end: new Date(ay - 2, 8, 30, 23, 59, 59) }
+  };
+}
+
+export function classifySalesPeriod(saleDate, jobData) {
+  const sale = parseDateLocal(saleDate);
+  if (!sale) return '';
+  const r = getSalesPeriodRanges(jobData);
+  if (sale >= r.CSP.start && sale <= r.CSP.end) return 'CSP';
+  if (sale >= r.PSP.start && sale <= r.PSP.end) return 'PSP';
+  if (sale >= r.HSP.start && sale <= r.HSP.end) return 'HSP';
+  return '';
+}
+
 // ===== SOURCE FILE DATA ACCESS HELPERS =====
 // These replace raw_data access with source file content parsing
 

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -189,24 +189,9 @@ export function getAssessmentYear(endDate, fallback = new Date().getFullYear()) 
   return dueYear - 1;
 }
 
-/**
- * Anchor year for the CSP/PSP/HSP sales periods.
- *
- * Assessor ("Lojik") clients are ongoing engagements, not revaluations with a
- * due date, so their periods track the current calendar year. Deriving theirs
- * from end_date parks them in a window that closed months ago.
- */
-export function getSalesPeriodYear(jobData, tenantConfig) {
-  const isLojik =
-    tenantConfig?.orgType === 'assessor' ||
-    jobData?.organizations?.org_type === 'assessor' ||
-    jobData?.org_type === 'assessor';
-  if (isLojik) return new Date().getFullYear();
-  return getAssessmentYear(jobData?.end_date);
-}
-
-export function getSalesPeriodRanges(jobData, tenantConfig) {
-  const ay = getSalesPeriodYear(jobData, tenantConfig);
+// CSP/PSP/HSP sales-period windows, anchored on the job assessment year.
+export function getSalesPeriodRanges(jobData) {
+  const ay = getAssessmentYear(jobData?.end_date);
   return {
     assessmentYear: ay,
     CSP: { start: new Date(ay - 1, 9, 1), end: new Date(ay, 11, 31, 23, 59, 59) },
@@ -215,10 +200,10 @@ export function getSalesPeriodRanges(jobData, tenantConfig) {
   };
 }
 
-export function classifySalesPeriod(saleDate, jobData, tenantConfig) {
+export function classifySalesPeriod(saleDate, jobData) {
   const sale = parseDateLocal(saleDate);
   if (!sale) return '';
-  const r = getSalesPeriodRanges(jobData, tenantConfig);
+  const r = getSalesPeriodRanges(jobData);
   if (sale >= r.CSP.start && sale <= r.CSP.end) return 'CSP';
   if (sale >= r.PSP.start && sale <= r.PSP.end) return 'PSP';
   if (sale >= r.HSP.start && sale <= r.HSP.end) return 'HSP';

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -196,16 +196,17 @@ export function getAssessmentYear(endDate, fallback = new Date().getFullYear()) 
  * due date, so their periods track the current calendar year. Deriving theirs
  * from end_date parks them in a window that closed months ago.
  */
-export function getSalesPeriodYear(jobData) {
+export function getSalesPeriodYear(jobData, tenantConfig) {
   const isLojik =
+    tenantConfig?.orgType === 'assessor' ||
     jobData?.organizations?.org_type === 'assessor' ||
     jobData?.org_type === 'assessor';
   if (isLojik) return new Date().getFullYear();
   return getAssessmentYear(jobData?.end_date);
 }
 
-export function getSalesPeriodRanges(jobData) {
-  const ay = getSalesPeriodYear(jobData);
+export function getSalesPeriodRanges(jobData, tenantConfig) {
+  const ay = getSalesPeriodYear(jobData, tenantConfig);
   return {
     assessmentYear: ay,
     CSP: { start: new Date(ay - 1, 9, 1), end: new Date(ay, 11, 31, 23, 59, 59) },
@@ -214,10 +215,10 @@ export function getSalesPeriodRanges(jobData) {
   };
 }
 
-export function classifySalesPeriod(saleDate, jobData) {
+export function classifySalesPeriod(saleDate, jobData, tenantConfig) {
   const sale = parseDateLocal(saleDate);
   if (!sale) return '';
-  const r = getSalesPeriodRanges(jobData);
+  const r = getSalesPeriodRanges(jobData, tenantConfig);
   if (sale >= r.CSP.start && sale <= r.CSP.end) return 'CSP';
   if (sale >= r.PSP.start && sale <= r.PSP.end) return 'PSP';
   if (sale >= r.HSP.start && sale <= r.HSP.end) return 'HSP';


### PR DESCRIPTION
### Summary
This PR corrects the "True Ratio" calculation in Pre-Valuation to use the full CSP/PSP/HSP sample window instead of only the current year, restricts land valuation paired-sales studies to same-VCS/same-sale-year comparisons, resolves payroll worksheet initials against the employee roster, fixes a decimal-entry bug in zoning minimum size, and removes an unused/unneeded sales-pool filter from the geocoder cleanup queue.

### Problem
- The True Ratio shown in Pre-Valuation only used current-year sales, which — being partway through the year — could produce lower-than-typical averages and didn't align with how the CSP/PSP/HSP periods are already used elsewhere for valuation.
- Land valuation's paired-sales study (Method 1) paired vacant land sales across wildly different sale years (e.g. 2020 vs 2024), producing unreliable incremental rates since it mixed different markets.
- Payroll worksheet imports trusted the hand-entered initials cell, which could be missing or wrong (e.g. a new hire's inspection bonus getting missed), even though the employee roster already had correct initials as used by the production tracker.
- Zoning's minimum size field used `parseInt`, blocking valid decimal entries like `.15` acres.
- The geocoding cleanup queue had an extra "sales pool" filter/chip that duplicated logic already available in `CoordinatesSubTab` and wasn't needed.

### Solution
- Added shared helpers (`getSalesPeriodRanges`, `classifySalesPeriod`) to compute CSP/PSP/HSP windows off the job's assessment year, and used them to bucket kept sales in Pre-Valuation into a pooled true ratio (Σ assessed ÷ Σ time-normalized price) per period and combined.
- Added a `canPairSales` gate in `LandValuationTab` requiring matching VCS and matching sale year before two sales can be paired for incremental rate calculations.
- Added `resolveInitials`/`findEmployeeByWorksheetName` in `PayrollManagement` to prefer the employee roster's initials over the worksheet cell, flagging mismatches and missing records as issues.
- Switched zoning minimum-size parsing from `parseInt` to `parseFloat` to allow decimal acreage values.
- Removed the `csvSalesInPool`/`csvSalesWindow` state, filter logic, and UI chip from `GeocodingTool`, along with the now-unused `parseDateLocal`/`getAssessmentYear` imports.
- Added a light-yellow row highlight in the Pre-Valuation sales review table when a raw sale price is below the current assessment, as a visual flag for the user to review (not an automatic reject).

### Key Changes
- `src/lib/supabaseClient.js`: new `getSalesPeriodRanges` and `classifySalesPeriod` helpers for CSP/PSP/HSP windows.
- `src/components/job-modules/market-tabs/PreValuationTab.jsx`: replaced current-year-only true ratio with pooled CSP/PSP/HSP calculation (`trueRatioByPeriod`), added per-period breakdown UI, added under-assessment row highlighting, and fixed `min_size` parsing to `parseFloat`.
- `src/components/job-modules/market-tabs/LandValuationTab.jsx`: added `canPairSales` gate (same VCS + same sale year) applied to both paired-rate calculation blocks.
- `src/components/PayrollManagement.jsx`: added `findEmployeeByWorksheetName` and `resolveInitials`, and surfaced issues for missing/mismatched initials during worksheet import.
- `src/components/GeocodingTool.jsx`: removed the sales-pool window filter, chip UI, and related state/memoized values.
- Minor comment cleanup in `AppellantEvidencePanel.jsx`, `DetailedAppraisalGrid.jsx`, `SalesComparisonTab.jsx`, and `CoordinatesSubTab.jsx`.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/vault-melody-c6qpvbn2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-vault-melody-c6qpvbn2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 269`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>vault-melody-c6qpvbn2</branchName>-->