### PR TITLE
Fix importer composite key year/ccdd mismatch

### DIFF
--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -3205,9 +3205,9 @@ const analyzeImportFile = async (file) => {
       // Process each row from Excel
       for (const row of dataForAnalysis) {
         // Build composite key from Excel data - vendor aware
-        // Extract year from job's created_at field
-        const jobYear = jobData?.created_at
-          ? new Date(jobData.created_at).getFullYear()
+        // Year must come from start_date — that's what the processors used to build the keys.
+        const jobYear = jobData?.start_date
+          ? parseInt(String(jobData.start_date).substring(0, 4), 10)
           : new Date().getFullYear();
         const year = row.Year || row.YEAR || jobYear;
         const ccdd = row.Ccdd || row.CCDD || jobData?.ccdd_code || jobData?.ccdd || '';
@@ -3376,8 +3376,9 @@ const analyzeImportFile = async (file) => {
       const getVal = (row, keys) => { for (const k of keys) { if (row[k] !== undefined && row[k] !== null && String(row[k]).trim() !== '') return row[k]; } return ''; };
 
       for (const row of data) {
-        const year = getVal(row, ['Year','YEAR','year']) || new Date().getFullYear();
-        const ccdd = getVal(row, ['CCDD','Ccdd','Ccdd','ccdd']) || jobData?.ccdd || '';
+        const year = getVal(row, ['Year','YEAR','year'])
+          || (jobData?.start_date ? parseInt(String(jobData.start_date).substring(0, 4), 10) : new Date().getFullYear());
+        const ccdd = getVal(row, ['CCDD','Ccdd','Ccdd','ccdd']) || jobData?.ccdd_code || jobData?.ccdd || '';
         const block = String(getVal(row, ['Block','BLOCK','block'])).trim();
         const lot = String(getVal(row, ['Lot','LOT','lot'])).trim();
         let qual = String(getVal(row, ['Qualifier','Qual','QUALIFIER','QUAL'])).trim(); if (!qual) qual = 'NONE';

--- a/src/components/job-modules/market-tabs/PreValuationTab.jsx
+++ b/src/components/job-modules/market-tabs/PreValuationTab.jsx
@@ -3204,13 +3204,16 @@ const analyzeImportFile = async (file) => {
 
       // Process each row from Excel
       for (const row of dataForAnalysis) {
-        // Build composite key from Excel data - vendor aware
-        // Year must come from start_date — that's what the processors used to build the keys.
+        // Build composite key from Excel data - vendor aware.
+        // Year+ccdd are read off the keys being matched against. Re-deriving them from job
+        // fields or a spreadsheet column is a second rule that drifts from the one the
+        // processors used at import time, and then nothing matches.
         const jobYear = jobData?.start_date
           ? parseInt(String(jobData.start_date).substring(0, 4), 10)
           : new Date().getFullYear();
-        const year = row.Year || row.YEAR || jobYear;
-        const ccdd = row.Ccdd || row.CCDD || jobData?.ccdd_code || jobData?.ccdd || '';
+        const keyPrefix = (worksheetProperties || []).find(p => p.property_composite_key)?.property_composite_key?.split('-')[0] || '';
+        const year = keyPrefix ? keyPrefix.slice(0, 4) : jobYear;
+        const ccdd = keyPrefix ? keyPrefix.slice(4) : (jobData?.ccdd_code || jobData?.ccdd || '');
         const block = (row.Block || row.BLOCK)?.toString() || '';
         const lot = (row.Lot || row.LOT || row.lot || '')?.toString().trim();
         console.log('Lot value from row:', row.Lot, 'Final lot:', lot);
@@ -3376,9 +3379,10 @@ const analyzeImportFile = async (file) => {
       const getVal = (row, keys) => { for (const k of keys) { if (row[k] !== undefined && row[k] !== null && String(row[k]).trim() !== '') return row[k]; } return ''; };
 
       for (const row of data) {
-        const year = getVal(row, ['Year','YEAR','year'])
-          || (jobData?.start_date ? parseInt(String(jobData.start_date).substring(0, 4), 10) : new Date().getFullYear());
-        const ccdd = getVal(row, ['CCDD','Ccdd','Ccdd','ccdd']) || jobData?.ccdd_code || jobData?.ccdd || '';
+        const keyPrefix = propKeys.find(k => k)?.split('-')[0] || '';
+        const year = keyPrefix ? keyPrefix.slice(0, 4)
+          : (jobData?.start_date ? parseInt(String(jobData.start_date).substring(0, 4), 10) : new Date().getFullYear());
+        const ccdd = keyPrefix ? keyPrefix.slice(4) : (jobData?.ccdd_code || jobData?.ccdd || '');
         const block = String(getVal(row, ['Block','BLOCK','block'])).trim();
         const lot = String(getVal(row, ['Lot','LOT','lot'])).trim();
         let qual = String(getVal(row, ['Qualifier','Qual','QUALIFIER','QUAL'])).trim(); if (!qual) qual = 'NONE';


### PR DESCRIPTION
### Summary
Fixes the page-by-page importer in `PreValuationTab.jsx` so it derives the year and CCDD prefix used to build composite keys from existing property data instead of re-deriving them independently, preventing match failures.

### Problem
The importer was constructing the year/ccdd portion of the composite key using the job's `created_at` field or Excel column values, which used a different rule than the one originally used when the composite keys were created. This mismatch (e.g., job start date of 4/22/26 vs. a stored key prefix of 2027) caused the importer to fail to match records against existing property data.

### Solution
Instead of independently re-deriving the year and ccdd values, the importer now extracts the key prefix directly from an existing `property_composite_key` on the worksheet/job properties being matched against, ensuring consistency with however the key was originally derived. Fallback logic uses the job's `start_date` (rather than `created_at`) when no existing key prefix is available.

### Key Changes
- In the first import analysis loop, derive `year` and `ccdd` from the `property_composite_key` prefix found in `worksheetProperties` when available, falling back to `jobData.start_date` (year portion) and `jobData.ccdd_code`/`ccdd`.
- In the second import loop, apply the same approach using `propKeys` to source the composite key prefix, with the same fallback to `jobData.start_date` and ccdd fields.
- Removed reliance on `jobData.created_at` and raw Excel `Year`/`CCDD` columns as the primary source for these values to avoid drift between key-creation and key-matching logic.


---

<a href="https://builder.io/app/projects/ddd291a471d24dc4a8c6060599d1fd79/velour-momentum-yiln9fxm"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ddd291a471d24dc4a8c6060599d1fd79-velour-momentum-yiln9fxm.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ddd291a471d24dc4a8c6060599d1fd79&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 270`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddd291a471d24dc4a8c6060599d1fd79</projectId>-->
<!--<branchName>velour-momentum-yiln9fxm</branchName>-->